### PR TITLE
Clean up uses of combineTypeAttributes

### DIFF
--- a/src/CombineClasses.ts
+++ b/src/CombineClasses.ts
@@ -138,7 +138,7 @@ export function combineClasses(
         forwardingRef: TypeRef
     ): TypeRef {
         assert(clique.size > 0, "Clique can't be empty");
-        const attributes = combineTypeAttributes(clique.map(c => c.getAttributes()).toArray());
+        const attributes = combineTypeAttributes(clique.toArray().map(c => c.getAttributes()));
         return unifyTypes(
             clique,
             attributes,

--- a/src/InferEnums.ts
+++ b/src/InferEnums.ts
@@ -51,7 +51,7 @@ function replaceUnion(group: Set<UnionType>, builder: GraphRewriteBuilder<UnionT
     assert(group.size === 1);
     const u = defined(group.first());
     const stringMembers = defined(unionNeedsReplacing(u));
-    const stringAttributes = combineTypeAttributes(stringMembers.map(t => t.getAttributes()).toArray());
+    const stringAttributes = combineTypeAttributes(stringMembers.toArray().map(t => t.getAttributes()));
     const types: TypeRef[] = [];
     u.members.forEach(t => {
         if (stringMembers.has(t)) return;

--- a/src/ResolveIntersections.ts
+++ b/src/ResolveIntersections.ts
@@ -152,7 +152,7 @@ class IntersectionAccumulator
 
     private updateEnumCases(members: OrderedSet<Type>): void {
         const enums = members.filter(t => t instanceof EnumType) as OrderedSet<EnumType>;
-        const attributes = combineTypeAttributes(enums.map(t => t.getAttributes()).toArray());
+        const attributes = combineTypeAttributes(enums.toArray().map(t => t.getAttributes()));
         this._enumAttributes = combineTypeAttributes(this._enumAttributes, attributes);
         if (members.find(t => t instanceof StringType) !== undefined) {
             return;
@@ -279,7 +279,7 @@ class IntersectionAccumulator
             mapType => this.addUnionSet(OrderedSet([mapType])),
             enumType => this.addUnionSet(OrderedSet([enumType])),
             unionType => {
-                attributes = combineTypeAttributes([attributes].concat(unionType.members.map(t => t.getAttributes()).toArray()));
+                attributes = combineTypeAttributes([attributes].concat(unionType.members.toArray().map(t => t.getAttributes())));
                 this.addUnionSet(unionType.members);
             },
             dateType => this.addUnionSet(OrderedSet([dateType])),
@@ -463,7 +463,7 @@ export function resolveIntersections(graph: TypeGraph, stringTypeMapping: String
 
         const accumulator = new IntersectionAccumulator();
         const extraAttributes = makeTypeAttributesInferred(
-            combineTypeAttributes(members.map(t => accumulator.addType(t)).toArray())
+            combineTypeAttributes(members.toArray().map(t => accumulator.addType(t)))
         );
         const attributes = combineTypeAttributes(intersectionAttributes, extraAttributes);
 

--- a/src/UnifyClasses.ts
+++ b/src/UnifyClasses.ts
@@ -36,7 +36,7 @@ function getCliqueProperties(
     }
     return properties.map(([types, count, isOptional], name) => {
         isOptional = isOptional || count < clique.length;
-        let attributes = combineTypeAttributes(types.map(t => t.getAttributes()).toArray());
+        let attributes = combineTypeAttributes(types.toArray().map(t => t.getAttributes()));
         attributes = namesTypeAttributeKind.setDefaultInAttributes(
             attributes,
             () => new TypeNames(OrderedSet([name]), OrderedSet(), true)


### PR DESCRIPTION
We would often do `someSet.map(...).toArray()`.  This
produces an intermediate set, which is expensive
because it must ensure that it has no duplicate members.
The better way is to do `someSet.toArray().map(...)`.