### PR TITLE
Fix unions as properties in Go

### DIFF
--- a/src/Language/Golang.ts
+++ b/src/Language/Golang.ts
@@ -157,6 +157,14 @@ class GoRenderer extends ConvenienceRenderer {
         }
     };
 
+    private propertyGoType(t: Type): Sourcelike {
+        const goType = this.goType(t, true);
+        if (t instanceof UnionType && nullableFromUnion(t) === null) {
+            return ["*", goType];
+        }
+        return goType;
+    }
+
     private goType = (t: Type, withIssues: boolean = false): Sourcelike => {
         return matchType<Sourcelike>(
             t,
@@ -210,7 +218,7 @@ class GoRenderer extends ConvenienceRenderer {
     private emitClass = (c: ClassType, className: Name): void => {
         let columns: Sourcelike[][] = [];
         this.forEachClassProperty(c, "none", (name, jsonName, p) => {
-            const goType = this.goType(p.type, true);
+            const goType = this.propertyGoType(p.type);
             const comment = singleDescriptionComment(this.descriptionForClassProperty(c, jsonName));
             columns.push([[name, " "], [goType, " "], ['`json:"', stringEscape(jsonName), '"`'], comment]);
         });

--- a/test/inputs/schema/direct-union.1.json
+++ b/test/inputs/schema/direct-union.1.json
@@ -1,0 +1,21 @@
+{
+    "stuff": {
+        "one": {
+            "required": null
+        },
+        "two": {
+            "required": "abc",
+            "optional": null
+        },
+        "three": {
+            "required": {
+                "foo": 123
+            },
+            "optional": [
+                1,
+                2,
+                3
+            ]
+        }
+    }
+}

--- a/test/inputs/schema/direct-union.schema
+++ b/test/inputs/schema/direct-union.schema
@@ -1,0 +1,43 @@
+{
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "stuff": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/thing"
+            }
+        }
+    },
+    "required": [
+        "stuff"
+    ],
+    "definitions": {
+        "thing": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "required": {
+                    "$ref": "#/definitions/anything"
+                },
+                "optional": {
+                    "$ref": "#/definitions/anything"
+                }
+            },
+            "required": [
+                "required"
+            ]
+        },
+        "anything": {
+            "type": [
+                "string",
+                "number",
+                "integer",
+                "boolean",
+                "object",
+                "array",
+                "null"
+            ]
+        }
+    }
+}


### PR DESCRIPTION
In the case where you had a class type with a union property, and that
class type was the value type of a map, the union wouldn't use the
custom unmarshaller, because of complicated Go stuff:
https://github.com/golang/go/issues/23263#issuecomment-354197562