### PR TITLE
IRNothing can be null

### DIFF
--- a/src/IRGraph.purs
+++ b/src/IRGraph.purs
@@ -184,6 +184,7 @@ nullableFromSet s =
 canBeNull :: IRType -> Boolean
 canBeNull =
     case _ of
+    IRNothing -> true
     IRNull -> true
     IRUnion (IRUnionRep { primitives }) -> (Bits.and primitives irUnion_Null) /= 0
     _ -> false


### PR DESCRIPTION
IRNothing means anything, so it can also be
null.  See #56