### PR TITLE
CLI Telemetry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ test/fixtures/objective-c/quicktype
 *.xcbkptlist
 *.xcuserstate
 /bin
+/.node-persist

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,7 +13,7 @@
       "args": [
         "--project",
         "src/tsconfig.json",
-        "src/cli.ts",
+        "src/cli/index.ts",
         "--lang",
         "ts",
         "--src-lang",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,10 @@
 {
   // Place your settings in this file to overwrite default and user settings.
   "editor.formatOnSave": true,
-  "spellright.ignoreFiles": ["**/.gitignore", "**/.spellignore"],
+  "spellright.ignoreFiles": [
+    "**/.gitignore",
+    "**/.spellignore"
+  ],
   "search.exclude": {
     "**/.git": true,
     "**/node_modules": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,16 @@
       "integrity": "sha512-jRHfWsvyMtXdbhnz5CVHxaBgnV6duZnPlQuRSo/dm/GnmikNcmZhxIES4E9OZjUmQ8C+HCl4KJux+cXN/ErGDQ==",
       "dev": true
     },
+    "@types/node-persist": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@types/node-persist/-/node-persist-0.0.33.tgz",
+      "integrity": "sha512-JY/aQpndK6Nb/9ccfAaptSgzUpZp2VXillSXNrD40CURfFACWTMyGnFYzz4L44iKu7CTIg6hqjRZbBCr60URdw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "8.9.5",
+        "@types/q": "0.0.37"
+      }
+    },
     "@types/pako": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/pako/-/pako-1.0.0.tgz",
@@ -75,6 +85,12 @@
       "integrity": "sha512-WR/XtQMjTx4phclpWhfuoFURYPOwiBZD89gCCTG6RETzE70AZPAGGJ0h/t+a/E27MCVf1s2Z+wvH1pVTyckIcA==",
       "dev": true
     },
+    "@types/q": {
+      "version": "0.0.37",
+      "resolved": "https://registry.npmjs.org/@types/q/-/q-0.0.37.tgz",
+      "integrity": "sha512-vjFGX1zMTMz/kUp3xgfJcxMVLkMWVMrdlyc0RwVyve1y9jxwqNaT8wTcv6M51ylq2a/zn5lm8g7qPSoIS4uvZQ==",
+      "dev": true
+    },
     "@types/shelljs": {
       "version": "0.7.8",
       "resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.7.8.tgz",
@@ -84,6 +100,12 @@
         "@types/glob": "5.0.35",
         "@types/node": "8.9.5"
       }
+    },
+    "@types/universal-analytics": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@types/universal-analytics/-/universal-analytics-0.4.2.tgz",
+      "integrity": "sha512-ndv0aYA5tNPdl4KYUperlswuiSj49+o7Pwx8hrCiE9x2oeiMrn7A2jXFDdTLFIymiYZImDX02ycq0i6uQ3TL0A==",
+      "dev": true
     },
     "@types/urijs": {
       "version": "github:quicktype/types-urijs#a23603a04e31e883a92244bff8515e3d841a8b98",
@@ -1128,6 +1150,15 @@
       "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
       "dev": true
     },
+    "is-absolute": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.6.tgz",
+      "integrity": "sha1-IN5p89uULvLYe5wto28XIjWxtes=",
+      "requires": {
+        "is-relative": "0.2.1",
+        "is-windows": "0.2.0"
+      }
+    },
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
@@ -1158,6 +1189,14 @@
       "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
       "dev": true
     },
+    "is-relative": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz",
+      "integrity": "sha1-0n9MfVFtF1+2ENuEu+7yPDvJeqU=",
+      "requires": {
+        "is-unc-path": "0.1.2"
+      }
+    },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
@@ -1168,10 +1207,23 @@
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
+    "is-unc-path": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.2.tgz",
+      "integrity": "sha1-arBTpyVzwQJQ/0FqOBTDUXivObk=",
+      "requires": {
+        "unc-path-regex": "0.1.2"
+      }
+    },
     "is-url": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.2.tgz",
       "integrity": "sha1-SYkFpZO/R8wtnn9zg3K792lsfyY="
