### PR TITLE
Rename top-level types if absolutely necessary

### DIFF
--- a/src/ConvenienceRenderer.ts
+++ b/src/ConvenienceRenderer.ts
@@ -33,16 +33,18 @@ import { enumCaseNames, classPropertyNames, unionMemberName, getAccessorName } f
 
 const wordWrap: (s: string) => string = require("wordwrap")(90);
 
-const givenNameOrder = 1;
-const inferredNameOrder = 3;
+const topLevelNameOrder = 1;
 
-const classPropertyNameOrder = 2;
-const assignedClassPropertyNameOrder = 1;
+const givenNameOrder = 10;
+const inferredNameOrder = 30;
 
-const enumCaseNameOrder = 2;
-const assignedEnumCaseNameOrder = 1;
+const classPropertyNameOrder = 20;
+const assignedClassPropertyNameOrder = 10;
 
-const unionMemberNameOrder = 4;
+const enumCaseNameOrder = 20;
+const assignedEnumCaseNameOrder = 10;
+
+const unionMemberNameOrder = 40;
 
 function splitDescription(descriptions: OrderedSet<string> | undefined): string[] | undefined {
     if (descriptions === undefined) return undefined;
@@ -130,7 +132,6 @@ export abstract class ConvenienceRenderer extends Renderer {
         return [];
     }
 
-    protected abstract topLevelNameStyle(rawName: string): string;
     protected abstract makeNamedTypeNamer(): Namer;
     protected abstract namerForClassProperty(c: ClassType, p: ClassProperty): Namer | null;
     protected abstract makeUnionMemberNamer(): Namer | null;
@@ -234,15 +235,8 @@ export abstract class ConvenienceRenderer extends Renderer {
         }
     };
 
