### PR TITLE
Don't process.exit from quicktype unless CLI

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -163,8 +163,7 @@ function getTargetLanguage(name: string): TargetLanguage {
     if (language) {
         return language;
     }
-    console.error(`'${name}' is not yet supported as an output language.`);
-    return process.exit(1);
+    throw new Error(`'${name}' is not yet supported as an output language.`);
 }
 
 export function usage() {
@@ -246,9 +245,8 @@ export class Run {
                 this._options = this.parseOptions(allOptionDefinitions, argv, false);
             } catch (error) {
                 if (error.name === "UNKNOWN_OPTION") {
-                    console.error("Error: Unknown option");
                     usage();
-                    process.exit(1);
+                    throw new Error("Unknown option");
                 }
                 throw error;
             }
@@ -322,16 +320,11 @@ export class Run {
 
     private renderSamplesOrSchemas = (): SerializedRenderResult => {
         const targetLanguage = getTargetLanguage(this._options.lang);
-        try {
-            const graph = this.makeGraph();
-            if (this._options.noRender) {
-                return { lines: ["Done.", ""], annotations: List() };
-            }
-            return targetLanguage.renderGraphAndSerialize(graph, this._options.rendererOptions);
-        } catch (e) {
-            console.error(e);
-            return process.exit(1);
+        const graph = this.makeGraph();
+        if (this._options.noRender) {
+            return { lines: ["Done.", ""], annotations: List() };
         }
+        return targetLanguage.renderGraphAndSerialize(graph, this._options.rendererOptions);
     };
 
     private splitAndWriteJava = (dir: string, str: string) => {
@@ -542,8 +535,7 @@ export class Run {
         if (options.out) {
             let extension = path.extname(options.out);
             if (extension === "") {
-                console.error("Please specify a language (--lang) or an output file extension.");
-                process.exit(1);
+                throw new Error("Please specify a language (--lang) or an output file extension.");
             }
             return extension.substr(1);
         }

--- a/src/quicktype.ts
+++ b/src/quicktype.ts
@@ -11,8 +11,12 @@ export async function main(args: string[] | Options) {
 }
 
 if (require.main === module) {
-    main(process.argv.slice(2)).catch(reason => {
-        console.error(reason);
+    main(process.argv.slice(2)).catch(e => {
+        if (e instanceof Error) {
+            console.error(`Error: ${e.message}.`);
+        } else {
+            console.error(e);
+        }
         process.exit(1);
     });
 }

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -76,19 +76,23 @@ export async function quicktypeForLanguage(
   sourceLanguage: string,
   additionalRendererOptions: RendererOptions
 ) {
-  await quicktype({
-    srcLang: sourceLanguage,
-    lang: language.name,
-    src: [sourceFile],
-    out: language.output,
-    topLevel: language.topLevel,
-    rendererOptions: _.merge(
-      {},
-      language.rendererOptions,
-      additionalRendererOptions
-    ),
-    quiet: true
-  });
+  try {
+    await quicktype({
+      srcLang: sourceLanguage,
+      lang: language.name,
+      src: [sourceFile],
+      out: language.output,
+      topLevel: language.topLevel,
+      rendererOptions: _.merge(
+        {},
+        language.rendererOptions,
+        additionalRendererOptions
+      ),
+      quiet: true
+    });
+  } catch (e) {
+    failWith("quicktype threw an exception", { error: e });
+  }
 }
 
 export async function inDir(dir: string, work: () => Promise<void>) {


### PR DESCRIPTION
When we run quicktype from test we must throw, not exit.
Fixes #303