+    },
+    "is-windows": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
+      "integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw="
     },
     "isarray": {
       "version": "1.0.0",
@@ -1419,6 +1471,16 @@
       "requires": {
         "encoding": "0.1.12",
         "is-stream": "1.1.0"
+      }
+    },
+    "node-persist": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/node-persist/-/node-persist-2.1.0.tgz",
+      "integrity": "sha1-5lK784haBNrWo1PXQXYXfIORRwc=",
+      "requires": {
+        "is-absolute": "0.2.6",
+        "mkdirp": "0.5.1",
+        "q": "1.1.2"
       }
     },
     "oauth-sign": {
@@ -1670,6 +1732,11 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+    },
+    "q": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.1.2.tgz",
+      "integrity": "sha1-Y1fikSBnAdmfGXq4TlforRlvKok="
     },
     "qs": {
       "version": "6.4.0",
@@ -2219,6 +2286,11 @@
       "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
       "integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I="
     },
+    "unc-path-regex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
+      "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo="
+    },
     "unicode-properties": {
       "version": "github:quicktype/unicode-properties#d5fddfea1ef9d05c6479a979e225476063e13f52",
       "requires": {
@@ -2250,6 +2322,15 @@
         "mkdirp": "0.5.1",
         "os-tmpdir": "1.0.2",
         "uid2": "0.0.3"
+      }
+    },
+    "universal-analytics": {
+      "version": "0.4.16",
+      "resolved": "https://registry.npmjs.org/universal-analytics/-/universal-analytics-0.4.16.tgz",
+      "integrity": "sha512-I9vK/S6NI2rbPs4UMJs5uAJR7WKUnSQliN0EEl48j7XpVjR87n2wEXp1pMBGGSI5sIIJrKFyVg/nyGomXPPVCg==",
+      "requires": {
+        "request": "2.81.0",
+        "uuid": "3.2.1"
       }
     },
     "universalify": {

--- a/package.json
+++ b/package.json
@@ -26,13 +26,16 @@
     "lodash": "^4.17.4",
     "moment": "^2.19.3",
     "node-fetch": "^1.7.1",
+    "node-persist": "^2.1.0",
     "pako": "^1.0.6",
     "pkg": "^4.3.0",
     "pluralize": "^7.0.0",
     "stream-json": "0.5.2",
     "string-to-stream": "^1.1.0",
     "unicode-properties": "quicktype/unicode-properties#dist",
-    "urijs": "^1.19.1"
+    "universal-analytics": "^0.4.16",
+    "urijs": "^1.19.1",
+    "uuid": "^3.2.1"
   },
   "devDependencies": {
     "@types/graphql": "^0.11.7",
@@ -41,9 +44,11 @@
     "@types/js-base64": "^2.3.1",
     "@types/lodash": "^4.14.72",
     "@types/node": "^8.0.19",
+    "@types/node-persist": "0.0.33",
     "@types/pako": "^1.0.0",
     "@types/pluralize": "0.0.28",
     "@types/shelljs": "^0.7.8",
+    "@types/universal-analytics": "^0.4.2",
     "@types/urijs": "github:quicktype/types-urijs",
     "ajv": "^5.2.2",
     "compare-versions": "^3.1.0",
@@ -60,6 +65,8 @@
     "uglify-js": "^3.0.26",
     "watch": "^1.0.2"
   },
-  "files": ["dist/**"],
-  "bin": "dist/cli.js"
+  "files": [
+    "dist/**"
+  ],
+  "bin": "dist/cli/index.js"
 }

