### PR TITLE
Use strings for Go enums. Fixes #373

### DIFF
--- a/test/languages.ts
+++ b/test/languages.ts
@@ -70,14 +70,7 @@ export const GoLanguage: Language = {
   allowMissingNull: false,
   output: "quicktype.go",
   topLevel: "TopLevel",
-  skipJSON: [
-    "identifiers.json",
-    "simple-identifiers.json",
-    "blns-object.json",
-    "e324e.json", // https://github.com/golang/go/issues/23263
-    "76ae1.json", // same
-    "7d397.json" // same
-  ],
+  skipJSON: ["identifiers.json", "simple-identifiers.json", "blns-object.json"],
   skipSchema: [],
   rendererOptions: {},
   quickTestRendererOptions: []


### PR DESCRIPTION
Unfortunately we don't check the validity of
the enums anymore, both when marshalling
and when unmarshalling.  If we kept the
custom marshalling methods we could check
there, but they wouldn't get invoked in all
cases, like the integers before, so we'd have
checking in most, but not all cases, and a hard
job of explaining which case applies in which
situation.