### PR TITLE
Dense option for Rust

### DIFF
--- a/test/languages.ts
+++ b/test/languages.ts
@@ -105,7 +105,7 @@ export const GoLanguage: Language = {
   skipMiscJSON: false,
   skipSchema: [],
   rendererOptions: {},
-  quickTestRendererOptions: []
+  quickTestRendererOptions: [{ density: "dense" }]
 };
 
 export const CPlusPlusLanguage: Language = {

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -83,7 +83,7 @@ export const RustLanguage: Language = {
   skipSchema: [],
   skipMiscJSON: true,
   rendererOptions: {},
-  quickTestRendererOptions: []
+  quickTestRendererOptions: [{ density: "dense" }]
 };
 
 export const GoLanguage: Language = {
@@ -105,7 +105,7 @@ export const GoLanguage: Language = {
   skipMiscJSON: false,
   skipSchema: [],
   rendererOptions: {},
-  quickTestRendererOptions: [{ density: "dense" }]
+  quickTestRendererOptions: []
 };
 
 export const CPlusPlusLanguage: Language = {


### PR DESCRIPTION
For `pokedex.json`:

```rust
extern crate serde_json;

#[derive(Serialize, Deserialize)]
pub struct Pokedex {
    pokemon: Vec<Pokemon>,
}

#[derive(Serialize, Deserialize)]
pub struct Pokemon {
    id: i64,
    num: String,
    name: String,
    img: String,
    #[serde(rename = "type")]
    purple_type: Vec<String>,
    height: String,
    weight: String,
    candy: String,
    candy_count: Option<i64>,
    egg: Egg,
    spawn_chance: f64,
    avg_spawns: f64,
    spawn_time: String,
    multipliers: Option<Vec<f64>>,
    weaknesses: Vec<Weakness>,
    next_evolution: Option<Vec<Evolution>>,
    prev_evolution: Option<Vec<Evolution>>,
}

#[derive(Serialize, Deserialize)]
pub struct Evolution {
    num: String,
    name: String,
}

#[derive(Serialize, Deserialize)]
pub enum Egg {
    #[serde(rename = "Not in Eggs")]
    NotInEggs,
    #[serde(rename = "Omanyte Candy")]
    OmanyteCandy,
    #[serde(rename = "10 km")]
    The10Km,
    #[serde(rename = "2 km")]
    The2Km,
    #[serde(rename = "5 km")]
    The5Km,
}

#[derive(Serialize, Deserialize)]
pub enum Weakness {
    Bug,
    Dark,
    Dragon,
    Electric,
    Fairy,
    Fighting,
    Fire,
    Flying,
    Ghost,
    Grass,
    Ground,
    Ice,
    Poison,
    Psychic,
    Rock,
    Steel,
    Water,
}
```

See #516