### PR TITLE
Extension features

### DIFF
--- a/src/ConvenienceRenderer.ts
+++ b/src/ConvenienceRenderer.ts
@@ -301,16 +301,18 @@ export abstract class ConvenienceRenderer extends Renderer {
         blankLocations: BlankLineLocations,
         f: (t: Type, name: Name) => void,
         predicate?: (t: Type) => boolean
-    ): void => {
+    ): boolean => {
         let topLevels: Collection<string, Type>;
         if (predicate) {
             topLevels = this.topLevels.filter(predicate);
         } else {
             topLevels = this.topLevels;
         }
+        if (topLevels.count() === 0) return false;
         this.forEachWithBlankLines(topLevels, blankLocations, (t: Type, name: string) =>
             f(t, defined(this._topLevelNames.get(name)))
         );
+        return true;
     };
 
     setAlphabetizeProperties = (value: boolean): void => {

--- a/src/ConvenienceRenderer.ts
+++ b/src/ConvenienceRenderer.ts
@@ -444,6 +444,12 @@ export abstract class ConvenienceRenderer extends Renderer {
         ).lines.join("\n");
     };
 
+    protected emitCommentLines = (commentStart: string, lines: string[]): void => {
+        for (const line of lines) {
+            this.emitLine((commentStart + line).trimRight());
+        }
+    };
+
     protected emitSource(): void {
         const types = this.typeGraph.allNamedTypes(this.childrenOfType);
         this._haveUnions = types.some(t => t instanceof UnionType);

--- a/src/Language/CPlusPlus.ts
+++ b/src/Language/CPlusPlus.ts
@@ -622,6 +622,7 @@ inline ${this._optionalType}<T> get_optional(const json &j, const char *property
     protected emitSourceStructure(): void {
         if (this.leadingComments !== undefined) {
             this.emitCommentLines("// ", this.leadingComments);
+            this.emitNewline();
         } else if (!this._justTypes) {
             this.emitCommentLines("// ", [
                 " To parse this JSON data, first install",
@@ -640,18 +641,19 @@ inline ${this._optionalType}<T> get_optional(const json &j, const char *property
                     " data = nlohmann::json::parse(jsonString);"
                 );
             });
+            this.emitNewline();
         }
-        this.emitNewline();
-        if (this.haveUnions && !this._uniquePtr) {
-            this.emitLine("#include <boost/optional.hpp>");
-        }
-        if (this.haveNamedUnions) {
-            this.emitLine("#include <boost/variant.hpp>");
-        }
-        if (!this._justTypes) {
-            this.emitLine('#include "json.hpp"');
-        }
-        this.emitNewline();
+        
+        let didInclude = false;
+        const include = (name: string): void => {
+            this.emitLine(`#include ${name}`);
+            didInclude = true;            
+        };
+        if (this.haveUnions && !this._uniquePtr) include("<boost/optional.hpp>");
+        if (this.haveNamedUnions) include("<boost/variant.hpp>");
+        if (!this._justTypes) include('"json.hpp"');
+        if (didInclude) this.emitNewline();
+
         if (this._justTypes) {
             this.emitTypes();
         } else {

--- a/src/Language/CSharp.ts
+++ b/src/Language/CSharp.ts
@@ -574,13 +574,42 @@ class CSharpRenderer extends ConvenienceRenderer {
         });
     };
 
-    protected emitSourceStructure(): void {
+    private emitTypesAndSupport = (): void => {
         const using = (ns: Sourcelike): void => {
             this.emitLine("using ", ns, ";");
         };
 
+        if (this._needAttributes || this._needHelpers) {
+            for (const ns of ["System", "System.Net", "System.Collections.Generic"]) {
+                using(ns);
+            }
+            this.emitNewline();
+            using("Newtonsoft.Json");
+            if (this._dense) {
+                using([denseJsonPropertyName, " = Newtonsoft.Json.JsonPropertyAttribute"]);
+            }
+            this.emitNewline();
+        }
+        this.forEachClass("interposing", this.emitClassDefinition);
+        this.forEachEnum("leading-and-interposing", this.emitEnumDefinition);
+        this.forEachUnion("leading-and-interposing", this.emitUnionDefinition);
+        if (this._needHelpers) {
+            this.forEachTopLevel("leading-and-interposing", this.emitFromJsonForTopLevel);
+            this.forEachEnum("leading-and-interposing", this.emitEnumExtension);
+            this.forEachUnion("leading-and-interposing", this.emitUnionJSONPartial);
+            this.emitNewline();
+            this.emitSerializeClass();
+        }
+        if (this._needHelpers || (this._needAttributes && (this.haveNamedUnions || this.haveEnums))) {
+            this.emitNewline();
+            this.emitConverterClass();
+        }
+    };
+
+    protected emitSourceStructure(): void {
         if (this.leadingComments !== undefined) {
             this.emitCommentLines("// ", this.leadingComments);
+            this.emitNewline();
         } else if (this._needHelpers) {
             this.emitLine(
                 "// To parse this JSON data, add NuGet 'Newtonsoft.Json' then do",
@@ -593,35 +622,14 @@ class CSharpRenderer extends ConvenienceRenderer {
                 this.emitLine("//");
                 this.emitLine("//    var data = ", topLevelName, ".FromJson(jsonString);");
             });
-            this.emitLine("//");
+            this.emitNewline();
         }
 
-        this.emitLine("namespace ", this._namespaceName);
-        this.emitBlock(() => {
-            for (const ns of ["System", "System.Net", "System.Collections.Generic"]) {
-                using(ns);
-            }
-            if (this._needAttributes || this._needHelpers) {
-                this.emitNewline();
-                using("Newtonsoft.Json");
-                if (this._dense) {
-                    using([denseJsonPropertyName, " = Newtonsoft.Json.JsonPropertyAttribute"]);
-                }
-            }
-            this.forEachClass("leading-and-interposing", this.emitClassDefinition);
-            this.forEachEnum("leading-and-interposing", this.emitEnumDefinition);
-            this.forEachUnion("leading-and-interposing", this.emitUnionDefinition);
-            if (this._needHelpers) {
-                this.forEachTopLevel("leading-and-interposing", this.emitFromJsonForTopLevel);
-                this.forEachEnum("leading-and-interposing", this.emitEnumExtension);
-                this.forEachUnion("leading-and-interposing", this.emitUnionJSONPartial);
-                this.emitNewline();
-                this.emitSerializeClass();
-            }
-            if (this._needHelpers || (this._needAttributes && (this.haveNamedUnions || this.haveEnums))) {
-                this.emitNewline();
-                this.emitConverterClass();
-            }
-        });
+        if (this._needHelpers || this._needAttributes) {
+            this.emitLine("namespace ", this._namespaceName);
+            this.emitBlock(this.emitTypesAndSupport);
+        } else {
+            this.emitTypesAndSupport();
+        }
     }
 }

--- a/src/Language/CSharp.ts
+++ b/src/Language/CSharp.ts
@@ -65,7 +65,11 @@ export default class CSharpTargetLanguage extends TargetLanguage {
         return { date: "date-time", time: "date-time", dateTime: "date-time" };
     }
 
-    protected get rendererClass(): new (graph: TypeGraph, ...optionValues: any[]) => ConvenienceRenderer {
+    protected get rendererClass(): new (
+        graph: TypeGraph,
+        leadingComments: string[] | undefined,
+        ...optionValues: any[]
+    ) => ConvenienceRenderer {
         return CSharpRenderer;
     }
 }
@@ -117,13 +121,14 @@ class CSharpRenderer extends ConvenienceRenderer {
 
     constructor(
         graph: TypeGraph,
+        leadingComments: string[] | undefined,
         private readonly _namespaceName: string,
         private readonly _version: Version,
         private readonly _dense: boolean,
         private readonly _useList: boolean,
         outputFeatures: OutputFeatures
     ) {
-        super(graph);
+        super(graph, leadingComments);
         this._needHelpers = outputFeatures.helpers;
         this._needAttributes = outputFeatures.attributes;
     }
@@ -574,7 +579,9 @@ class CSharpRenderer extends ConvenienceRenderer {
             this.emitLine("using ", ns, ";");
         };
 
-        if (this._needHelpers) {
+        if (this.leadingComments !== undefined) {
+            this.emitCommentLines("// ", this.leadingComments);
+        } else if (this._needHelpers) {
             this.emitLine(
                 "// To parse this JSON data, add NuGet 'Newtonsoft.Json' then do",
                 this.topLevels.size === 1 ? "" : " one of these",

--- a/src/Language/Elm.ts
+++ b/src/Language/Elm.ts
@@ -3,7 +3,7 @@
 import { Map, List } from "immutable";
 
 import { TargetLanguage } from "../TargetLanguage";
-import { EnumOption, StringOption } from "../RendererOptions";
+import { EnumOption, StringOption, BooleanOption } from "../RendererOptions";
 import { NamedType, Type, matchType, nullableFromUnion, ClassType, UnionType, EnumType, PrimitiveType } from "../Type";
 import { TypeGraph } from "../TypeGraph";
 import { ConvenienceRenderer } from "../ConvenienceRenderer";
@@ -26,6 +26,7 @@ import { Sourcelike, maybeAnnotated } from "../Source";
 import { anyTypeIssueAnnotation, nullTypeIssueAnnotation } from "../Annotation";
 
 export default class ElmTargetLanguage extends TargetLanguage {
+    private readonly _justTypesOption = new BooleanOption("just-types", "Plain types only", false);
     private readonly _listOption = new EnumOption("array-type", "Use Array or List", [
         ["array", false],
         ["list", true]
@@ -35,7 +36,7 @@ export default class ElmTargetLanguage extends TargetLanguage {
 
     constructor() {
         super("Elm", ["elm"], "elm");
-        this.setOptions([this._moduleOption, this._listOption]);
+        this.setOptions([this._justTypesOption, this._moduleOption, this._listOption]);
     }
 
     protected get rendererClass(): new (
@@ -156,6 +157,7 @@ class ElmRenderer extends ConvenienceRenderer {
     constructor(
         graph: TypeGraph,
         leadingComments: string[] | undefined,
+        private readonly _justTypes: boolean,
         private readonly _moduleName: string,
         private readonly _useList: boolean
     ) {
@@ -515,7 +517,8 @@ class ElmRenderer extends ConvenienceRenderer {
 
         if (this.leadingComments !== undefined) {
             this.emitCommentLines("-- ", this.leadingComments);
-        } else {
+            this.emitNewline();
+        } else if (!this._justTypes) {
             this.emitCommentLines("-- ", [
                 "To decode the JSON data, add this file to your project, run",
                 "",
@@ -533,8 +536,8 @@ class ElmRenderer extends ConvenienceRenderer {
                 ")"
             );
             this.emitMultiline(`--
-            -- and you're off to the races with
-            --`);
+-- and you're off to the races with
+--`);
             this.forEachTopLevel("none", (_, name) => {
                 let { decoder } = defined(this._topLevelDependents.get(name));
                 if (decoder === undefined) {
@@ -542,42 +545,47 @@ class ElmRenderer extends ConvenienceRenderer {
                 }
                 this.emitLine("--     decodeString ", decoder, " myJsonString");
             });
+            this.emitNewline();
         }
-        this.emitNewline();
 
-        this.emitLine("module ", this._moduleName, " exposing");
-        this.indent(() => {
-            for (let i = 0; i < exports.length; i++) {
-                this.emitLine(i === 0 ? "(" : ",", " ", exports[i]);
-            }
-            this.emitLine(")");
-        });
-        this.emitNewline();
+        if (!this._justTypes) {
+            this.emitLine("module ", this._moduleName, " exposing");
+            this.indent(() => {
+                for (let i = 0; i < exports.length; i++) {
+                    this.emitLine(i === 0 ? "(" : ",", " ", exports[i]);
+                }
+                this.emitLine(")");
+            });
+            this.emitNewline();
 
-        this.emitMultiline(`import Json.Decode as Jdec
+            this.emitMultiline(`import Json.Decode as Jdec
 import Json.Decode.Pipeline as Jpipe
 import Json.Encode as Jenc
 import Dict exposing (Dict, map, toList)`);
-        if (this._useList) {
-            this.emitLine("import List exposing (map)");
-        } else {
-            this.emitLine("import Array exposing (Array, map)");
+            if (this._useList) {
+                this.emitLine("import List exposing (map)");
+            } else {
+                this.emitLine("import Array exposing (Array, map)");
+            }
+            this.emitNewline();
         }
 
-        this.forEachTopLevel(
-            "leading-and-interposing",
-            this.emitTopLevelDefinition,
-            t => !this.namedTypeToNameForTopLevel(t)
-        );
+        if (
+            this.forEachTopLevel("interposing", this.emitTopLevelDefinition, t => !this.namedTypeToNameForTopLevel(t))
+        ) {
+            this.emitNewline();
+        }
         this.forEachNamedType(
-            "leading-and-interposing",
+            "interposing",
             false,
             this.emitClassDefinition,
             this.emitEnumDefinition,
             this.emitUnionDefinition
         );
-        this.emitNewline();
 
+        if (this._justTypes) return;
+
+        this.emitNewline();
         this.emitLine("-- decoders and encoders");
         this.forEachTopLevel("leading-and-interposing", this.emitTopLevelFunctions);
         this.forEachNamedType(

--- a/src/Language/Golang.ts
+++ b/src/Language/Golang.ts
@@ -26,18 +26,19 @@ import {
     allUpperWordStyle
 } from "../Strings";
 import { defined } from "../Support";
-import { StringOption } from "../RendererOptions";
+import { StringOption, BooleanOption } from "../RendererOptions";
 import { Sourcelike, maybeAnnotated } from "../Source";
 import { anyTypeIssueAnnotation, nullTypeIssueAnnotation } from "../Annotation";
 import { TargetLanguage } from "../TargetLanguage";
 import { ConvenienceRenderer } from "../ConvenienceRenderer";
 
 export default class GoTargetLanguage extends TargetLanguage {
+    private readonly _justTypesOption = new BooleanOption("just-types", "Plain types only", false);
     private readonly _packageOption = new StringOption("package", "Generated package name", "NAME", "main");
 
     constructor() {
         super("Go", ["go", "golang"], "go");
-        this.setOptions([this._packageOption]);
+        this.setOptions([this._justTypesOption, this._packageOption]);
     }
 
     protected get rendererClass(): new (
@@ -82,7 +83,12 @@ function isValueType(t: Type): boolean {
 class GoRenderer extends ConvenienceRenderer {
     private _topLevelUnmarshalNames = Map<Name, Name>();
 
-    constructor(graph: TypeGraph, leadingComments: string[] | undefined, private readonly _packageName: string) {
+    constructor(
+        graph: TypeGraph,
+        leadingComments: string[] | undefined,
+        private readonly _justTypes: boolean,
+        private readonly _packageName: string
+    ) {
         super(graph, leadingComments);
     }
 
@@ -171,8 +177,11 @@ class GoRenderer extends ConvenienceRenderer {
         const unmarshalName = defined(this._topLevelUnmarshalNames.get(name));
         if (!this.namedTypeToNameForTopLevel(t)) {
             this.emitLine("type ", name, " ", this.goType(t));
-            this.emitNewline();
         }
+
+        if (this._justTypes) return;
+
+        this.emitNewline();
         this.emitFunc([unmarshalName, "(data []byte) (", name, ", error)"], () => {
             this.emitLine("var r ", name);
             this.emitLine("err := json.Unmarshal(data, &r)");
@@ -208,6 +217,9 @@ class GoRenderer extends ConvenienceRenderer {
             })
         );
         this.emitLine(")");
+
+        if (this._justTypes) return;
+
         this.emitNewline();
         this.emitFunc(["(x *", enumName, ") UnmarshalJSON(data []byte) error"], () => {
             this.emitMultiline(`dec := json.NewDecoder(bytes.NewReader(data))
@@ -289,6 +301,9 @@ if err != nil {
             columns.push([[fieldName, " "], goType]);
         });
         this.emitStruct(unionName, columns);
+
+        if (this._justTypes) return;
+
         this.emitNewline();
         this.emitFunc(["(x *", unionName, ") UnmarshalJSON(data []byte) error"], () => {
             for (const kind of compoundTypeKinds) {
@@ -328,29 +343,44 @@ if err != nil {
     protected emitSourceStructure(): void {
         if (this.leadingComments !== undefined) {
             this.emitCommentLines("// ", this.leadingComments);
-        } else {
+            this.emitNewline();
+        } else if (!this._justTypes) {
             this.emitLine("// To parse and unparse this JSON data, add this code to your project and do:");
             this.forEachTopLevel("none", (_: Type, name: Name) => {
                 this.emitLine("//");
                 this.emitLine("//    r, err := ", defined(this._topLevelUnmarshalNames.get(name)), "(bytes)");
                 this.emitLine("//    bytes, err = r.Marshal()");
             });
+            this.emitNewline();
         }
-        this.emitNewline();
-        this.emitLine("package ", this._packageName);
-        this.emitNewline();
-        if (this.haveEnums || this.haveNamedUnions) {
-            this.emitLine('import "bytes"');
-            this.emitLine('import "errors"');
+        if (!this._justTypes) {
+            this.emitLine("package ", this._packageName);
+            this.emitNewline();
+            if (this.haveEnums || this.haveNamedUnions) {
+                this.emitLine('import "bytes"');
+                this.emitLine('import "errors"');
+            }
+            if (this.haveEnums) {
+                this.emitLine('import "fmt"');
+            }
+            this.emitLine('import "encoding/json"');
+            this.emitNewline();
         }
-        if (this.haveEnums) {
-            this.emitLine('import "fmt"');
+        if (
+            this.forEachTopLevel(
+                "interposing",
+                this.emitTopLevel,
+                t => !this._justTypes || !this.namedTypeToNameForTopLevel(t)
+            )
+        ) {
+            this.emitNewline();
         }
-        this.emitLine('import "encoding/json"');
-        this.forEachTopLevel("leading-and-interposing", this.emitTopLevel);
-        this.forEachClass("leading-and-interposing", this.emitClass);
+        this.forEachClass("interposing", this.emitClass);
         this.forEachEnum("leading-and-interposing", this.emitEnum);
         this.forEachUnion("leading-and-interposing", this.emitUnion);
+
+        if (this._justTypes) return;
+
         if (this.haveNamedUnions) {
             this.emitNewline();
             this

--- a/src/Language/JSONSchema.ts
+++ b/src/Language/JSONSchema.ts
@@ -21,7 +21,11 @@ export default class JSONSchemaTargetLanguage extends TargetLanguage {
         return { date: "date", time: "time", dateTime: "date-time" };
     }
 
-    protected get rendererClass(): new (graph: TypeGraph, ...optionValues: any[]) => ConvenienceRenderer {
+    protected get rendererClass(): new (
+        graph: TypeGraph,
+        leadingComments: string[] | undefined,
+        ...optionValues: any[]
+    ) => ConvenienceRenderer {
         return JSONSchemaRenderer;
     }
 }

--- a/src/Language/SimpleTypes.ts
+++ b/src/Language/SimpleTypes.ts
@@ -38,7 +38,11 @@ export default class SimpleTypesTargetLanguage extends TargetLanguage {
         return { date: "date", time: "time", dateTime: "date-time" };
     }
 
-    protected get rendererClass(): new (graph: TypeGraph, ...optionValues: any[]) => ConvenienceRenderer {
+    protected get rendererClass(): new (
+        graph: TypeGraph,
+        leadingComments: string[] | undefined,
+        ...optionValues: any[]
+    ) => ConvenienceRenderer {
         return SimpleTypesRenderer;
     }
 }
@@ -69,8 +73,8 @@ function simpleNameStyle(original: string, uppercase: boolean): string {
 }
 
 class SimpleTypesRenderer extends ConvenienceRenderer {
-    constructor(graph: TypeGraph, private readonly inlineUnions: boolean) {
-        super(graph);
+    constructor(graph: TypeGraph, leadingComments: string[] | undefined, private readonly inlineUnions: boolean) {
+        super(graph, leadingComments);
     }
 
     protected topLevelNameStyle(rawName: string): string {
@@ -160,6 +164,10 @@ class SimpleTypesRenderer extends ConvenienceRenderer {
     };
 
     protected emitSourceStructure() {
+        if (this.leadingComments !== undefined) {
+            this.emitCommentLines("// ", this.leadingComments);
+            this.emitNewline();
+        }
         this.forEachClass("interposing", this.emitClass);
         this.forEachEnum("leading-and-interposing", this.emitEnum);
         if (!this.inlineUnions) {

--- a/src/Language/Swift.ts
+++ b/src/Language/Swift.ts
@@ -49,7 +49,11 @@ export default class SwiftTargetLanguage extends TargetLanguage {
         this.setOptions([this._justTypesOption, this._classOption]);
     }
 
-    protected get rendererClass(): new (graph: TypeGraph, ...optionValues: any[]) => ConvenienceRenderer {
+    protected get rendererClass(): new (
+        graph: TypeGraph,
+        leadingComments: string[] | undefined,
+        ...optionValues: any[]
+    ) => ConvenienceRenderer {
         return SwiftRenderer;
     }
 }
@@ -187,8 +191,13 @@ const upperNamingFunction = funPrefixNamer(s => swiftNameStyle(true, s));
 const lowerNamingFunction = funPrefixNamer(s => swiftNameStyle(false, s));
 
 class SwiftRenderer extends ConvenienceRenderer {
-    constructor(graph: TypeGraph, private readonly _justTypes: boolean, private readonly _useClasses: boolean) {
-        super(graph);
+    constructor(
+        graph: TypeGraph,
+        leadingComments: string[] | undefined,
+        private readonly _justTypes: boolean,
+        private readonly _useClasses: boolean
+    ) {
+        super(graph, leadingComments);
     }
 
     protected get forbiddenNamesForGlobalNamespace(): string[] {
@@ -277,7 +286,10 @@ class SwiftRenderer extends ConvenienceRenderer {
     };
 
     private renderHeader = (): void => {
-        if (!this._justTypes) {
+        if (this.leadingComments !== undefined) {
+            this.emitCommentLines("// ", this.leadingComments);
+            this.emitNewline();
+        } else if (!this._justTypes) {
             this.emitLine("// To parse the JSON, add this file to your project and do:");
             this.emitLine("//");
             this.forEachTopLevel("none", (_, name) => {

--- a/src/Language/TypeScript.ts
+++ b/src/Language/TypeScript.ts
@@ -35,7 +35,11 @@ export default class L extends TargetLanguage {
         this.setOptions([this._justTypes, this._declareUnions, this._runtimeTypecheck]);
     }
 
-    protected get rendererClass(): new (graph: TypeGraph, ...optionValues: any[]) => ConvenienceRenderer {
+    protected get rendererClass(): new (
+        graph: TypeGraph,
+        leadingComments: string[] | undefined,
+        ...optionValues: any[]
+    ) => ConvenienceRenderer {
         return TypeScriptRenderer;
     }
 }
@@ -87,11 +91,12 @@ class TypeScriptRenderer extends ConvenienceRenderer {
 
     constructor(
         graph: TypeGraph,
+        leadingComments: string[] | undefined,
         private readonly _justTypes: boolean,
         declareUnions: boolean,
         private readonly _runtimeTypecheck: boolean
     ) {
-        super(graph);
+        super(graph, leadingComments);
         this._inlineUnions = !declareUnions;
     }
 
@@ -364,7 +369,10 @@ function O(className: string) {
     };
 
     protected emitSourceStructure() {
-        if (!this._justTypes) {
+        if (this.leadingComments !== undefined) {
+            this.emitCommentLines("// ", this.leadingComments);
+            this.emitNewline();
+        } else if (!this._justTypes) {
             this.emitMultiline(`// To parse this data:
 //`);
             const topLevelNames: Sourcelike[] = [];

--- a/src/Renderer.ts
+++ b/src/Renderer.ts
@@ -34,7 +34,7 @@ export abstract class Renderer {
     private _emitted: Sourcelike[];
     private _currentEmitTarget: Sourcelike[];
 
-    constructor(protected readonly typeGraph: TypeGraph) {
+    constructor(protected readonly typeGraph: TypeGraph, protected readonly leadingComments: string[] | undefined) {
         this._currentEmitTarget = this._emitted = [];
     }
 

--- a/src/TargetLanguage.ts
+++ b/src/TargetLanguage.ts
@@ -25,17 +25,26 @@ export abstract class TargetLanguage {
         return this._options.map(o => o.definition);
     }
 
-    protected abstract get rendererClass(): new (graph: TypeGraph, ...optionValues: any[]) => Renderer;
+    protected abstract get rendererClass(): new (
+        graph: TypeGraph,
+        leadingComments: string[] | undefined,
+        ...optionValues: any[]
+    ) => Renderer;
 
     renderGraphAndSerialize(
         graph: TypeGraph,
         alphabetizeProperties: boolean,
+        leadingComments: string[] | undefined,
         rendererOptions: { [name: string]: any }
     ): SerializedRenderResult {
         if (this._options === undefined) {
             return panic(`Target language ${this.displayName} did not set its options`);
         }
-        const renderer = new this.rendererClass(graph, ...this._options.map(o => o.getValue(rendererOptions)));
+        const renderer = new this.rendererClass(
+            graph,
+            leadingComments,
+            ...this._options.map(o => o.getValue(rendererOptions))
+        );
         if ((renderer as any).setAlphabetizeProperties !== undefined) {
             (renderer as ConvenienceRenderer).setAlphabetizeProperties(alphabetizeProperties);
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,10 +75,11 @@ export interface Options {
     alphabetizeProperties: boolean;
     combineClasses: boolean;
     noRender: boolean;
+    leadingComments: string[] | undefined;
     rendererOptions: RendererOptions;
 }
 
-const defaultOptions = {
+const defaultOptions: Options = {
     lang: "ts",
     sources: [],
     inferMaps: true,
@@ -86,6 +87,7 @@ const defaultOptions = {
     alphabetizeProperties: false,
     combineClasses: true,
     noRender: false,
+    leadingComments: undefined,
     rendererOptions: {}
 };
 
@@ -201,6 +203,7 @@ export class Run {
         return targetLanguage.renderGraphAndSerialize(
             graph,
             this._options.alphabetizeProperties,
+            this._options.leadingComments,
             this._options.rendererOptions
         );
     };


### PR DESCRIPTION
This does three things:

1. Add an API-only option to let the renderer emit leading comments.

2. Implement `just-types` for all renderers where it applies (it makes no sense for Simple Types and JSON Schema).

3. Not emitting packages/namespaces/whatever for `just-types`.

@dvdsgl Objections to 3?