--- a/script/build.ts
+++ b/script/build.ts
@@ -26,7 +26,7 @@ function buildTypeScript() {
 
 function makeDistributedCLIExecutable() {
   const prefix = "#!/usr/bin/env node\n";
-  const cli = path.join(OUTDIR, "cli.js");
+  const cli = path.join(OUTDIR, "cli/index.js");
   mapFile(cli, cli, content => {
     if (content.substr(0, prefix.length) === prefix) {
       return content;

--- a/script/make-pkgs.sh
+++ b/script/make-pkgs.sh
@@ -5,6 +5,6 @@ npm install
 mkdir -p bin/macos
 mkdir -p bin/linux
 mkdir -p bin/windows
-pkg -t node8-macos-x64 -o bin/macos/quicktype dist/cli.js
-pkg -t node8-linux-x64 -o bin/linux/quicktype dist/cli.js
-pkg -t node8-win-x64 -o bin/windows/quicktype.exe dist/cli.js
+pkg -t node8-macos-x64 -o bin/macos/quicktype dist/cli/index.js
+pkg -t node8-linux-x64 -o bin/linux/quicktype dist/cli/index.js
+pkg -t node8-win-x64 -o bin/windows/quicktype.exe dist/cli/index.js

--- a/script/quicktype
+++ b/script/quicktype
@@ -13,4 +13,4 @@ BASEDIR="$SCRIPTDIR/.."
 if [ x"$SKIP_BUILD" = x ] ; then
     ( cd "$BASEDIR" ; npm run build &>/dev/null )
 fi
-node --stack_trace_limit=100 "$BASEDIR/dist/cli.js" "$@"
+node --stack_trace_limit=100 "$BASEDIR/dist/cli/index.js" "$@"

--- a/src/cli/NodeIO.ts
+++ b/src/cli/NodeIO.ts
@@ -2,10 +2,10 @@
 
 import * as fs from "fs";
 import { Readable } from "stream";
-import { getStream } from "./get-stream/index";
+import { getStream } from "../get-stream/index";
 
-import { JSONSchemaStore, JSONSchema } from "./JSONSchemaStore";
-import { panic } from "./Support";
+import { JSONSchemaStore, JSONSchema } from "../JSONSchemaStore";
+import { panic } from "../Support";
 
 // The typings for this module are screwy
 const isURL = require("is-url");

--- a/src/cli/analytics.ts
+++ b/src/cli/analytics.ts
@@ -1,0 +1,55 @@
+import * as ga from "universal-analytics";
+import * as storage from "./storage";
+
+const uuid = require("uuid/v4");
+
+const GoogleAnalyticsID = "UA-102732788-5";
+
+export interface Analytics {
+    pageview(page: string): void;
+    timing(category: string, variable: string, time: number): void;
+    event(category: string, action: string, label?: string, value?: string | number): void;
+}
+
+export class NoAnalytics implements Analytics {
+    pageview(_page: string): void {
+        // Pass
+    }
+
+    timing(_category: string, _variable: string, _time: number): void {
+        // Pass
+    }
+
+    event(_category: string, _action: string, _label?: string, _value?: string | number): void {
+        // Pass
+    }
+}
+
+export class GoogleAnalytics implements Analytics {
+    private readonly visitor: ga.Visitor;
+
+    constructor() {
+        const userId = storage.get("userId", uuid());
+        this.visitor = ga(GoogleAnalyticsID, userId);
+    }
+
+    pageview(page: string): void {
+        this.visitor.pageview(page).send();
+    }
+
+    timing(category: string, variable: string, time: number): void {
+        this.visitor.timing(category, variable, time).send();
+    }
+
+    event(category: string, action: string, label?: string, value?: string | number): void {
+        if (label !== undefined) {
+            if (value !== undefined) {
+                this.visitor.event(category, action, label, value).send();
+            } else {
+                this.visitor.event(category, action, label).send();
+            }
+        } else {
+            this.visitor.event(category, action).send();
+        }
+    }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -18,18 +18,19 @@ import {
     quicktypeMultiFile,
     SerializedRenderResult,
     TargetLanguage
-} from ".";
-import { OptionDefinition } from "./RendererOptions";
-import * as defaultTargetLanguages from "./Language/All";
-import { urlsFromURLGrammar } from "./URLGrammar";
-import { Annotation } from "./Source";
-import { IssueAnnotationData } from "./Annotation";
+} from "..";
+
+import { OptionDefinition } from "../RendererOptions";
+import * as defaultTargetLanguages from "../Language/All";
+import { urlsFromURLGrammar } from "../URLGrammar";
+import { Annotation } from "../Source";
+import { IssueAnnotationData } from "../Annotation";
 import { Readable } from "stream";
-import { panic, assert, defined, withDefault } from "./Support";
-import { introspectServer } from "./GraphQLIntrospection";
-import { getStream } from "./get-stream/index";
-import { train } from "./MarkovChain";
-import { sourcesFromPostmanCollection } from "./PostmanCollection";
+import { panic, assert, defined, withDefault } from "../Support";
+import { introspectServer } from "../GraphQLIntrospection";
+import { getStream } from "../get-stream/index";
+import { train } from "../MarkovChain";
+import { sourcesFromPostmanCollection } from "../PostmanCollection";
 import { readableFromFileOrURL, readFromFileOrURL, FetchingJSONSchemaStore } from "./NodeIO";
 
 const commandLineArgs = require("command-line-args");
@@ -568,7 +569,7 @@ async function typeSourceForURIs(name: string, uris: string[], options: CLIOptio
             return await sourceFromFileOrUrlArray(name, uris);
         case "schema":
             assert(uris.length === 1, `Must have exactly one schema for ${name}`);
-            return {name, uri: uris[0], topLevelRefs: topLevelRefsForOptions(options) };
+            return { name, uri: uris[0], topLevelRefs: topLevelRefsForOptions(options) };
         default:
             return panic(`typeSourceForURIs must not be called for source language ${options.srcLang}`);
     }

--- a/src/cli/storage.ts
+++ b/src/cli/storage.ts
@@ -1,0 +1,35 @@
+import * as path from "path";
+import { homedir } from "os";
+
+import * as persist from "node-persist";
+
+export async function init() {
+    try {
+        await persist.init({
+            dir: path.join(homedir(), ".quicktype")
+        });
+    } catch (error) {
+        console.error(`Could not initialize persistence`, error);
+    }
+}
+export function get<T>(name: string, def: T, onError?: T): T {
+    try {
+        let v = persist.getItemSync(name);
+        if (v === undefined) {
+            set(name, def);
+            v = def;
+        }
+        return v;
+    } catch (error) {
+        console.error(`Could not get ${name}`, error);
+        return onError !== undefined ? onError : def;
+    }
+}
+
+export function set<T>(name: string, val: T): void {
+    try {
+        persist.setItemSync(name, val);
+    } catch (error) {
+        console.error(`Could not set ${name}`, error);
+    }
+}

--- a/src/cli/telemetry.ts
+++ b/src/cli/telemetry.ts
@@ -1,0 +1,90 @@
+import * as storage from "./storage";
+import { NoAnalytics, Analytics, GoogleAnalytics } from "./analytics";
+
+const chalk = require("chalk");
+
+export type TelemetryState = "none" | "disabled" | "enabled";
+
+let analytics: Analytics = new NoAnalytics();
+
+export async function init() {
+    await storage.init();
+
+    if (state() === "enabled") {
+        analytics = new GoogleAnalytics();
+    }
+}
+
+export function pageview(page: string): void {
+    analytics.pageview(page);
+}
+
+export function timing(category: string, variable: string, time: number): void {
+    analytics.timing(category, variable, time);
+}
+
+export function event(category: string, action: string, label?: string, value?: string | number): void {
+    analytics.event(category, action, label, value);
+}
+
+export function enable(): void {
+    if (state() !== "enabled") {
+        console.error(chalk.green("Thank you for enabling telemetry. It helps us make quicktype even better!"));
+    }
+
+    setState("enabled");
+    analytics = new GoogleAnalytics();
+}
+
+export function disable(): void {
+    if (state() !== "disabled") {
+        console.error("Telemetry disabled. To support quicktype in other ways, please share it.");
+    }
+
+    setState("disabled");
+    analytics = new NoAnalytics();
+}
+
+export function state(): TelemetryState {
+    return storage.get<TelemetryState>("analyticsState", "none", "disabled");
+}
+
+export function setState(newState: TelemetryState) {
+    storage.set("analyticsState", newState);
+}
+
+export async function timeAsync<T>(variable: string, work: () => Promise<T>): Promise<T> {
+    const start = new Date().getTime();
+    const result = await work();
+    const end = new Date().getTime();
+    timing("default", variable, end - start);
+    return result;
+}
+
+export const TELEMETRY_HEADER = `Please help improve quicktype by enabling anonymous telemetry with:
+
+  $ quicktype --telemetry enable
+
+You can also enable telemetry on any quicktype invocation:
+
+  $ quicktype pokedex.json -o Pokedex.cs --telemetry enable
+
+This helps us improve quicktype by measuring:
+
+  * How many people use quicktype
+  * Which features are popular or unpopular
+  * Performance
+  * Errors
+
+quicktype does not collect:
+
+  * Your filenames or input data
+  * Any personally identifiable information (PII)
+  * Anything not directly related to quicktype's usage
+
+If you don't want to help improve quicktype, you can dismiss this message with:
+
+  $ quicktype --telemetry disable
+
+For a full privacy policy, visit app.quicktype.io/privacy
+`;

--- a/test/run-for-all.sh
+++ b/test/run-for-all.sh
@@ -21,7 +21,7 @@ for fn in `find . -name '*.schema'` ; do
     fbase=`basename "$fn" .schema`
     odir="$OUTPUT_DIR/schema/$fdir"
     mkdir -p "$odir"
-    node "$__dir/../dist/cli.js" --lang "$LANGUAGE" $OPTIONS --src-lang schema --quiet -o "$odir/$fbase.$LANGUAGE" "$fn"
+    node "$__dir/../dist/cli/index.js" --lang "$LANGUAGE" $OPTIONS --src-lang schema --quiet -o "$odir/$fbase.$LANGUAGE" "$fn"
 done
 
 cd "$JSON_INPUT_DIR"
@@ -31,5 +31,5 @@ for fn in `find . -name '*.json'` ; do
     fbase=`basename "$fn" .json`
     odir="$OUTPUT_DIR/json/$fdir"
     mkdir -p "$odir"
-    node "$__dir/../dist/cli.js" --lang "$LANGUAGE" $OPTIONS --quiet -o "$odir/$fbase.$LANGUAGE" "$fn"
+    node "$__dir/../dist/cli/index.js" --lang "$LANGUAGE" $OPTIONS --quiet -o "$odir/$fbase.$LANGUAGE" "$fn"
 done

--- a/test/test.ts
+++ b/test/test.ts
@@ -76,7 +76,7 @@ async function main(sources: string[]) {
 
 function testCLI() {
   console.log(`* CLI sanity check`);
-  const qt = (args: string) => exec(`node dist/cli.js ${args}`);
+  const qt = (args: string) => exec(`node dist/cli/index.js ${args}`);
 
   console.log("* Ensure we can quicktype a URL");
   qt(`https://blockchain.info/latestblock`);

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -102,7 +102,8 @@ export async function quicktypeForLanguage(
       topLevel: language.topLevel,
       alphabetizeProperties,
       rendererOptions: _.merge({}, language.rendererOptions, additionalRendererOptions),
-      quiet: true
+      quiet: true,
+      telemetry: "disable"
     });
   } catch (e) {
     failWith("quicktype threw an exception", { error: e });


### PR DESCRIPTION
Telemetry is off by default and controlled with:

```bash
$ quicktype --telemetry enable|disable
```

Until the user enables or disables telemetry, this header is added to files produced by the quicktype CLI:

```
Please help improve quicktype by enabling anonymous telemetry with:

  $ quicktype --telemetry enable

You can also enable telemetry on any quicktype invocation:

  $ quicktype https://blockchain.info/latestblock -o Block.cs --telemetry enable

This helps us improve quicktype by measuring:

  * How many people use quicktype?
  * What features are popular or unpopular?
  * How does quicktype perform? Are there any errors?

quicktype does not collect:

  * Your filenames or input data
  * Any personally identifiable information (PII)
  * Anything not directly related to quicktype's usage

If you don't want to help us, you can dismiss this message with:

  $ quicktype --telemetry disable

For a full privacy policy, please see https://app.quicktype.io/privacy
```

## Information collected

- [x] Duration of quicktype invocation
- [x] Number and target language of invocations
- [ ] quicktype exceptions