### PR TITLE
Build & test with only 2 CPUs on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ addons:
     packages:
       - dotnet-dev-1.0.1
 script:
-  - test/test
+  - script/correct-cpus.sh test/test
 cache:
   directories:
     - sysconfcpus/bin

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "build": "npm install --ignore-scripts && bower install && pulp build -- --source-maps --stash --censor-warnings && npm run bundle-cli",
+    "build": "script/build.sh",
     "test": "npm run build && pulp test && test/test.ts",
     "postinstall": "npm run build && (cd app && npm install --quiet) && (cd cli && npm install)",
     "start": "cd app && npm start",

--- a/script/build.sh
+++ b/script/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+npm install --ignore-scripts
+bower install
+script/correct-cpus.sh pulp build -- --source-maps --stash --censor-warnings
+npm run bundle-cli

--- a/script/correct-cpus.sh
+++ b/script/correct-cpus.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+# On CI, this sets the number of CPUs to 2
+# Travis incorrectly reports 8, slowing down
+# elm and purescript compilers
+
+if [ ! $CI ];
+then
+    bash $@
+    exit 0
+fi
+
 if [ ! -d sysconfcpus/bin ];
 then
     git clone https://github.com/obmarg/libsysconfcpus.git; 
@@ -9,4 +19,4 @@ then
     cd ..;
 fi
 
-$TRAVIS_BUILD_DIR/sysconfcpus/bin/sysconfcpus -n 2 elm-make --yes
+$TRAVIS_BUILD_DIR/sysconfcpus/bin/sysconfcpus -n 2 $@

--- a/test/test.ts
+++ b/test/test.ts
@@ -92,9 +92,7 @@ const FIXTURES: Fixture[] = [
     {
         name: "elm",
         base: "test/fixtures/elm",
-        setup: IS_CI
-                ? "./setup-ci.sh"
-                : "rm -rf elm-stuff/build-artifacts && elm-make --yes",
+        setup: "rm -rf elm-stuff/build-artifacts && elm-make --yes",
         diffViaSchema: true,
         output: "QuickType.elm",
         topLevel: "QuickType",


### PR DESCRIPTION
Our PureScript builds are extra slow because PureScript's compiler trust's Travis's misleading report that 8 CPUs are available, when only 2 are.