### PR TITLE
Objective-C small changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quicktype",
-  "version": "8.4.0",
+  "version": "8.5.0",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/Language/Objective-C.ts
+++ b/src/Language/Objective-C.ts
@@ -1079,10 +1079,10 @@ class ObjectiveCRenderer extends ConvenienceRenderer {
         if (this.needsMap) {
             this.emitMultiline(`static id map(id collection, id (^f)(id value)) {
     id result = nil;
-    if ([collection isKindOfClass:[NSArray class]]) {
+    if ([collection isKindOfClass:NSArray.class]) {
         result = [NSMutableArray arrayWithCapacity:[collection count]];
         for (id x in collection) [result addObject:f(x)];
-    } else if ([collection isKindOfClass:[NSDictionary class]]) {
+    } else if ([collection isKindOfClass:NSDictionary.class]) {
         result = [NSMutableDictionary dictionaryWithCapacity:[collection count]];
         for (id key in collection) [result setObject:f([collection objectForKey:key]) forKey:key];
     }

--- a/src/Language/Objective-C.ts
+++ b/src/Language/Objective-C.ts
@@ -660,6 +660,7 @@ class ObjectiveCRenderer extends ConvenienceRenderer {
 
     private emitClassInterface = (t: ClassType, className: Name): void => {
         const isTopLevel = this.topLevels.valueSeq().contains(t);
+        const propertyTable: Sourcelike[][] = [];
 
         this.emitLine("@interface ", className, " : NSObject");
         if (DEBUG) this.emitLine("@property NSDictionary<NSString *, id> *_json;");
@@ -671,15 +672,12 @@ class ObjectiveCRenderer extends ConvenienceRenderer {
                 attributes.push("nullable");
             }
             attributes.push(this.memoryAttribute(property.type, property.type.isNullable));
-            this.emitLine(
-                "@property ",
-                ["(", attributes.join(", "), ")"],
-                " ",
-                this.pointerAwareTypeName(property.type),
-                name,
-                ";"
-            );
+            propertyTable.push([
+                ["@property ", ["(", attributes.join(", "), ")"], " "],
+                [this.pointerAwareTypeName(property.type), name, ";"]
+            ]);
         });
+        this.emitTable(propertyTable);
 
         if (!this._justTypes && isTopLevel) {
             if (t.properties.count() > 0) this.ensureBlankLine();

--- a/src/Language/Objective-C.ts
+++ b/src/Language/Objective-C.ts
@@ -94,6 +94,12 @@ function typeNameStyle(prefix: string, original: string): string {
 }
 
 function propertyNameStyle(original: string, isBool: boolean = false): string {
+    // Objective-C developers are uncomfortable with property "id"
+    // so we use an alternate name in this special case.
+    if (original === "id") {
+        original = "identifier";
+    }
+
     let words = splitIntoWords(original);
 
     if (isBool) {
@@ -174,6 +180,7 @@ const keywords = [
 ];
 
 const forbiddenPropertyNames = [
+    "id",
     "hash",
     "description",
     "init",

--- a/src/Language/Objective-C.ts
+++ b/src/Language/Objective-C.ts
@@ -1009,9 +1009,7 @@ class ObjectiveCRenderer extends ConvenienceRenderer {
                 this.ensureBlankLine();
                 this.emitExtraComments("Shorthand for simple blocks");
                 this.emitLine(`#define λ(decl, expr) (^(decl) { return (expr); })`);
-                if (this._extraComments) {
-                    this.ensureBlankLine();
-                }
+                this.ensureBlankLine();
                 this.emitExtraComments("nil → NSNull conversion for JSON dictionaries");
                 this.emitBlock("static id NSNullify(id _Nullable x)", () =>
                     this.emitLine("return (x == nil || x == NSNull.null) ? NSNull.null : x;")

--- a/src/Language/Objective-C.ts
+++ b/src/Language/Objective-C.ts
@@ -1013,7 +1013,9 @@ class ObjectiveCRenderer extends ConvenienceRenderer {
                     this.ensureBlankLine();
                 }
                 this.emitExtraComments("nil → NSNull conversion for JSON dictionaries");
-                this.emitLine("#define NSNullify(x) ([x isNotEqualTo:[NSNull null]] ? x : [NSNull null])");
+                this.emitBlock("static id NSNullify(id _Nullable x)", () =>
+                    this.emitLine("return (x == nil || x == NSNull.null) ? NSNull.null : x;")
+                );
                 this.ensureBlankLine();
                 this.emitLine("NS_ASSUME_NONNULL_BEGIN");
                 this.ensureBlankLine();


### PR DESCRIPTION
* Don't allow 'id' as a property name
* `NSNullable` as function (Avoids re-evaluating parameter and works on iOS)
* Properties as tidy table with types aligned