### PR TITLE
TypeRef.index has side-effects, so it can't be a getter

### DIFF
--- a/src/Type.ts
+++ b/src/Type.ts
@@ -79,13 +79,13 @@ export abstract class Type {
 
         while (workList.length > 0) {
             let [a, b] = defined(workList.pop());
-            if (a.typeRef.index > b.typeRef.index) {
+            if (a.typeRef.getIndex() > b.typeRef.getIndex()) {
                 [a, b] = [b, a];
             }
 
             if (!a.isPrimitive()) {
-                let ai = a.typeRef.index;
-                let bi = b.typeRef.index;
+                let ai = a.typeRef.getIndex();
+                let bi = b.typeRef.getIndex();
 
                 let found = false;
                 for (const [dai, dbi] of done) {


### PR DESCRIPTION
The debugger will invoke getters at will.