### PR TITLE
json-schema: Don't error on unsupported string formats.

### DIFF
--- a/src/JSONSchemaInput.ts
+++ b/src/JSONSchemaInput.ts
@@ -287,7 +287,9 @@ export function addTypesInSchema(
                         case "date-time":
                             return typeBuilder.getPrimitiveType("date-time");
                         default:
-                            return panic(`String format ${schema.format} not supported`);
+                            // FIXME: Output a warning here instead to indicate that
+                            // the format is uninterpreted.
+                            return typeBuilder.getStringType(typeAttributes, undefined);
                     }
                 }
                 return typeBuilder.getStringType(typeAttributes, undefined);


### PR DESCRIPTION
The string format can be anything and there's no need to fail if
the format isn't recognized / interpreted.