### PR TITLE
Fix a graph rewriting bug.  Fixes #713

### DIFF
--- a/src/AccessorNames.ts
+++ b/src/AccessorNames.ts
@@ -50,7 +50,7 @@ function lookupKey(accessors: AccessorNames, key: string, language: string): [st
 
 export function objectPropertyNames(o: ObjectType, language: string): Map<string, [string, boolean] | undefined> {
     const accessors = accessorNamesTypeAttributeKind.tryGetInAttributes(o.getAttributes());
-    const map = o.properties;
+    const map = o.getProperties();
     if (accessors === undefined) return map.map(_ => undefined);
     return map.map((_cp, n) => lookupKey(accessors, n, language));
 }

--- a/src/CombineClasses.ts
+++ b/src/CombineClasses.ts
@@ -31,8 +31,8 @@ function typeSetsCanBeCombined(s1: OrderedSet<Type>, s2: OrderedSet<Type>): bool
 }
 
 function canBeCombined(c1: ClassType, c2: ClassType): boolean {
-    const p1 = c1.properties;
-    const p2 = c2.properties;
+    const p1 = c1.getProperties();
+    const p2 = c2.getProperties();
     if (p1.size < p2.size * REQUIRED_OVERLAP || p2.size < p1.size * REQUIRED_OVERLAP) {
         return false;
     }
@@ -127,7 +127,8 @@ export function combineClasses(
     graph: TypeGraph,
     stringTypeMapping: StringTypeMapping,
     alphabetizeProperties: boolean,
-    conflateNumbers: boolean
+    conflateNumbers: boolean,
+    debugPrintReconstitution: boolean
 ): TypeGraph {
     const cliques = findSimilarityCliques(graph, false);
 
@@ -148,5 +149,12 @@ export function combineClasses(
         );
     }
 
-    return graph.rewrite("combine classes", stringTypeMapping, alphabetizeProperties, cliques, makeCliqueClass);
+    return graph.rewrite(
+        "combine classes",
+        stringTypeMapping,
+        alphabetizeProperties,
+        cliques,
+        debugPrintReconstitution,
+        makeCliqueClass
+    );
 }

