### PR TITLE
Convenience initializers disabled by default in when outputting Swift

### DIFF
--- a/src/Language/Swift.ts
+++ b/src/Language/Swift.ts
@@ -49,7 +49,7 @@ export default class SwiftTargetLanguage extends TargetLanguage {
     private readonly _convenienceInitializers = new BooleanOption(
         "initializers",
         "Convenience initializers",
-        true
+        false
     );
 
     private readonly _alamofireHandlers = new BooleanOption("alamofire", "Alamofire extensions", false);


### PR DESCRIPTION
Convenience initializers are no longer enabled by default, you have to pass `--initializers` when outputting Swift.

This confused, me and I could not find any documentation on how to disable the convenience initializers.

This changes default behaviour so adding a `--no-initializers` option might be a better resolution. 