-    protected makeNameForTopLevel(_t: Type, givenName: string, maybeNamedType: Type | undefined): Name {
-        let styledName: string;
-        if (maybeNamedType !== undefined) {
-            styledName = defined(this._namedTypeNamer).nameStyle(givenName);
-        } else {
-            styledName = this.topLevelNameStyle(givenName);
-        }
-
-        return new FixedName(styledName);
+    protected makeNameForTopLevel(_t: Type, givenName: string, _maybeNamedType: Type | undefined): Name {
+        return new SimpleName(OrderedSet([givenName]), defined(this._namedTypeNamer), topLevelNameOrder);
     }
 
     private addNameForTopLevel = (type: Type, givenName: string): Name => {

--- a/src/Language/CPlusPlus.ts
+++ b/src/Language/CPlusPlus.ts
@@ -286,10 +286,6 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
         return { names: [], includeGlobalForbidden: true };
     }
 
-    protected topLevelNameStyle(rawName: string): string {
-        return this._typeNameStyle(rawName);
-    }
-
     protected makeNamedTypeNamer(): Namer {
         return this._typeNamingFunction;
     }

--- a/src/Language/CSharp.ts
+++ b/src/Language/CSharp.ts
@@ -167,10 +167,6 @@ export class CSharpRenderer extends ConvenienceRenderer {
         return { names: [unionNamed], includeGlobalForbidden: true };
     }
 
-    protected topLevelNameStyle(rawName: string): string {
-        return csNameStyle(rawName);
-    }
-
     protected makeNamedTypeNamer(): Namer {
         return namingFunction;
     }

--- a/src/Language/Elm.ts
+++ b/src/Language/Elm.ts
@@ -168,10 +168,6 @@ export class ElmRenderer extends ConvenienceRenderer {
         return forbiddenNames;
     }
 
-    protected topLevelNameStyle(rawName: string): string {
-        return elmNameStyle(rawName, true);
-    }
-
     protected makeTopLevelDependencyNames(t: Type, topLevelName: Name): DependencyName[] {
         const encoder = new DependencyName(
             lowerNamingFunction,

--- a/src/Language/Golang.ts
+++ b/src/Language/Golang.ts
@@ -106,10 +106,6 @@ export class GoRenderer extends ConvenienceRenderer {
         super(targetLanguage, graph, leadingComments);
     }
 
-    protected topLevelNameStyle(rawName: string): string {
-        return goNameStyle(rawName);
-    }
-
     protected makeNamedTypeNamer(): Namer {
         return namingFunction;
     }

--- a/src/Language/JSONSchema.ts
+++ b/src/Language/JSONSchema.ts
@@ -61,10 +61,6 @@ function jsonNameStyle(original: string): string {
 type Schema = { [name: string]: any };
 
 export class JSONSchemaRenderer extends ConvenienceRenderer {
-    protected topLevelNameStyle(rawName: string): string {
-        return jsonNameStyle(rawName);
-    }
-
     protected makeNamedTypeNamer(): Namer {
         return namingFunction;
     }

--- a/src/Language/Java.ts
+++ b/src/Language/Java.ts
@@ -202,10 +202,6 @@ export class JavaRenderer extends ConvenienceRenderer {
         return { names: [], includeGlobalForbidden: true };
     }
 
-    protected topLevelNameStyle(rawName: string): string {
-        return javaNameStyle(true, false, rawName);
-    }
-
     protected makeNamedTypeNamer(): Namer {
         return typeNamingFunction;
     }

--- a/src/Language/JavaScript.ts
+++ b/src/Language/JavaScript.ts
@@ -106,10 +106,6 @@ export class JavaScriptRenderer extends ConvenienceRenderer {
         super(targetLanguage, graph, leadingComments);
     }
 
-    protected topLevelNameStyle(rawName: string): string {
-        return typeNameStyle(rawName);
-    }
-
     protected makeNamedTypeNamer(): Namer {
         return new Namer("types", typeNameStyle, []);
     }

--- a/src/Language/Objective-C.ts
+++ b/src/Language/Objective-C.ts
@@ -278,10 +278,6 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
         return { names: forbiddenForEnumCases, includeGlobalForbidden: true };
     }
 
-    protected topLevelNameStyle(rawName: string): string {
-        return camelCase(rawName);
-    }
-
     protected makeNamedTypeNamer(): Namer {
         return funPrefixNamer("types", rawName => typeNameStyle(this._classPrefix, rawName));
     }

--- a/src/Language/Ruby/index.ts
+++ b/src/Language/Ruby/index.ts
@@ -146,10 +146,6 @@ export class RubyRenderer extends ConvenienceRenderer {
         return "class" === t.kind;
     }
 
-    protected topLevelNameStyle(rawName: string): string {
-        return simpleNameStyle(rawName, true);
-    }
-
     protected forbiddenNamesForGlobalNamespace(): string[] {
         return keywords.globals.concat(["Types", "JSON", "Dry", "Constructor"]);
     }

--- a/src/Language/Rust.ts
+++ b/src/Language/Rust.ts
@@ -228,10 +228,6 @@ export class RustRenderer extends ConvenienceRenderer {
         return { names: [], includeGlobalForbidden: true };
     }
 
-    protected topLevelNameStyle(rawName: string): string {
-        return rustStyle(rawName, false);
-    }
-
     protected get commentLineStart(): string {
         return "/// ";
     }

--- a/src/Language/Swift.ts
+++ b/src/Language/Swift.ts
@@ -262,10 +262,6 @@ export class SwiftRenderer extends ConvenienceRenderer {
         return { names: [], includeGlobalForbidden: true };
     }
 
-    protected topLevelNameStyle(rawName: string): string {
-        return swiftNameStyle(true, rawName);
-    }
-
     protected makeNamedTypeNamer(): Namer {
         return upperNamingFunction;
     }


### PR DESCRIPTION
With the option of making all types in a schema top-levels ,
and the same thing with TypeScript input, the likelihood
that a type name will be illegal is quite high.