### PR TITLE
Adds DCE elimination for PureScript code.

### DIFF
--- a/cli/quicktype.ts
+++ b/cli/quicktype.ts
@@ -5,7 +5,7 @@ import * as Either from "./either";
 import tryRequire from "./try-require"
 import * as _ from "lodash";
 
-const Main: Main = tryRequire("../output/Main", "./Main");
+const Main: Main = tryRequire("../output/purs/Main", "./Main");
 const makeSource = require("stream-json");
 const Assembler = require("stream-json/utils/Assembler");
 const commandLineArgs = require('command-line-args');

--- a/script/build.sh
+++ b/script/build.sh
@@ -1,8 +1,29 @@
-#!/bin/sh
+#!/bin/sh -eux
 
 npm install --ignore-scripts
 bower install --allow-root
-pulp build -- --source-maps --stash --censor-warnings
+
+pulp build --build-path "./output/raw" \
+  -- --source-maps --censor-warnings --stash
+
+## Purs Bundling ##
+MODULE_ENTRIES="Main Samples" # Space-separated
+
+MODULE_OPTS=""
+for MOD in $MODULE_ENTRIES; do
+  MODULE_OPTS="${MODULE_OPTS} -m ${MOD}"
+done
+
+purs bundle 'output/raw/**/index.js' 'output/raw/**/foreign.js' \
+  -o output/purs/index.js \
+  --source-maps \
+  $MODULE_OPTS
+echo ';module.exports = PS;' >> output/purs/index.js
+
+for MOD in $MODULE_ENTRIES; do
+  echo "'use strict';module.exports = require('./index')['${MOD}'];" > "output/purs/${MOD}.js"
+done
+## /Purs Bundling ##
 
 tsc --project cli/tsconfig.json
 

--- a/script/start.sh
+++ b/script/start.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-pulp --watch --then "clear && script/quicktype $@" build
+pulp --watch --then "clear && script/quicktype $@" build --build-path "./output/raw"

--- a/test/test.ts
+++ b/test/test.ts
@@ -14,8 +14,8 @@ const Ajv = require('ajv');
 const strictDeepEquals: (x: any, y: any) => boolean = require('deep-equal');
 const shell = require("shelljs");
 
-const Main = require("../output/Main");
-const Samples = require("../output/Samples");
+const Main = require("../output/purs/Main");
+const Samples = require("../output/purs/Samples");
 
 const exit = require('exit');
 const chalk = require("chalk");


### PR DESCRIPTION
A bundle is now spat out at `output/purs/index.js`, with some shims in that directory for each of the exposed modules (just `Main` and `Samples` for now); the cli JS now looks there instead.

This is, unfortunately, a little horrific. It's both working around a problem where I couldn't add `--to` without having the other options be rejected (https://github.com/purescript-contrib/pulp/issues/208#issuecomment-326813274), and also trying to preserve the `Main` and `Samples` modules as separate files even after bundling (to keep the `Main/index.js` <--> `Main.d.ts` correspondence you have).

(Happy to treat this as an experiment that is quietly closed, if this is all a bit too much. 💦 )