--- a/src/ConvenienceRenderer.ts
+++ b/src/ConvenienceRenderer.ts
@@ -347,7 +347,8 @@ export abstract class ConvenienceRenderer extends Renderer {
         let ns: Namespace | undefined;
 
         const accessorNames = objectPropertyNames(o, this.targetLanguage.name);
-        const names = o.sortedProperties
+        const names = o
+            .getSortedProperties()
             .map((p, jsonName) => {
                 const [assignedName, isFixed] = getAccessorName(accessorNames, jsonName);
                 let name: Name | undefined;
@@ -452,7 +453,8 @@ export abstract class ConvenienceRenderer extends Renderer {
         const names = this.names;
         if (t instanceof ClassType) {
             const propertyNameds = defined(this._propertyNamesStoreView).get(t);
-            const sortedMap = t.properties
+            const sortedMap = t
+                .getProperties()
                 .filter((_, n) => propertyNameds.get(n) !== undefined)
                 .map(p => p.type)
                 .sortBy((_, n) => defined(names.get(defined(propertyNameds.get(n)))));
@@ -602,11 +604,11 @@ export abstract class ConvenienceRenderer extends Renderer {
         if (this._alphabetizeProperties) {
             const alphabetizedPropertyNames = propertyNames.sortBy(n => this.names.get(n)).toOrderedMap();
             this.forEachWithBlankLines(alphabetizedPropertyNames, blankLocations, (name, jsonName) => {
-                const p = defined(o.properties.get(jsonName));
+                const p = defined(o.getProperties().get(jsonName));
                 f(name, jsonName, p);
             });
         } else {
-            this.forEachWithBlankLines(o.properties, blankLocations, (p, jsonName) => {
+            this.forEachWithBlankLines(o.getProperties(), blankLocations, (p, jsonName) => {
                 const name = defined(propertyNames.get(jsonName));
                 f(name, jsonName, p);
             });
@@ -806,7 +808,7 @@ export abstract class ConvenienceRenderer extends Renderer {
         this._haveMaps = types.some(t => t instanceof MapType);
         this._haveOptionalProperties = types
             .filter(t => t instanceof ClassType)
-            .some(c => (c as ClassType).properties.some(p => p.isOptional));
+            .some(c => (c as ClassType).getProperties().some(p => p.isOptional));
         this._namedTypes = this._declarationIR.declarations.filter(d => d.kind === "define").map(d => d.type);
         const { objects, enums, unions } = separateNamedTypes(this._namedTypes);
         this._namedObjects = objects;

--- a/src/FlattenUnions.ts
+++ b/src/FlattenUnions.ts
@@ -13,7 +13,8 @@ export function flattenUnions(
     graph: TypeGraph,
     stringTypeMapping: StringTypeMapping,
     conflateNumbers: boolean,
-    makeObjectTypes: boolean
+    makeObjectTypes: boolean,
+    debugPrintReconstitution: boolean
 ): [TypeGraph, boolean] {
     let needsRepeat = false;
 
@@ -47,7 +48,7 @@ export function flattenUnions(
         foundIntersection = true;
         return false;
     });
-    graph = graph.rewrite("flatten unions", stringTypeMapping, false, groups, replace);
+    graph = graph.rewrite("flatten unions", stringTypeMapping, false, groups, debugPrintReconstitution, replace);
 
     // console.log(`flattened ${nonCanonicalUnions.size} of ${unions.size} unions`);
     return [graph, !needsRepeat && !foundIntersection];

--- a/src/GatherNames.ts
+++ b/src/GatherNames.ts
@@ -21,12 +21,12 @@ export function gatherNames(graph: TypeGraph): void {
     let processed: Set<List<any>> = Set();
 
     function processObjectType(o: ObjectType, names: OrderedSet<string>, parentNames: OrderedSet<string> | undefined) {
-        const properties = o.properties.sortBy((_, n) => n);
+        const properties = o.getProperties().sortBy((_, n) => n);
         properties.forEach((property, propertyName) => {
             processType(property.type, OrderedSet([propertyName]), names);
         });
 
-        const values = o.additionalProperties;
+        const values = o.getAdditionalProperties();
         if (values !== undefined) {
             processType(values, names.map(pluralize.singular), parentNames, "value");
         }

--- a/src/InferEnums.ts
+++ b/src/InferEnums.ts
@@ -68,20 +68,35 @@ function replaceUnion(group: Set<UnionType>, builder: GraphRewriteBuilder<UnionT
     return builder.getUnionType(u.getAttributes(), OrderedSet(types), forwardingRef);
 }
 
-export function inferEnums(graph: TypeGraph, stringTypeMapping: StringTypeMapping): TypeGraph {
+export function inferEnums(
+    graph: TypeGraph,
+    stringTypeMapping: StringTypeMapping,
+    debugPrintReconstitution: boolean
+): TypeGraph {
     const allStrings = graph
         .allTypesUnordered()
         .filter(t => t instanceof StringType)
         .map(t => [t])
         .toArray() as StringType[][];
-    return graph.rewrite("infer enums", stringTypeMapping, false, allStrings, replaceString);
+    return graph.rewrite("infer enums", stringTypeMapping, false, allStrings, debugPrintReconstitution, replaceString);
 }
 
-export function flattenStrings(graph: TypeGraph, stringTypeMapping: StringTypeMapping): TypeGraph {
+export function flattenStrings(
+    graph: TypeGraph,
+    stringTypeMapping: StringTypeMapping,
+    debugPrintReconstitution: boolean
+): TypeGraph {
     const allUnions = graph.allNamedTypesSeparated().unions;
     const unionsToReplace = allUnions
         .filter(unionNeedsReplacing)
         .map(t => [t])
         .toArray();
-    return graph.rewrite("flatten strings", stringTypeMapping, false, unionsToReplace, replaceUnion);
+    return graph.rewrite(
+        "flatten strings",
+        stringTypeMapping,
+        false,
+        unionsToReplace,
+        debugPrintReconstitution,
+        replaceUnion
+    );
 }

--- a/src/InferMaps.ts
+++ b/src/InferMaps.ts
@@ -86,14 +86,19 @@ function shouldBeMap(properties: Map<string, ClassProperty>): Set<Type> | undefi
     return allCases;
 }
 
-export function inferMaps(graph: TypeGraph, stringTypeMapping: StringTypeMapping, conflateNumbers: boolean): TypeGraph {
+export function inferMaps(
+    graph: TypeGraph,
+    stringTypeMapping: StringTypeMapping,
+    conflateNumbers: boolean,
+    debugPrintReconstitution: boolean
+): TypeGraph {
     function replaceClass(
         setOfOneClass: Set<ClassType>,
         builder: GraphRewriteBuilder<ClassType>,
         forwardingRef: TypeRef
     ): TypeRef {
         const c = defined(setOfOneClass.first());
-        const properties = c.properties;
+        const properties = c.getProperties();
 
         const shouldBe = shouldBeMap(properties);
         if (shouldBe === undefined) {
@@ -123,6 +128,15 @@ export function inferMaps(graph: TypeGraph, stringTypeMapping: StringTypeMapping
     const allClasses = graph.allNamedTypesSeparated().objects.filter(o => o instanceof ClassType) as OrderedSet<
         ClassType
     >;
-    const classesToReplace = allClasses.filter(c => !c.isFixed && shouldBeMap(c.properties) !== undefined).toArray();
-    return graph.rewrite("infer maps", stringTypeMapping, false, classesToReplace.map(c => [c]), replaceClass);
+    const classesToReplace = allClasses
+        .filter(c => !c.isFixed && shouldBeMap(c.getProperties()) !== undefined)
+        .toArray();
+    return graph.rewrite(
+        "infer maps",
+        stringTypeMapping,
+        false,
+        classesToReplace.map(c => [c]),
+        debugPrintReconstitution,
+        replaceClass
+    );
 }

--- a/src/Language/CSharp.ts
+++ b/src/Language/CSharp.ts
@@ -331,7 +331,7 @@ export class CSharpRenderer extends ConvenienceRenderer {
             className,
             this.superclassForType(c),
             () => {
-                if (c.properties.isEmpty()) return;
+                if (c.getProperties().isEmpty()) return;
                 const blankLines = this.blankLinesBetweenAttributes() ? "interposing" : "none";
                 let columns: Sourcelike[][] = [];
                 let isFirstProperty = true;

--- a/src/Language/JSONSchema.ts
+++ b/src/Language/JSONSchema.ts
@@ -136,13 +136,13 @@ export class JSONSchemaRenderer extends ConvenienceRenderer {
     private definitionForObject(o: ObjectType, title: string | undefined): Schema {
         let properties: Schema | undefined;
         let required: string[] | undefined;
-        if (o.properties.isEmpty()) {
+        if (o.getProperties().isEmpty()) {
             properties = undefined;
             required = undefined;
         } else {
             const props: Schema = {};
             const req: string[] = [];
-            o.properties.forEach((p, name) => {
+            o.getProperties().forEach((p, name) => {
                 props[name] = this.schemaForType(p.type);
                 if (!p.isOptional) {
                     req.push(name);
@@ -151,8 +151,8 @@ export class JSONSchemaRenderer extends ConvenienceRenderer {
             properties = props;
             required = req.sort();
         }
-        const additionalProperties =
-            o.additionalProperties !== undefined ? this.schemaForType(o.additionalProperties) : false;
+        const additional = o.getAdditionalProperties();
+        const additionalProperties = additional !== undefined ? this.schemaForType(additional) : false;
         return {
             type: "object",
             additionalProperties,

--- a/src/Language/Java.ts
+++ b/src/Language/Java.ts
@@ -356,7 +356,7 @@ export class JavaRenderer extends ConvenienceRenderer {
     }
 
     protected emitClassAttributes(c: ClassType, _className: Name): void {
-        if (c.properties.isEmpty() && !this._justTypes) {
+        if (c.getProperties().isEmpty() && !this._justTypes) {
             this.emitLine("@JsonAutoDetect(fieldVisibility=JsonAutoDetect.Visibility.NONE)");
         }
     }

--- a/src/Language/JavaScript.ts
+++ b/src/Language/JavaScript.ts
@@ -187,8 +187,9 @@ export class JavaScriptRenderer extends ConvenienceRenderer {
 
         this.emitBlock(`const typeMap${anyAnnotation} = `, ";", () => {
             this.forEachObject("none", (t: ObjectType, name: Name) => {
+                const additionalProperties = t.getAdditionalProperties();
                 const additional =
-                    t.additionalProperties !== undefined ? this.typeMapTypeFor(t.additionalProperties) : "false";
+                    additionalProperties !== undefined ? this.typeMapTypeFor(additionalProperties) : "false";
                 this.emitBlock(['"', name, '": o('], [", ", additional, "),"], () => {
                     this.forEachClassProperty(t, "none", (propName, _propJsonName, property) => {
                         this.emitLine(propName, ": ", this.typeMapTypeForProperty(property), ",");

--- a/src/Language/Objective-C.ts
+++ b/src/Language/Objective-C.ts
@@ -668,7 +668,7 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
         });
 
         if (!this._justTypes && isTopLevel) {
-            if (t.properties.count() > 0) this.ensureBlankLine();
+            if (!t.getProperties().isEmpty()) this.ensureBlankLine();
 
             this.emitLine(
                 "+ (_Nullable instancetype)fromJSON:(NSString *)json encoding:(NSStringEncoding)encoding error:(NSError *_Nullable *)error;"
@@ -1048,7 +1048,7 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
             return (
                 t instanceof MapType ||
                 t instanceof ArrayType ||
-                (t instanceof ClassType && t.properties.some(p => needsMap(p.type)))
+                (t instanceof ClassType && t.getProperties().some(p => needsMap(p.type)))
             );
         }
         return this.typeGraph.allTypesUnordered().some(needsMap);

--- a/src/Language/Ruby/index.ts
+++ b/src/Language/Ruby/index.ts
@@ -401,7 +401,7 @@ export class RubyRenderer extends ConvenienceRenderer {
         this.emitDescription(this.descriptionForType(c));
         this.emitBlock(["class ", className, " < Dry::Struct"], () => {
             let table: Sourcelike[][] = [];
-            let count = c.properties.count();
+            let count = c.getProperties().size;
             this.forEachClassProperty(c, "none", (name, jsonName, p) => {
                 const last = --count === 0;
                 const description = this.descriptionForClassProperty(c, jsonName);

--- a/src/Language/Swift.ts
+++ b/src/Language/Swift.ts
@@ -534,7 +534,7 @@ export class SwiftRenderer extends ConvenienceRenderer {
                 const allPropertiesRedundant = groups.every(group => {
                     return group.every(p => p.label === undefined);
                 });
-                if (!allPropertiesRedundant && !c.properties.isEmpty()) {
+                if (!allPropertiesRedundant && !c.getProperties().isEmpty()) {
                     this.ensureBlankLine();
                     this.emitBlock("enum CodingKeys: String, CodingKey", () => {
                         for (const group of groups) {

--- a/src/ReplaceObjectType.ts
+++ b/src/ReplaceObjectType.ts
@@ -12,7 +12,8 @@ export function replaceObjectType(
     graph: TypeGraph,
     stringTypeMapping: StringTypeMapping,
     _conflateNumbers: boolean,
-    leaveFullObjects: boolean
+    leaveFullObjects: boolean,
+    debugPrintReconstitution: boolean
 ): TypeGraph {
     function replace(
         setOfOneType: Set<ObjectType>,
@@ -21,8 +22,8 @@ export function replaceObjectType(
     ): TypeRef {
         const o = defined(setOfOneType.first());
         const attributes = o.getAttributes();
-        const properties = o.properties;
-        const additionalProperties = o.additionalProperties;
+        const properties = o.getProperties();
+        const additionalProperties = o.getAdditionalProperties();
 
         function reconstituteProperties(): OrderedMap<string, ClassProperty> {
             return properties.map(cp => new ClassProperty(builder.reconstituteTypeRef(cp.typeRef), cp.isOptional));
@@ -82,8 +83,8 @@ export function replaceObjectType(
 
     const allObjectTypes = graph.allTypesUnordered().filter(t => t.kind === "object") as Set<ObjectType>;
     const objectTypesToReplace = leaveFullObjects
-        ? allObjectTypes.filter(o => o.properties.isEmpty() || o.additionalProperties === undefined)
+        ? allObjectTypes.filter(o => o.getProperties().isEmpty() || o.getAdditionalProperties() === undefined)
         : allObjectTypes;
     const groups = objectTypesToReplace.toArray().map(t => [t]);
-    return graph.rewrite("replace object type", stringTypeMapping, false, groups, replace);
+    return graph.rewrite("replace object type", stringTypeMapping, false, groups, debugPrintReconstitution, replace);
 }

--- a/src/Type.ts
+++ b/src/Type.ts
@@ -62,7 +62,7 @@ export abstract class Type {
 
     abstract get isNullable(): boolean;
     abstract isPrimitive(): this is PrimitiveType;
-    abstract map(builder: TypeReconstituter, f: (tref: TypeRef) => TypeRef): TypeRef;
+    abstract reconstitute<T extends Type>(builder: TypeReconstituter<T>): void;
 
     equals(other: any): boolean {
         if (!Object.prototype.hasOwnProperty.call(other, "typeRef")) {
@@ -182,9 +182,8 @@ export class PrimitiveType extends Type {
         return true;
     }
 
-    map(builder: TypeReconstituter, _: (tref: TypeRef) => TypeRef): TypeRef {
-        // console.log(`${mapIndentation()}mapping ${this.kind}`);
-        return builder.getPrimitiveType(this.kind);
+    reconstitute<T extends Type>(builder: TypeReconstituter<T>): void {
+        builder.getPrimitiveType(this.kind);
     }
 
     protected structuralEqualityStep(_other: Type, _queue: (a: Type, b: Type) => boolean): boolean {
@@ -201,9 +200,8 @@ export class StringType extends PrimitiveType {
         super(typeRef, "string", false);
     }
 
-    map(builder: TypeReconstituter, _: (tref: TypeRef) => TypeRef): TypeRef {
-        // console.log(`${mapIndentation()}mapping ${this.kind}`);
-        return builder.getStringType(this.enumCases);
+    reconstitute<T extends Type>(builder: TypeReconstituter<T>): void {
+        builder.getStringType(this.enumCases);
     }
 
     protected structuralEqualityStep(_other: Type, _queue: (a: Type, b: Type) => boolean): boolean {
@@ -249,12 +247,15 @@ export class ArrayType extends Type {
         return false;
     }
 
-    map(builder: TypeReconstituter, f: (tref: TypeRef) => TypeRef): TypeRef {
-        // console.log(`${mapIndentation()}mapping ${this.kind}`);
-        // mapPath.push("[]");
-        const result = builder.getArrayType(f(this.getItemsRef()));
-        // mapPath.pop();
-        return result;
+    reconstitute<T extends Type>(builder: TypeReconstituter<T>): void {
+        const itemsRef = this.getItemsRef();
+        const maybeItems = builder.lookup(itemsRef);
+        if (maybeItems === undefined) {
+            builder.getUniqueArrayType();
+            builder.setArrayItems(builder.reconstitute(this.getItemsRef()));
+        } else {
+            builder.getArrayType(maybeItems);
+        }
     }
 
     protected structuralEqualityStep(other: ArrayType, queue: (a: Type, b: Type) => boolean): boolean {
@@ -296,14 +297,16 @@ export class ObjectType extends Type {
         typeRef: TypeRef,
         kind: TypeKind,
         readonly isFixed: boolean,
-        readonly properties: OrderedMap<string, ClassProperty>,
+        private _properties: OrderedMap<string, ClassProperty> | undefined,
         private _additionalPropertiesRef: TypeRef | undefined
     ) {
         super(typeRef, kind);
 
         assert(kind === "object" || kind === "map" || kind === "class");
         if (kind === "map") {
-            assert(properties.isEmpty());
+            if (_properties !== undefined) {
+                assert(_properties.isEmpty());
+            }
             assert(!isFixed);
         } else if (kind === "class") {
             assert(_additionalPropertiesRef === undefined);
@@ -312,21 +315,43 @@ export class ObjectType extends Type {
         }
     }
 
-    get sortedProperties(): OrderedMap<string, ClassProperty> {
-        const properties = this.properties;
+    setProperties(properties: OrderedMap<string, ClassProperty>, additionalPropertiesRef: TypeRef | undefined) {
+        if (this instanceof MapType) {
+            assert(properties.isEmpty(), "Cannot set properties on map type");
+        } else if (this._properties !== undefined) {
+            return panic("Tried to set object properties again");
+        }
+
+        if (this instanceof ClassType) {
+            assert(additionalPropertiesRef === undefined, "Cannot set additional properties of class type");
+        }
+
+        this._properties = properties;
+        this._additionalPropertiesRef = additionalPropertiesRef;
+    }
+
+    getProperties(): OrderedMap<string, ClassProperty> {
+        return defined(this._properties);
+    }
+
+    getSortedProperties(): OrderedMap<string, ClassProperty> {
+        const properties = this.getProperties();
         const sortedKeys = properties.keySeq().sort();
         const props = sortedKeys.map((k: string): [string, ClassProperty] => [k, defined(properties.get(k))]);
         return OrderedMap(props);
     }
 
-    get additionalProperties(): Type | undefined {
+    getAdditionalProperties(): Type | undefined {
+        assert(this._properties !== undefined, "Properties are not set yet");
         if (this._additionalPropertiesRef === undefined) return undefined;
         return this._additionalPropertiesRef.deref()[0];
     }
 
     get children(): OrderedSet<Type> {
-        const children = this.sortedProperties.map(p => p.type).toOrderedSet();
-        const additionalProperties = this.additionalProperties;
+        const children = this.getSortedProperties()
+            .map(p => p.type)
+            .toOrderedSet();
+        const additionalProperties = this.getAdditionalProperties();
         if (additionalProperties === undefined) {
             return children;
         }
@@ -341,38 +366,63 @@ export class ObjectType extends Type {
         return false;
     }
 
-    map(builder: TypeReconstituter, f: (tref: TypeRef) => TypeRef): TypeRef {
-        // const indent = "  ".repeat(mapPath.length);
-        // const path = mapPath.join(".");
-        // console.log(`${indent} mapping class ${this.getCombinedName()} at ${path}`);
-        const properties = this.properties.map((p, _n) => {
-            // console.log(`${indent}  property ${path}.${n}`);
-            // mapPath.push(n);
-            const result = new ClassProperty(f(p.typeRef), p.isOptional);
-            // mapPath.pop();
-            return result;
-        });
-        const additionalProperties = mapOptional(f, this._additionalPropertiesRef);
-        switch (this.kind) {
-            case "object":
-                assert(this.isFixed);
-                return builder.getUniqueObjectType(properties, additionalProperties);
-            case "map":
-                return builder.getMapType(defined(additionalProperties));
-            case "class":
-                if (this.isFixed) {
-                    return builder.getUniqueClassType(true, properties);
-                } else {
-                    return builder.getClassType(properties);
-                }
-            default:
-                return panic(`Invalid object type kind ${this.kind}`);
+    reconstitute<T extends Type>(builder: TypeReconstituter<T>): void {
+        const maybePropertyTypes = builder.lookup(this.getProperties().map(cp => cp.typeRef));
+        const maybeAdditionalProperties = mapOptional(r => builder.lookup(r), this._additionalPropertiesRef);
+
+        if (
+            maybePropertyTypes !== undefined &&
+            (maybeAdditionalProperties !== undefined || this._additionalPropertiesRef === undefined)
+        ) {
+            const properties = this.getProperties().map(
+                (cp, n) => new ClassProperty(defined(maybePropertyTypes.get(n)), cp.isOptional)
+            );
+
+            switch (this.kind) {
+                case "object":
+                    assert(this.isFixed);
+                    builder.getObjectType(properties, maybeAdditionalProperties);
+                    break;
+                case "map":
+                    builder.getMapType(defined(maybeAdditionalProperties));
+                    break;
+                case "class":
+                    if (this.isFixed) {
+                        builder.getUniqueClassType(true, properties);
+                    } else {
+                        builder.getClassType(properties);
+                    }
+                    break;
+                default:
+                    return panic(`Invalid object type kind ${this.kind}`);
+            }
+        } else {
+            switch (this.kind) {
+                case "object":
+                    assert(this.isFixed);
+                    builder.getUniqueObjectType(undefined, undefined);
+                    break;
+                case "map":
+                    builder.getUniqueMapType();
+                    break;
+                case "class":
+                    builder.getUniqueClassType(this.isFixed, undefined);
+                    break;
+                default:
+                    return panic(`Invalid object type kind ${this.kind}`);
+            }
+
+            const properties = this.getProperties().map(
+                cp => new ClassProperty(builder.reconstitute(cp.typeRef), cp.isOptional)
+            );
+            const additionalProperties = mapOptional(r => builder.reconstitute(r), this._additionalPropertiesRef);
+            builder.setObjectProperties(properties, additionalProperties);
         }
     }
 
     protected structuralEqualityStep(other: ObjectType, queue: (a: Type, b: Type) => boolean): boolean {
-        const pa = this.properties;
-        const pb = other.properties;
+        const pa = this.getProperties();
+        const pb = other.getProperties();
         if (pa.size !== pb.size) return false;
         let failed = false;
         pa.forEach((cpa, name) => {
@@ -384,9 +434,11 @@ export class ObjectType extends Type {
         });
         if (failed) return false;
 
-        if ((this.additionalProperties === undefined) !== (other.additionalProperties === undefined)) return false;
-        if (this.additionalProperties === undefined || other.additionalProperties === undefined) return true;
-        return queue(this.additionalProperties, other.additionalProperties);
+        const thisAdditionalProperties = this.getAdditionalProperties();
+        const otherAdditionalProperties = other.getAdditionalProperties();
+        if ((thisAdditionalProperties === undefined) !== (otherAdditionalProperties === undefined)) return false;
+        if (thisAdditionalProperties === undefined || otherAdditionalProperties === undefined) return true;
+        return queue(thisAdditionalProperties, otherAdditionalProperties);
     }
 }
 
@@ -394,7 +446,7 @@ export class ClassType extends ObjectType {
     // @ts-ignore: This is initialized in the Type constructor
     kind: "class";
 
-    constructor(typeRef: TypeRef, readonly isFixed: boolean, readonly properties: OrderedMap<string, ClassProperty>) {
+    constructor(typeRef: TypeRef, isFixed: boolean, properties: OrderedMap<string, ClassProperty> | undefined) {
         super(typeRef, "class", isFixed, properties, undefined);
     }
 }
@@ -403,12 +455,13 @@ export class MapType extends ObjectType {
     // @ts-ignore: This is initialized in the Type constructor
     readonly kind: "map";
 
-    constructor(typeRef: TypeRef, valuesRef: TypeRef) {
+    constructor(typeRef: TypeRef, valuesRef: TypeRef | undefined) {
         super(typeRef, "map", false, OrderedMap(), valuesRef);
     }
 
+    // FIXME: Remove and use `getAdditionalProperties()` instead.
     get values(): Type {
-        return defined(this.additionalProperties);
+        return defined(this.getAdditionalProperties());
     }
 }
 
@@ -446,9 +499,8 @@ export class EnumType extends Type {
         return false;
     }
 
-    map(builder: TypeReconstituter, _: (tref: TypeRef) => TypeRef): TypeRef {
-        // console.log(`${mapIndentation()}mapping ${this.kind}`);
-        return builder.getEnumType(this.cases);
+    reconstitute<T extends Type>(builder: TypeReconstituter<T>): void {
+        builder.getEnumType(this.cases);
     }
 
     protected structuralEqualityStep(other: EnumType, _queue: (a: Type, b: Type) => void): boolean {
@@ -492,7 +544,7 @@ export abstract class SetOperationType extends Type {
         return false;
     }
 
-    protected structuralEqualityStep(other: UnionType, queue: (a: Type, b: Type) => boolean): boolean {
+    protected structuralEqualityStep(other: SetOperationType, queue: (a: Type, b: Type) => boolean): boolean {
         return setOperationCasesEqual(this.members, other.members, queue);
     }
 }
@@ -509,10 +561,15 @@ export class IntersectionType extends SetOperationType {
         return panic("isNullable not implemented for IntersectionType");
     }
 
-    map(builder: TypeReconstituter, f: (tref: TypeRef) => TypeRef): TypeRef {
-        const members = this.getMemberRefs().map(f);
-        // FIXME: Eventually switch to non-unique
-        return builder.getUniqueIntersectionType(members);
+    reconstitute<T extends Type>(builder: TypeReconstituter<T>): void {
+        const memberRefs = this.getMemberRefs();
+        const maybeMembers = builder.lookup(memberRefs);
+        if (maybeMembers === undefined) {
+            builder.getUniqueIntersectionType();
+            builder.setSetOperationMembers(builder.reconstitute(memberRefs));
+        } else {
+            builder.getIntersectionType(maybeMembers);
+        }
     }
 }
 
@@ -562,9 +619,15 @@ export class UnionType extends SetOperationType {
         return true;
     }
 
-    map(builder: TypeReconstituter, f: (tref: TypeRef) => TypeRef): TypeRef {
-        const members = this.getMemberRefs().map(f);
-        return builder.getUnionType(members);
+    reconstitute<T extends Type>(builder: TypeReconstituter<T>): void {
+        const memberRefs = this.getMemberRefs();
+        const maybeMembers = builder.lookup(memberRefs);
+        if (maybeMembers === undefined) {
+            builder.getUniqueUnionType();
+            builder.setSetOperationMembers(builder.reconstitute(memberRefs));
+        } else {
+            builder.getUnionType(maybeMembers);
+        }
     }
 }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -425,7 +425,7 @@ function makeOptionDefinitions(targetLanguages: TargetLanguage[]): OptionDefinit
             name: "debug",
             type: String,
             typeLabel: "OPTIONS",
-            description: "Comma separated debug options: print-graph,provenance"
+            description: "Comma separated debug options: print-graph, provenance, print-reconstitution"
         },
         {
             name: "telemetry",
@@ -741,12 +741,15 @@ export async function makeQuicktypeOptions(
 
     let debugPrintGraph = false;
     let checkProvenance = false;
+    let debugPrintReconstitution = false;
     if (options.debug !== undefined) {
         const components = options.debug.split(",");
         for (let component of components) {
             component = component.trim();
             if (component === "print-graph") {
                 debugPrintGraph = true;
+            } else if (component === "print-reconstitution") {
+                debugPrintReconstitution = true;
             } else if (component === "provenance") {
                 checkProvenance = true;
             } else {
@@ -778,7 +781,8 @@ export async function makeQuicktypeOptions(
         outputFilename: mapOptional(path.basename, options.out),
         schemaStore: new FetchingJSONSchemaStore(),
         debugPrintGraph,
-        checkProvenance
+        checkProvenance,
+        debugPrintReconstitution
     };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import { JSONSchemaStore } from "./JSONSchemaStore";
 import { TypeInference } from "./Inference";
 import { inferMaps } from "./InferMaps";
 import { TypeBuilder } from "./TypeBuilder";
-import { TypeGraph, noneToAny, optionalToNullable } from "./TypeGraph";
+import { TypeGraph, noneToAny, optionalToNullable, removeIndirectionIntersections } from "./TypeGraph";
 import { makeNamesTypeAttributes } from "./TypeNames";
 import { makeGraphQLQueryTypes } from "./GraphQL";
 import { gatherNames } from "./GatherNames";
@@ -158,6 +158,10 @@ export class Run {
         }
 
         const debugPrintReconstitution = this._options.debugPrintReconstitution === true;
+
+        if (typeBuilder.didAddForwardingIntersection) {
+            graph = removeIndirectionIntersections(graph, stringTypeMapping, debugPrintReconstitution);
+        }
 
         let unionsDone = false;
         if (!schemaInputs.isEmpty()) {

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -219,6 +219,7 @@ export const GoLanguage: Language = {
     "6de06.json",
     "7eb30.json",
     "7681c.json",
+    "76ae1.json",
     "ae9ca.json",
     "af2d1.json",
     "be234.json",


### PR DESCRIPTION
This occurs in weird circumstances when a type that's
reconstituted refers to itself.  We take greater care not
to look at a type's children before constructing it.