### PR TITLE
Include postman item names and request urls in descriptions

### DIFF
--- a/src/PostmanCollection.ts
+++ b/src/PostmanCollection.ts
@@ -1,7 +1,6 @@
 "use strict";
 
 import { JSONTypeSource } from ".";
-import { isObject } from "lodash";
 
 function isValidJSON(s: string): boolean {
     try {
@@ -39,9 +38,9 @@ export function sourcesFromPostmanCollection(
                 const source: JSONTypeSource = { name: c.name, samples };
                 const sourceDescription = [c.name];
 
-                if (isObject(c.request)) {
+                if (typeof c.request === "object") {
                     const { method, url } = c.request;
-                    if (method !== undefined && isObject(url) && url.raw !== undefined) {
+                    if (method !== undefined && typeof url === "object" && url.raw !== undefined) {
                         sourceDescription.push(`${method} ${url.raw}`);
                     }
                 }

--- a/src/PostmanCollection.ts
+++ b/src/PostmanCollection.ts
@@ -41,7 +41,7 @@ export function sourcesFromPostmanCollection(
 
                 if (isObject(c.request)) {
                     const { method, url } = c.request;
-                    if (method !== undefined && url.raw !== undefined) {
+                    if (method !== undefined && isObject(url) && url.raw !== undefined) {
                         sourceDescription.push(`${method} ${url.raw}`);
                     }
                 }

--- a/src/PostmanCollection.ts
+++ b/src/PostmanCollection.ts
@@ -1,6 +1,7 @@
 "use strict";
 
 import { JSONTypeSource } from ".";
+import { isObject } from "lodash";
 
 function isValidJSON(s: string): boolean {
     try {
@@ -36,9 +37,20 @@ export function sourcesFromPostmanCollection(
             }
             if (samples.length > 0) {
                 const source: JSONTypeSource = { name: c.name, samples };
-                if (typeof c.request === "object" && typeof c.request.description === "string") {
-                    source.description = c.request.description;
+                const sourceDescription = [c.name];
+
+                if (isObject(c.request)) {
+                    const { method, url } = c.request;
+                    if (method !== undefined && url.raw !== undefined) {
+                        sourceDescription.push(`${method} ${url.raw}`);
+                    }
                 }
+
+                if (typeof c.request === "object" && typeof c.request.description === "string") {
+                    sourceDescription.push(c.request.description);
+                }
+
+                source.description = sourceDescription.length === 0 ? undefined : sourceDescription.join("\n\n");
                 sources.push(source);
             }
         }


### PR DESCRIPTION
For example:

```csharp
    /// <summary>
    /// Response Status Code
    /// 
    /// GET https://postman-echo.com/status/200
    /// 
    /// This endpoint allows one to instruct the server which status code to respond with.
    /// 
    /// Every response is accompanied by a status code. The status code provides a summary of the
    /// nature of response sent by the server. For example, a status code of `200` means
    /// everything is okay with the response and a code of `404` implies that the requested URL
    /// does not exist on server.
    /// A list of all valid HTTP status code can be found at the [List of Status
    /// Codes](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes) wikipedia article. When
    /// using Postman, the response status code is described for easy reference.
    /// 
    /// Note that if an invalid status code is requested to be sent, the server returns a status
    /// code of `400 Bad Request`.
    /// </summary>
    public partial class ResponseStatusCode
    {
        [JsonProperty("status")]
        public long Status { get; set; }
    }
```