### PR TITLE
Separate namespace for forbidden words. Fixes #420

### DIFF
--- a/src/ConvenienceRenderer.ts
+++ b/src/ConvenienceRenderer.ts
@@ -22,6 +22,7 @@ import { trimEnd } from "lodash";
 import { declarationsForGraph, DeclarationIR, cycleBreakerTypesForGraph, Declaration } from "./DeclarationIR";
 
 export abstract class ConvenienceRenderer extends Renderer {
+    protected forbiddenWordsNamespace: Namespace;
     protected globalNamespace: Namespace;
     private _topLevelNames: Map<string, Name>;
     private _namesForNamedTypes: Map<Type, Name>;
@@ -96,7 +97,8 @@ export abstract class ConvenienceRenderer extends Renderer {
     }
 
     protected setUpNaming(): Namespace[] {
-        this.globalNamespace = keywordNamespace("global", this.forbiddenNamesForGlobalNamespace);
+        this.forbiddenWordsNamespace = keywordNamespace("forbidden", this.forbiddenNamesForGlobalNamespace);
+        this.globalNamespace = new Namespace("global", undefined, Set([this.forbiddenWordsNamespace]), Set());
         const { classes, enums, unions } = this.typeGraph.allNamedTypesSeparated();
         const namedUnions = unions.filter((u: UnionType) => this.unionNeedsName(u)).toOrderedSet();
         this._namesForNamedTypes = Map();
@@ -116,7 +118,7 @@ export abstract class ConvenienceRenderer extends Renderer {
             const name = this.addNamedForNamedType(u);
             this.addUnionMemberNames(u, name);
         });
-        return [this.globalNamespace];
+        return [this.forbiddenWordsNamespace, this.globalNamespace];
     }
 
     private addDependenciesForNamedType = (type: Type, named: Name): void => {

--- a/src/Language/CPlusPlus.ts
+++ b/src/Language/CPlusPlus.ts
@@ -271,11 +271,11 @@ class CPlusPlusRenderer extends ConvenienceRenderer {
         _c: ClassType,
         _classNamed: Name
     ): { names: Name[]; namespaces: Namespace[] } {
-        return { names: [], namespaces: [this.globalNamespace] };
+        return { names: [], namespaces: [this.forbiddenWordsNamespace] };
     }
 
     protected forbiddenForEnumCases(_e: EnumType, _enumNamed: Name): { names: Name[]; namespaces: Namespace[] } {
-        return { names: [], namespaces: [this.globalNamespace] };
+        return { names: [], namespaces: [this.forbiddenWordsNamespace] };
     }
 
     protected topLevelNameStyle(rawName: string): string {

--- a/src/Language/Elm.ts
+++ b/src/Language/Elm.ts
@@ -204,7 +204,7 @@ class ElmRenderer extends ConvenienceRenderer {
         _c: ClassType,
         _classNamed: Name
     ): { names: Name[]; namespaces: Namespace[] } {
-        return { names: [], namespaces: [this.globalNamespace] };
+        return { names: [], namespaces: [this.forbiddenWordsNamespace] };
     }
 
     protected get unionMemberNamer(): Namer {

--- a/src/Language/Java.ts
+++ b/src/Language/Java.ts
@@ -186,7 +186,7 @@ class JavaRenderer extends ConvenienceRenderer {
         _c: ClassType,
         _classNamed: Name
     ): { names: Name[]; namespaces: Namespace[] } {
-        return { names: [], namespaces: [this.globalNamespace] };
+        return { names: [], namespaces: [this.forbiddenWordsNamespace] };
     }
 
     protected topLevelNameStyle(rawName: string): string {

--- a/src/Language/Swift.ts
+++ b/src/Language/Swift.ts
@@ -234,11 +234,11 @@ class SwiftRenderer extends ConvenienceRenderer {
         _c: ClassType,
         _classNamed: Name
     ): { names: Name[]; namespaces: Namespace[] } {
-        return { names: [], namespaces: [this.globalNamespace, this._propertyForbiddenNamespace] };
+        return { names: [], namespaces: [this.forbiddenWordsNamespace, this._propertyForbiddenNamespace] };
     }
 
     protected forbiddenForEnumCases(_e: EnumType, _enumNamed: Name): { names: Name[]; namespaces: Namespace[] } {
-        return { names: [], namespaces: [this.globalNamespace] };
+        return { names: [], namespaces: [this.forbiddenWordsNamespace] };
     }
 
     protected topLevelNameStyle(rawName: string): string {


### PR DESCRIPTION
With forbidden words as well as named types and functions in the global namespace, there was no way to make property names that could be the same as global names but still rename them if they clash with forbidden names.  Now we keep forbidden names and global names in separate namespaces.