### PR TITLE
hashable conformance

### DIFF
--- a/src/Language/Swift.ts
+++ b/src/Language/Swift.ts
@@ -392,7 +392,7 @@ export class SwiftRenderer extends ConvenienceRenderer {
     private getProtocolString = (): Sourcelike => {
         let protocols: string[] = [];
         if (this._version > 4) {
-            protocols.push("Hashable", "Equatable");
+            protocols.push("Hashable");
         }
         if (!this._justTypes) {
             protocols.push("Codable");


### PR DESCRIPTION
Since Swift 4.1, namely
- [SE-0143](https://github.com/apple/swift-evolution/blob/master/proposals/0143-conditional-conformances.md)
- [SE-0185](https://github.com/apple/swift-evolution/blob/master/proposals/0143-conditional-conformances.md)

and the fact that model is not Hashable unless it's also Equatable, as shown directly in the protocol definition
```
public protocol Hashable : Equatable {

    /// The hash value.
    ///
    /// Hash values are not guaranteed to be equal across different executions of
    /// your program. Do not save hash values to use during a future execution.
    public var hashValue: Int { get }
}
```

it's enough to conform quicktype's auto-generated models only to Hashable protocol.