### PR TITLE
Generate Alamofire response handlers for top-levels

### DIFF
--- a/src/Language/Swift.ts
+++ b/src/Language/Swift.ts
@@ -52,7 +52,7 @@ export default class SwiftTargetLanguage extends TargetLanguage {
         true
     );
 
-    private readonly _alamofireHandlers = new BooleanOption("alamofire", "Generate Alamofire response handlers", true);
+    private readonly _alamofireHandlers = new BooleanOption("alamofire", "Generate Alamofire response handlers", false);
 
     private readonly _classOption = new EnumOption("struct-or-class", "Generate structs or classes", [
         ["struct", false],


### PR DESCRIPTION
Help Alamofire users read top-level types from responses:

```swift
Alamofire.request("https://...pokedex.json").responsePokedex { response in
    if let pokedex = response.result.value {
        // We have a pokedex: Pokedex
    }
}
```