### PR TITLE
Boolean options are named 'x' by default

### DIFF
--- a/src/Language/JavaScript.ts
+++ b/src/Language/JavaScript.ts
@@ -22,7 +22,7 @@ import { BooleanOption, Option } from "../RendererOptions";
 const unicode = require("unicode-properties");
 
 export class JavaScriptTargetLanguage extends TargetLanguage {
-    protected readonly runtimeTypecheck = new BooleanOption(
+    protected readonly _runtimeTypecheck = new BooleanOption(
         "runtime-typecheck",
         "Verify JSON.parse results at runtime",
         true
@@ -37,7 +37,7 @@ export class JavaScriptTargetLanguage extends TargetLanguage {
     }
 
     protected getOptions(): Option<any>[] {
-        return [this.runtimeTypecheck];
+        return [this._runtimeTypecheck];
     }
 
     get supportsOptionalClassProperties(): boolean {

--- a/src/Language/JavaScript.ts
+++ b/src/Language/JavaScript.ts
@@ -23,9 +23,9 @@ const unicode = require("unicode-properties");
 
 export class JavaScriptTargetLanguage extends TargetLanguage {
     protected readonly omitRuntimeTypecheck = new BooleanOption(
-        "no-runtime-typecheck",
-        "Don't verify JSON.parse results at runtime",
-        false
+        "runtime-typecheck",
+        "Verify JSON.parse results at runtime",
+        true
     );
 
     constructor(

--- a/src/Language/JavaScript.ts
+++ b/src/Language/JavaScript.ts
@@ -22,7 +22,7 @@ import { BooleanOption, Option } from "../RendererOptions";
 const unicode = require("unicode-properties");
 
 export class JavaScriptTargetLanguage extends TargetLanguage {
-    protected readonly _runtimeTypecheck = new BooleanOption(
+    protected readonly runtimeTypecheck = new BooleanOption(
         "runtime-typecheck",
         "Verify JSON.parse results at runtime",
         true
@@ -37,7 +37,7 @@ export class JavaScriptTargetLanguage extends TargetLanguage {
     }
 
     protected getOptions(): Option<any>[] {
-        return [this._runtimeTypecheck];
+        return [this.runtimeTypecheck];
     }
 
     get supportsOptionalClassProperties(): boolean {

--- a/src/Language/Swift.ts
+++ b/src/Language/Swift.ts
@@ -45,14 +45,7 @@ type Version = 4 | 4.1;
 
 export default class SwiftTargetLanguage extends TargetLanguage {
     private readonly _justTypesOption = new BooleanOption("just-types", "Plain types only", false);
-
-    private readonly _convenienceInitializers = new BooleanOption(
-        "initializers",
-        "Convenience initializers",
-        true,
-        "No convenience initializers"
-    );
-
+    private readonly _convenienceInitializers = new BooleanOption("initializers", "Convenience initializers", true);
     private readonly _alamofireHandlers = new BooleanOption("alamofire", "Alamofire extensions", false);
 
     private readonly _classOption = new EnumOption("struct-or-class", "Structs or classes", [

--- a/src/Language/TypeScriptFlow.ts
+++ b/src/Language/TypeScriptFlow.ts
@@ -16,7 +16,7 @@ export abstract class TypeScriptFlowBaseTargetLanguage extends JavaScriptTargetL
     private readonly _declareUnions = new BooleanOption("explicit-unions", "Explicitly name unions", false);
 
     protected getOptions(): Option<any>[] {
-        return [this._justTypes, this._declareUnions, this._runtimeTypecheck];
+        return [this._justTypes, this._declareUnions, this.runtimeTypecheck];
     }
 
     protected abstract get rendererClass(): new (

--- a/src/Language/TypeScriptFlow.ts
+++ b/src/Language/TypeScriptFlow.ts
@@ -16,7 +16,7 @@ export abstract class TypeScriptFlowBaseTargetLanguage extends JavaScriptTargetL
     private readonly _declareUnions = new BooleanOption("explicit-unions", "Explicitly name unions", false);
 
     protected getOptions(): Option<any>[] {
-        return [this._justTypes, this._declareUnions, this.omitRuntimeTypecheck];
+        return [this._justTypes, this._declareUnions, this._runtimeTypecheck];
     }
 
     protected abstract get rendererClass(): new (
@@ -48,9 +48,9 @@ abstract class TypeScriptFlowBaseRenderer extends JavaScriptRenderer {
         leadingComments: string[] | undefined,
         private readonly _justTypes: boolean,
         declareUnions: boolean,
-        omitRuntimeTypecheck: boolean
+        runtimeTypecheck: boolean
     ) {
-        super(graph, leadingComments, omitRuntimeTypecheck);
+        super(graph, leadingComments, runtimeTypecheck);
         this._inlineUnions = !declareUnions;
     }
 

--- a/src/RendererOptions.ts
+++ b/src/RendererOptions.ts
@@ -1,6 +1,6 @@
 "use strict";
 
-import { panic, assert } from "./Support";
+import { panic } from "./Support";
 
 export interface OptionDefinition {
     name: string;
@@ -73,8 +73,6 @@ export class BooleanOption extends Option<boolean> {
         if (negated === undefined) {
             negated = !this.definition.defaultValue;
         }
-
-        assert(value !== negated, `${this.definition.name} and no-${this.definition.name} cannot have the same value`);
 
         if (this.definition.defaultValue) {
             return value && !negated;

--- a/src/RendererOptions.ts
+++ b/src/RendererOptions.ts
@@ -1,6 +1,6 @@
 "use strict";
 
-import { panic } from "./Support";
+import { panic, assert } from "./Support";
 
 export interface OptionDefinition {
     name: string;
@@ -73,6 +73,8 @@ export class BooleanOption extends Option<boolean> {
         if (negated === undefined) {
             negated = !this.definition.defaultValue;
         }
+
+        assert(value !== negated, `${this.definition.name} and no-${this.definition.name} cannot have the same value`);
 
         if (this.definition.defaultValue) {
             return value && !negated;

--- a/src/TargetLanguage.ts
+++ b/src/TargetLanguage.ts
@@ -19,8 +19,14 @@ export abstract class TargetLanguage {
         return this.getOptions().map(o => o.definition);
     }
 
-    get cliOptionDefinitions(): OptionDefinition[] {
-        return this.getOptions().map(o => o.cliDefinition);        
+    get cliOptionDefinitions(): { display: OptionDefinition[]; actual: OptionDefinition[] } {
+        let actual: OptionDefinition[] = [];
+        let display: OptionDefinition[] = [];
+        for (const { cliDefinitions } of this.getOptions()) {
+            actual = actual.concat(cliDefinitions.actual);
+            display = display.concat(cliDefinitions.display);
+        }
+        return { actual, display };
     }
 
     protected abstract get rendererClass(): new (

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -488,7 +488,7 @@ export function parseCLIOptions(argv: string[], targetLanguage?: TargetLanguage)
     if (targetLanguage === undefined) {
         targetLanguage = getTargetLanguage(incompleteOptions.lang);
     }
-    const rendererOptionDefinitions = targetLanguage.cliOptionDefinitions;
+    const rendererOptionDefinitions = targetLanguage.cliOptionDefinitions.actual;
     // Use the global options as well as the renderer options from now on:
     const allOptionDefinitions = _.concat(optionDefinitions, rendererOptionDefinitions);
     try {
@@ -530,7 +530,7 @@ function usage(targetLanguages: TargetLanguage[]) {
     const rendererSections: UsageSection[] = [];
 
     _.forEach(targetLanguages, language => {
-        const definitions = language.cliOptionDefinitions;
+        const definitions = language.cliOptionDefinitions.display;
         if (definitions.length === 0) return;
 
         rendererSections.push({


### PR DESCRIPTION
and get an automatic 'no-x' variant on the CLI

![image](https://user-images.githubusercontent.com/108197/37571197-b3fc165a-2ab6-11e8-9d06-aaf9b774871b.png)

## Example

```bash
$ quicktype getting-started.json -l swift --alamofire --no-initializers
```

Produces:

```swift
import Foundation
import Alamofire

struct GettingStarted: Codable {
    let greeting: String
    let instructions: [String]
}

// MARK: - Alamofire response handlers

extension DataRequest {
    fileprivate func decodableResponseSerializer<T: Decodable>() -> DataResponseSerializer<T> {
        return DataResponseSerializer { _, response, data, error in
            guard error == nil else { return .failure(error!) }

            guard let data = data else {
                return .failure(AFError.responseSerializationFailed(reason: .inputDataNil))
            }

            return Result { try JSONDecoder().decode(T.self, from: data) }
        }
    }

    @discardableResult
    fileprivate func responseDecodable<T: Decodable>(queue: DispatchQueue? = nil, completionHandler: @escaping (DataResponse<T>) -> Void) -> Self {
        return response(queue: queue, responseSerializer: decodableResponseSerializer(), completionHandler: completionHandler)
    }

    @discardableResult
    func responseGettingStarted(queue: DispatchQueue? = nil, completionHandler: @escaping (DataResponse<GettingStarted>) -> Void) -> Self {
        return responseDecodable(queue: queue, completionHandler: completionHandler)
    }
}
```