### PR TITLE
[NOMERGE] Swift improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quicktype",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -46,6 +46,8 @@
     "uglify-js": "^3.0.26",
     "watch": "^1.0.2"
   },
-  "files": ["dist/**"],
+  "files": [
+    "dist/**"
+  ],
   "bin": "dist/cli.js"
 }

--- a/src/ConvenienceRenderer.ts
+++ b/src/ConvenienceRenderer.ts
@@ -18,6 +18,8 @@ import { Renderer, BlankLineLocations } from "./Renderer";
 import { defined, panic, nonNull } from "./Support";
 import { Sourcelike, sourcelikeToSource, serializeRenderResult } from "./Source";
 
+import { trimEnd } from "lodash";
+
 export abstract class ConvenienceRenderer extends Renderer {
     protected globalNamespace: Namespace;
     private _topLevelNames: Map<string, Name>;
@@ -446,7 +448,7 @@ export abstract class ConvenienceRenderer extends Renderer {
 
     protected emitCommentLines = (commentStart: string, lines: string[]): void => {
         for (const line of lines) {
-            this.emitLine((commentStart + line).trimRight());
+            this.emitLine(trimEnd(commentStart + line));
         }
     };
 

--- a/src/Language/Swift.ts
+++ b/src/Language/Swift.ts
@@ -482,6 +482,12 @@ class SwiftRenderer extends ConvenienceRenderer {
     guard let data = json.data(using: encoding) else { return nil }
     self.init(data: data)
 }`);
+                this.ensureBlankLine();
+                this.emitMultiline(`convenience init?(url: String) {
+    guard let url = URL(string: url) else { return nil }
+    guard let data = try? Data(contentsOf: url) else { return nil }
+    self.init(data: data)
+}`);
             } else {
                 // 1. Two convenience initializers for Json string and data
                 this.emitBlock(["init?(data: Data)"], () => {
@@ -497,6 +503,12 @@ class SwiftRenderer extends ConvenienceRenderer {
                     this.emitLine("guard let data = json.data(using: encoding) else { return nil }");
                     this.emitLine("self.init(data: data)");
                 });
+                this.ensureBlankLine();
+                this.emitMultiline(`init?(url: String) {
+    guard let url = URL(string: url) else { return nil }
+    guard let data = try? Data(contentsOf: url) else { return nil }
+    self.init(data: data)
+}`);
             }
 
             // Convenience serializers
@@ -608,6 +620,12 @@ var json: String? {
                 this.emitLine("guard let data = json.data(using: encoding) else { return nil }");
                 this.emitLine("self.init(data: data)");
             });
+            this.ensureBlankLine();
+            this.emitMultiline(`init?(url: String) {
+    guard let url = URL(string: url) else { return nil }
+    guard let data = try? Data(contentsOf: url) else { return nil }
+    self.init(data: data)
+}`);
             this.ensureBlankLine();
             this.emitBlock("var jsonData: Data?", () => {
                 this.emitLine("return try? JSONEncoder().encode(self)");

--- a/src/Language/Swift.ts
+++ b/src/Language/Swift.ts
@@ -465,7 +465,7 @@ class SwiftRenderer extends ConvenienceRenderer {
                         ".self, from: data) else { return nil }"
                     );
                     let args: Sourcelike[] = [];
-                    this.forEachClassProperty(c, "none", (name, _, t) => {
+                    this.forEachClassProperty(c, "none", name => {
                         if (args.length > 0) args.push(", ");
                         args.push(name, ": ", "me.", name);
                     });
@@ -578,8 +578,8 @@ var json: String? {
     };
 
     private emitTopLevelMapAndArrayExtensions = (t: Type, name: Name): void => {
-        const typeSource = this.swiftType(t);
         let extensionSource: Sourcelike;
+
         if (t instanceof ArrayType) {
             extensionSource = ["Array where Element == ", name, ".Element"];
         } else if (t instanceof MapType) {

--- a/src/Language/Swift.ts
+++ b/src/Language/Swift.ts
@@ -366,7 +366,7 @@ class SwiftRenderer extends ConvenienceRenderer {
                 });
             }
 
-            if (!this._justTypes) {
+            if (!this._justTypes && !c.properties.isEmpty()) {
                 this.ensureBlankLine();
                 this.emitBlock("enum CodingKeys: String, CodingKey", () => {
                     this.forEachClassProperty(c, "none", (name, jsonName) => {

--- a/src/Language/Swift.ts
+++ b/src/Language/Swift.ts
@@ -314,6 +314,14 @@ class SwiftRenderer extends ConvenienceRenderer {
             this.forEachClassProperty(c, "none", (name, _, t) => {
                 this.emitLine("let ", name, ": ", this.swiftType(t, true));
             });
+            if (!this._justTypes) {
+                this.ensureBlankLine();
+                this.emitBlock("enum CodingKeys: String, CodingKey", () => {
+                    this.forEachClassProperty(c, "none", (name, jsonName) => {
+                        this.emitLine("case ", name, ' = "', stringEscape(jsonName), '"');
+                    });
+                });
+            }
         });
     };
 
@@ -385,17 +393,6 @@ class SwiftRenderer extends ConvenienceRenderer {
             this.emitBlock("var jsonString: String?", () => {
                 this.emitLine("guard let data = self.jsonData else { return nil }");
                 this.emitLine("return String(data: data, encoding: .utf8)");
-            });
-        });
-    };
-
-    private renderClassExtensions4 = (c: ClassType, className: Name): void => {
-        if (c.properties.isEmpty()) return;
-        this.emitBlock(["extension ", className], () => {
-            this.emitBlock("enum CodingKeys: String, CodingKey", () => {
-                this.forEachClassProperty(c, "none", (name, jsonName) => {
-                    this.emitLine("case ", name, ' = "', stringEscape(jsonName), '"');
-                });
             });
         });
     };
@@ -723,7 +720,7 @@ class JSONAny: Codable {
             this.forEachNamedType(
                 "leading-and-interposing",
                 false,
-                this.renderClassExtensions4,
+                () => undefined,
                 () => undefined,
                 this.renderUnionExtensions4
             );

--- a/src/Language/Swift.ts
+++ b/src/Language/Swift.ts
@@ -15,7 +15,7 @@ import {
     TypeKind
 } from "../Type";
 import { TypeGraph } from "../TypeGraph";
-import { Namespace, Name, Namer, funPrefixNamer, FixedName } from "../Naming";
+import { Namespace, Name, Namer, funPrefixNamer } from "../Naming";
 import { BooleanOption, EnumOption } from "../RendererOptions";
 import { Sourcelike, maybeAnnotated, modifySource } from "../Source";
 import { anyTypeIssueAnnotation, nullTypeIssueAnnotation } from "../Annotation";
@@ -36,7 +36,6 @@ import {
     allUpperWordStyle,
     camelCase
 } from "../Strings";
-import { intercalate } from "../Support";
 
 const MAX_SAMELINE_PROPERTIES = 4;
 
@@ -319,14 +318,12 @@ class SwiftRenderer extends ConvenienceRenderer {
 
     private getProtocolString = (): Sourcelike => {
         let protocols: string[] = [];
-
         if (this._version > 4) {
             protocols.push("Hashable", "Equatable");
         }
         if (!this._justTypes) {
             protocols.push("Codable");
         }
-
         return protocols.length
             ? ": " + protocols.join(", ")
             : "";
@@ -368,7 +365,6 @@ class SwiftRenderer extends ConvenienceRenderer {
                     this.emitLine("let ", name, ": ", this.swiftType(t, true));
                 });
             }
-
 
             if (!this._justTypes) {
                 this.ensureBlankLine();

--- a/test/fixtures/swift/main.swift
+++ b/test/fixtures/swift/main.swift
@@ -15,7 +15,7 @@ else {
     exit(1)
 }
 
-guard let obj = TopLevel.from(data: data)
+guard let obj = TopLevel(data: data)
 else {
     print("Error: Could not deserialize")
     exit(1)

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -154,7 +154,11 @@ function makeSwiftLanguage(rendererOptions: {
     ],
     skipSchema: [],
     rendererOptions: rendererOptions,
-    quickTestRendererOptions: [{ "struct-or-class": "class" }]
+    quickTestRendererOptions: [
+      { "struct-or-class": "class" },
+      { density: "dense" },
+      { density: "normal" }
+    ]
   };
 }
 


### PR DESCRIPTION
# Prototype

https://app2.quicktype.io/#l=swift

---

- [x] Remove separation between type declarations and Codable extensions
- [x] Replace static `from` extensions with failable constructors within primary type definitions
- [x] Implement `dense` option
  - [x] Group contiguous fields with same types
  - [x] Omit `CodingKey` case strings when redundant (e.g. `case x = "x"`)
  - [x] Group contiguous redundant `CodingKey` cases
  - [x] Omit `CodingKeys` enum when all cases are redundant
- [ ] ~~Make `from(url:)` callback-based~~
- [x] Add Swift 4.1 auto-protocols
- [ ] Fix #365 