### PR TITLE
Simplify npm packaging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,10 +36,6 @@ jobs:
       before_install: true
       install: npm install
       script: npm run pub
-      before_deploy:
-        - npm run patch-npm-version
-        - cp package.json dist/
-        - cd dist
       deploy:
         provider: npm
         email: djsiegel@gmail.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ script: >
 jobs:
   include:
     - stage: deploy
+      if: branch == master
       env:
         - FIXTURE=none
       before_install: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: node_js
 node_js: node # latest
 sudo: required
-branches:
-  except:
-    - release
 env:
   - FIXTURE=golang,cplusplus,schema,graphql
   - FIXTURE=swift,java,schema-json-csharp

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,16 +11,13 @@ env:
 services:
   - docker
 before_install: >
-  [[ $TRAVIS_COMMIT_MESSAGE == *"ci:skip-tests"* ]] || \
-    docker pull dvdsgl/quicktype:latest
+  [[ $TRAVIS_COMMIT_MESSAGE == *"ci:skip-tests"* ]] || docker pull dvdsgl/quicktype:latest
 install: >
-  [[ $TRAVIS_COMMIT_MESSAGE == *"ci:skip-tests"* ]] || \
-  docker build \
+  [[ $TRAVIS_COMMIT_MESSAGE == *"ci:skip-tests"* ]] || docker build \
     --cache-from dvdsgl/quicktype:latest \
     --tag dvdsgl/quicktype .
 script: >
-  [[ $TRAVIS_COMMIT_MESSAGE == *"ci:skip-tests"* ]] || \
-  docker run \
+  [[ $TRAVIS_COMMIT_MESSAGE == *"ci:skip-tests"* ]] || docker run \
     -e FIXTURE \
     -e CI \
     -e TRAVIS_BRANCH \

--- a/package.json
+++ b/package.json
@@ -2,12 +2,11 @@
   "name": "quicktype",
   "version": "5.0.1",
   "license": "Apache-2.0",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "repository": "https://github.com/quicktype/quicktype",
   "scripts": {
     "pub": "script/publish.sh",
-    "patch-npm-version": "script/patch-npm-version.ts",
     "prepare": "npm run build",
     "build": "script/build.ts",
     "test": "npm run build && script/test",
@@ -47,6 +46,8 @@
     "uglify-js": "^3.0.26",
     "watch": "^1.0.2"
   },
-  "files": ["*"],
-  "bin": "cli.js"
+  "files": [
+    "dist/**"
+  ],
+  "bin": "dist/cli.js"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quicktype",
-  "version": "5.0.1",
+  "version": "6.0.0",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -46,8 +46,6 @@
     "uglify-js": "^3.0.26",
     "watch": "^1.0.2"
   },
-  "files": [
-    "dist/**"
-  ],
+  "files": ["dist/**"],
   "bin": "dist/cli.js"
 }

--- a/script/build.ts
+++ b/script/build.ts
@@ -36,10 +36,6 @@ function makeDistributedCLIExecutable() {
   shell.chmod("+x", cli);
 }
 
-function bundleDistributables() {
-  shell.cp(["README.md", "package.json"], "dist");
-}
-
 function main() {
   const skipPrereqs = !!process.env.SKIP_INSTALL_PREREQUISITES;
 
@@ -49,7 +45,6 @@ function main() {
 
   buildTypeScript();
   makeDistributedCLIExecutable();
-  bundleDistributables();
 }
 
 main();

--- a/script/publish.sh
+++ b/script/publish.sh
@@ -2,24 +2,13 @@
 
 OUTDIR=dist
 
+./script/patch-npm-version.ts
+
 # If not on CI, do a clean build
 if [ -z "$CI" ]; then
     rm -rf $OUTDIR
     npm run build
 fi
-
-# Copy npm package files into output/
-mkdir -p output
-cp -r LICENSE* package*.json $OUTDIR/
-
-cd $OUTDIR
-
-# Travis looks for this script when it does npm publish
-# We have to do this since we're building and publishing in
-# different folders
-mkdir script
-printf "#!/bin/bash\ntrue\n" > script/build.ts
-chmod +x script/build.ts
 
 # If not on CI, publish directly
 if [ -z "$CI" ]; then


### PR DESCRIPTION
Publish from root project directory rather than dist. This makes things like `npm link` work.

ci:skip-tests