### PR TITLE
Disregard nullables when naming top level

### DIFF
--- a/src-ts/Type.ts
+++ b/src-ts/Type.ts
@@ -24,9 +24,12 @@ export abstract class Type {
 
     abstract get children(): OrderedSet<Type>;
 
-    get directlyReachableNamedTypes(): OrderedSet<NamedType> {
-        if (this.isNamedType()) return OrderedSet([this]);
-        return orderedSetUnion(this.children.map((t: Type) => t.directlyReachableNamedTypes));
+    directlyReachableTypes<T>(setForType: (t: Type) => OrderedSet<T> | null): OrderedSet<T> {
+        const set = setForType(this);
+        if (set) return set;
+        return orderedSetUnion(
+            this.children.map((t: Type) => t.directlyReachableTypes(setForType))
+        );
     }
 
     abstract equals(other: any): boolean;


### PR DESCRIPTION
If the top-level directly contained a named
type was wasn't one itself, we would make
that type the same as the top-level.  This was
incorrect in the case where the named type
was a nullable union, which we don't
actually give a name to.

Fixes #265