### PR TITLE
Add visibility option on Rust fields

### DIFF
--- a/test/languages.ts
+++ b/test/languages.ts
@@ -89,7 +89,12 @@ export const RustLanguage: Language = {
   skipSchema: [],
   skipMiscJSON: false,
   rendererOptions: {},
-  quickTestRendererOptions: [{ density: "dense" }],
+  quickTestRendererOptions: [
+    { density: "dense" },
+    { visibility: "crate" },
+    { visibility: "private" },
+    { visibility: "public" }
+  ],
   sourceFiles: ["src/Language/Rust.ts"]
 };
 


### PR DESCRIPTION
#655 

This adds an option to control visibility modifiers on generated struct fields in Rust.

I don't know if I need to edit anything elsewhere or if this is good, but it appears to work from my tests!