### PR TITLE
Make top-levels from inferred JSON fixed

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -185,14 +185,17 @@ export class Run {
 
         // JSON
         const doInferEnums = this._options.inferEnums;
-        if (Object.keys(this._allInputs.samples).length > 0) {
+        const numSamples = Object.keys(this._allInputs.samples).length;
+        if (numSamples > 0) {
             const inference = new TypeInference(typeBuilder, doInferEnums, this._options.inferDates);
+            const fixedTopLevels = numSamples > 1;
 
             Map(this._allInputs.samples).forEach(({ samples, description }, name) => {
                 const tref = inference.inferType(
                     this._compressedJSON as CompressedJSON,
                     makeNamesTypeAttributes(name, false),
-                    samples
+                    samples,
+                    fixedTopLevels
                 );
                 typeBuilder.addTopLevel(name, tref);
                 if (description !== undefined) {


### PR DESCRIPTION
So we don't combine top-levels with each other.