### PR TITLE
Remove whitespace at end of blank doc comment lines.

### DIFF
--- a/src/ConvenienceRenderer.ts
+++ b/src/ConvenienceRenderer.ts
@@ -654,7 +654,7 @@ export abstract class ConvenienceRenderer extends Renderer {
     };
 
     protected get commentLineStart(): string {
-        return "// ";
+        return "//";
     }
 
     protected emitCommentLines(
@@ -675,7 +675,12 @@ export abstract class ConvenienceRenderer extends Renderer {
         }
         let first = true;
         for (const line of lines) {
-            this.emitLine(first ? firstLineStart : lineStart, trimEnd(line));
+            const c = trimEnd(line);
+            if (c) {
+                this.emitLine(first ? firstLineStart : lineStart, ' ', c));
+            } else {
+                this.emitLine(first ? firstLineStart : lineStart);
+            }
             first = false;
         }
         if (afterLine !== undefined) {

--- a/src/Language/Elm.ts
+++ b/src/Language/Elm.ts
@@ -229,7 +229,7 @@ class ElmRenderer extends ConvenienceRenderer {
     }
 
     protected get commentLineStart(): string {
-        return "-- ";
+        return "--";
     }
 
     protected emitDescriptionBlock(lines: string[]): void {

--- a/src/Language/Ruby/index.ts
+++ b/src/Language/Ruby/index.ts
@@ -133,7 +133,7 @@ class RubyRenderer extends ConvenienceRenderer {
     }
 
     protected get commentLineStart(): string {
-        return "# ";
+        return "#";
     }
 
     protected get needsTypeDeclarationBeforeUse(): boolean {

--- a/src/Language/Rust.ts
+++ b/src/Language/Rust.ts
@@ -225,7 +225,7 @@ class RustRenderer extends ConvenienceRenderer {
     }
 
     protected get commentLineStart(): string {
-        return "/// ";
+        return "///";
     }
 
     private nullableRustType = (t: Type, withIssues: boolean): Sourcelike => {


### PR DESCRIPTION
Since `commentLineStart` had a space at the end of it, if the
line in the comment was blank, there would be a space at the end
of that blank line.

In Rust, this resulted in a bunch of lines modified by `rustfmt`,
so it would be nicer to just not generate that extra bit of
whitespace.