### PR TITLE
Remove whitespace at end of blank doc comment lines.

### DIFF
--- a/src/ConvenienceRenderer.ts
+++ b/src/ConvenienceRenderer.ts
@@ -675,7 +675,11 @@ export abstract class ConvenienceRenderer extends Renderer {
         }
         let first = true;
         for (const line of lines) {
-            this.emitLine(first ? firstLineStart : lineStart, trimEnd(line));
+            let start = first ? firstLineStart : lineStart;
+            if (line === "") {
+                start = trimEnd(start);
+            }
+            this.emitLine(start, trimEnd(line));
             first = false;
         }
         if (afterLine !== undefined) {


### PR DESCRIPTION
Since `commentLineStart` had a space at the end of it, if the
line in the comment was blank, there would be a space at the end
of that blank line.

In Rust, this resulted in a bunch of lines modified by `rustfmt`,
so it would be nicer to just not generate that extra bit of
whitespace.