### PR TITLE
Don't forbid type names for properties in C#

### DIFF
--- a/src/Language/CSharp.ts
+++ b/src/Language/CSharp.ts
@@ -347,7 +347,7 @@ class CSharpRenderer extends ConvenienceRenderer {
             // FIXME: Make FromJson a Named
             this.emitExpressionMember(
                 ["public static ", csType, " FromJson(string json)"],
-                ["JsonConvert.DeserializeObject<", csType, ">(json, Converter.Settings)"]
+                ["JsonConvert.DeserializeObject<", csType, ">(json, ", this._namespaceName, ".Converter.Settings)"]
             );
         });
     };
@@ -511,7 +511,7 @@ class CSharpRenderer extends ConvenienceRenderer {
                 // FIXME: Make ToJson a Named
                 this.emitExpressionMember(
                     ["public static string ToJson(this ", this.csType(t), " self)"],
-                    "JsonConvert.SerializeObject(self, Converter.Settings)"
+                    ["JsonConvert.SerializeObject(self, ", this._namespaceName, ".Converter.Settings)"]
                 );
             });
         });

--- a/src/Language/CSharp.ts
+++ b/src/Language/CSharp.ts
@@ -159,7 +159,20 @@ class CSharpRenderer extends ConvenienceRenderer {
     }
 
     protected forbiddenForClassProperties(_: ClassType, classNamed: Name): ForbiddenWordsInfo {
-        return { names: [classNamed, "FromJson"], includeGlobalForbidden: true };
+        return {
+            names: [
+                classNamed,
+                "FromJson",
+                "ToString",
+                "GetHashCode",
+                "Finalize",
+                "Equals",
+                "GetType",
+                "MemberwiseClone",
+                "ReferenceEquals"
+            ],
+            includeGlobalForbidden: false
+        };
     }
 
     protected forbiddenForUnionMembers(_: UnionType, unionNamed: Name): ForbiddenWordsInfo {

--- a/src/Language/CSharp.ts
+++ b/src/Language/CSharp.ts
@@ -162,6 +162,7 @@ class CSharpRenderer extends ConvenienceRenderer {
         return {
             names: [
                 classNamed,
+                "ToJson",
                 "FromJson",
                 "ToString",
                 "GetHashCode",


### PR DESCRIPTION
Fixes #503