### PR TITLE
Use our fork of typescript-json-schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "stream-json": "0.5.2",
     "string-to-stream": "^1.1.0",
     "typescript": "~2.6.2",
-    "typescript-json-schema": "^0.21.0",
+    "typescript-json-schema": "quicktype/typescript-json-schema",
     "unicode-properties": "quicktype/unicode-properties#dist",
     "universal-analytics": "^0.4.16",
     "urijs": "^1.19.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "stream-json": "0.5.2",
     "string-to-stream": "^1.1.0",
     "typescript": "~2.6.2",
-    "typescript-json-schema": "quicktype/typescript-json-schema",
+    "typescript-json-schema": "quicktype/typescript-json-schema#dist",
     "unicode-properties": "quicktype/unicode-properties#dist",
     "universal-analytics": "^0.4.16",
     "urijs": "^1.19.1",

--- a/script/build.ts
+++ b/script/build.ts
@@ -18,9 +18,17 @@ function mapFile(
 
 function installPrereqs() {
   shell.exec("npm install --ignore-scripts");
+
+  console.error("Restoring node_modules/typescript-json-schema.");
+  console.error("TODO remove this once upstream figures out packaging");
+  shell.exec(`cd node_modules/typescript-json-schema && npm i`);
 }
 
 function buildTypeScript() {
+  console.error("Building node_modules/typescript-json-schema.");
+  console.error("TODO remove this once upstream figures out packaging");
+  shell.exec(`cd node_modules/typescript-json-schema && npm run build`);
+
   shell.exec(`tsc --project src`);
 }
 

--- a/script/build.ts
+++ b/script/build.ts
@@ -18,17 +18,9 @@ function mapFile(
 
 function installPrereqs() {
   shell.exec("npm install --ignore-scripts");
-
-  console.error("Restoring node_modules/typescript-json-schema.");
-  console.error("TODO remove this once upstream figures out packaging");
-  shell.exec(`cd node_modules/typescript-json-schema && npm i`);
 }
 
 function buildTypeScript() {
-  console.error("Building node_modules/typescript-json-schema.");
-  console.error("TODO remove this once upstream figures out packaging");
-  shell.exec(`cd node_modules/typescript-json-schema && npm run build`);
-
   shell.exec(`tsc --project src`);
 }
 


### PR DESCRIPTION
* `quicktype` branch represents our work ahead of upstream `master`
* `dist` contains compiled JavaScript, which is required to use this library but upstream does not want in PRs.