### PR TITLE
Don't make unified classes fixed

### DIFF
--- a/src/CombineClasses.ts
+++ b/src/CombineClasses.ts
@@ -124,7 +124,7 @@ export function combineClasses(graph: TypeGraph, stringTypeMapping: StringTypeMa
     function makeCliqueClass(clique: Set<ClassType>, builder: GraphRewriteBuilder<ClassType>): TypeRef {
         assert(clique.size > 0, "Clique can't be empty");
         const allNames = clique.map(c => c.getNames());
-        return unifyTypes(clique, typeNamesUnion(allNames), builder, false);
+        return unifyTypes(clique, typeNamesUnion(allNames), builder, false, false);
     }
 
     return graph.rewrite(stringTypeMapping, cliques, makeCliqueClass);

--- a/src/InferMaps.ts
+++ b/src/InferMaps.ts
@@ -73,7 +73,7 @@ function replaceClass(setOfOneClass: Set<ClassType>, builder: GraphRewriteBuilde
     // Reconstituting a type means generating the "same" type in the new
     // type graph.  Except we don't get Type objects but TypeRef objects,
     // which is a type-to-be.
-    return builder.getMapType(unifyTypes(shouldBe, c.getNames(), builder, false));
+    return builder.getMapType(unifyTypes(shouldBe, c.getNames(), builder, false, false));
 }
 
 export function inferMaps(graph: TypeGraph, stringTypeMapping: StringTypeMapping): TypeGraph {

--- a/src/JSONSchemaInput.ts
+++ b/src/JSONSchemaInput.ts
@@ -162,7 +162,7 @@ export function schemaToType(typeBuilder: TypeGraphBuilder, topLevelName: string
         requiredArray: string[]
     ): TypeRef {
         const required = Set(requiredArray);
-        const result = typeBuilder.getUniqueClassType(getName(schema, typeNames));
+        const result = typeBuilder.getUniqueClassType(getName(schema, typeNames), true);
         const c = assertIsClass(getHopefullyFinishedType(typeBuilder, result));
         setTypeForPath(path, result);
         // FIXME: We're using a Map instead of an OrderedMap here because we represent
@@ -269,7 +269,7 @@ export function schemaToType(typeBuilder: TypeGraphBuilder, topLevelName: string
             const types = cases.map(
                 (t, index) => toType(checkStringMap(t), path.push({ kind, index } as any), typeNames).deref()[0]
             );
-            return unifyTypes(OrderedSet(types), typeNames, typeBuilder, true);
+            return unifyTypes(OrderedSet(types), typeNames, typeBuilder, true, true);
         }
 
         if (schema.$ref !== undefined) {
@@ -284,7 +284,7 @@ export function schemaToType(typeBuilder: TypeGraphBuilder, topLevelName: string
                 return fromTypeName(schema, path, typeNames, defined(jsonTypes.first()));
             } else {
                 const types = jsonTypes.map(n => fromTypeName(schema, path, typeNames, n).deref()[0]);
-                return unifyTypes(types, typeNames, typeBuilder, true);
+                return unifyTypes(types, typeNames, typeBuilder, true, true);
             }
         } else if (schema.oneOf !== undefined) {
             return convertOneOrAnyOf(schema.oneOf, PathElementKind.OneOf);

--- a/src/Type.ts
+++ b/src/Type.ts
@@ -299,7 +299,7 @@ export class ClassType extends Type {
     map(builder: TypeReconstituter, f: (tref: TypeRef) => TypeRef): TypeRef {
         const properties = this.getPropertyRefs().map(f);
         if (this.isFixed) {
-            return builder.getUniqueClassType(properties);
+            return builder.getUniqueClassType(true, properties);
         } else {
             return builder.getClassType(properties);
         }

--- a/src/TypeBuilder.ts
+++ b/src/TypeBuilder.ts
@@ -303,10 +303,11 @@ export abstract class TypeBuilder {
     // via a flag?  That would make `ClassType.map` simpler.
     getUniqueClassType = (
         names: TypeNames,
+        isFixed: boolean,
         properties?: OrderedMap<string, TypeRef>,
         forwardingRef?: TypeRef
     ): TypeRef => {
-        return this.addType(forwardingRef, tref => new ClassType(tref, true, properties), names);
+        return this.addType(forwardingRef, tref => new ClassType(tref, isFixed, properties), names);
     };
 
     getUnionType(names: TypeNames, members: OrderedSet<TypeRef>, forwardingRef?: TypeRef): TypeRef {
@@ -415,8 +416,8 @@ export class TypeReconstituter {
         return this.useBuilder().getClassType(defined(this._typeNames), properties, this._forwardingRef);
     };
 
-    getUniqueClassType = (properties?: OrderedMap<string, TypeRef>): TypeRef => {
-        return this.useBuilder().getUniqueClassType(defined(this._typeNames), properties, this._forwardingRef);
+    getUniqueClassType = (isFixed: boolean, properties?: OrderedMap<string, TypeRef>): TypeRef => {
+        return this.useBuilder().getUniqueClassType(defined(this._typeNames), isFixed, properties, this._forwardingRef);
     };
 
     getUnionType = (members: OrderedSet<TypeRef>): TypeRef => {

--- a/src/UnifyClasses.ts
+++ b/src/UnifyClasses.ts
@@ -43,6 +43,7 @@ class UnifyUnionBuilder extends UnionBuilder<TypeBuilder & TypeLookerUp, TypeRef
         typeBuilder: TypeBuilder & TypeLookerUp,
         typeNames: TypeNames,
         private readonly _makeEnums: boolean,
+        private readonly _makeClassesFixed: boolean,
         private readonly _unifyTypes: (typesToUnify: TypeRef[], typeNames: TypeNames) => TypeRef
     ) {
         super(typeBuilder, typeNames);
@@ -84,7 +85,7 @@ class UnifyUnionBuilder extends UnionBuilder<TypeBuilder & TypeLookerUp, TypeRef
             }
             return tref;
         });
-        return this.typeBuilder.getUniqueClassType(this.typeNames, properties);
+        return this.typeBuilder.getUniqueClassType(this.typeNames, this._makeClassesFixed, properties);
     }
 
     protected makeArray(arrays: TypeRef[]): TypeRef {
@@ -96,7 +97,8 @@ export function unifyTypes(
     types: Set<Type>,
     typeNames: TypeNames,
     typeBuilder: TypeBuilder & TypeLookerUp,
-    makeEnums: boolean
+    makeEnums: boolean,
+    makeClassesFixed: boolean
 ): TypeRef {
     if (types.isEmpty()) {
         return panic("Cannot unify empty set of types");
@@ -109,8 +111,8 @@ export function unifyTypes(
         return maybeTypeRef;
     }
 
-    const unionBuilder = new UnifyUnionBuilder(typeBuilder, typeNames, makeEnums, (trefs, names) =>
-        unifyTypes(Set(trefs.map(tref => tref.deref()[0])), names, typeBuilder, makeEnums)
+    const unionBuilder = new UnifyUnionBuilder(typeBuilder, typeNames, makeEnums, makeClassesFixed, (trefs, names) =>
+        unifyTypes(Set(trefs.map(tref => tref.deref()[0])), names, typeBuilder, makeEnums, makeClassesFixed)
     );
 
     const addType = (t: Type): void => {


### PR DESCRIPTION
Having them fixed prevents conversion to maps.