### PR TITLE
Make gatherNames a lot faster and hopefully better

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "chalk": "^2.1.0",
+    "chance": "^1.0.13",
     "command-line-args": "^4.0.6",
     "command-line-usage": "^4.0.0",
     "graphql": "^0.11.7",
@@ -40,6 +41,7 @@
     "uuid": "^3.2.1"
   },
   "devDependencies": {
+    "@types/chance": "^1.0.0",
     "@types/graphql": "^0.11.7",
     "@types/handlebars": "^4.0.36",
     "@types/is-url": "^1.2.28",

--- a/src/GatherNames.ts
+++ b/src/GatherNames.ts
@@ -1,13 +1,14 @@
 "use strict";
 
-import { Set, OrderedSet, List } from "immutable";
+import { Set, OrderedSet, Map, isCollection } from "immutable";
 import * as pluralize from "pluralize";
 
 import { TypeGraph } from "./TypeGraph";
 import { matchCompoundType, Type, ObjectType } from "./Type";
-import { TypeNames, namesTypeAttributeKind } from "./TypeNames";
+import { TypeNames, namesTypeAttributeKind, TooManyTypeNames, tooManyNamesThreshold } from "./TypeNames";
+import { defined, panic } from "./Support";
 
-export function gatherNames(graph: TypeGraph): void {
+export function gatherNames(graph: TypeGraph, debugPrint: boolean): void {
     function setNames(t: Type, tn: TypeNames): void {
         graph.attributeStore.set(namesTypeAttributeKind, t, tn);
     }
@@ -18,72 +19,238 @@ export function gatherNames(graph: TypeGraph): void {
         }
     });
 
-    let processed: Set<List<any>> = Set();
+    let queue = OrderedSet<Type>();
+    // null means there are too many
+    let namesForType = Map<Type, OrderedSet<string> | null>();
 
-    function processObjectType(o: ObjectType, names: OrderedSet<string>, parentNames: OrderedSet<string> | undefined) {
-        const properties = o.getProperties().sortBy((_, n) => n);
-        properties.forEach((property, propertyName) => {
-            processType(property.type, OrderedSet([propertyName]), names);
-        });
+    function addNames(t: Type, names: OrderedSet<string> | null) {
+        const oldNames = namesForType.get(t);
+        if (oldNames === null) return;
 
-        const values = o.getAdditionalProperties();
-        if (values !== undefined) {
-            processType(values, names.map(pluralize.singular), parentNames, "value");
-        }
-    }
-
-    function processType(
-        t: Type,
-        names: OrderedSet<string>,
-        parentNames: OrderedSet<string> | undefined,
-        alternativeSuffix?: string
-    ) {
-        if (t.hasNames) {
-            const typeNames = t.getNames();
-            if (!typeNames.areInferred) {
-                names = typeNames.names;
-            }
+        let newNames: OrderedSet<string> | null;
+        if (oldNames === undefined) {
+            newNames = names;
+        } else if (names === null) {
+            newNames = null;
+        } else {
+            newNames = oldNames.union(names);
         }
 
-        const alternatives: string[] = [];
-        names.forEach(name => {
-            if (alternativeSuffix !== undefined) {
-                // FIXME: we should only add these for names we couldn't singularize
-                alternatives.push(`${name}_${alternativeSuffix}`);
+        if (newNames !== null && newNames.size >= tooManyNamesThreshold) {
+            newNames = null;
+        }
+        namesForType = namesForType.set(t, newNames);
+
+        if (oldNames !== undefined && newNames !== null) {
+            if (oldNames.size === newNames.size) {
+                return;
             }
-            if (parentNames !== undefined) {
-                alternatives.push(...parentNames.map(pn => `${pn}_${name}`).toArray());
-                // FIXME: add alternatives with the suffix here, too?
-            }
-            alternatives.push(`${name}_${t.kind}`);
-            if (parentNames !== undefined) {
-                alternatives.push(...parentNames.map(pn => `${pn}_${name}_${t.kind}`).toArray());
-                // FIXME: add alternatives with the suffix here, too?
-            }
-        });
-        const newNames = new TypeNames(names, OrderedSet(alternatives), true);
-        setNames(t, t.hasNames ? t.getNames().add(newNames) : newNames);
-        const processedEntry = List([t, names, parentNames]);
-        if (processed.has(processedEntry)) return;
-        processed = processed.add(processedEntry);
-        matchCompoundType(
-            t,
-            arrayType => {
-                processType(arrayType.items, names.map(pluralize.singular), parentNames, "element");
-            },
-            classType => processObjectType(classType, names, parentNames),
-            mapType => processObjectType(mapType, names, parentNames),
-            objectType => processObjectType(objectType, names, parentNames),
-            unionType => {
-                const members = unionType.members.sortBy(member => member.kind);
-                members.forEach(memberType => {
-                    processType(memberType, names, parentNames);
-                });
-            }
-        );
+        } else if (oldNames === newNames) {
+            return;
+        }
+
+        queue = queue.add(t);
     }
 
     graph.topLevels.forEach((t, name) => {
-        processType(t, OrderedSet([name]), undefined);
+        addNames(t, OrderedSet([name]));
+    });
+
+    while (!queue.isEmpty()) {
+        const t = defined(queue.first());
+        queue = queue.rest();
+
+        const names = defined(namesForType.get(t));
+        if (t instanceof ObjectType) {
+            const properties = t.getProperties().sortBy((_, n) => n);
+            properties.forEach((property, propertyName) => {
+                addNames(property.type, OrderedSet([propertyName]));
+            });
+
+            const values = t.getAdditionalProperties();
+            if (values !== undefined) {
+                addNames(values, names === null ? null : names.map(pluralize.singular));
+            }
+        } else {
+            matchCompoundType(
+                t,
+                arrayType => {
+                    addNames(arrayType.items, names === null ? null : names.map(pluralize.singular));
+                },
+                _classType => panic("We handled this above"),
+                _mapType => panic("We handled this above"),
+                _objectType => panic("We handled this above"),
+                unionType => {
+                    const members = unionType.members.sortBy(member => member.kind);
+                    members.forEach(memberType => {
+                        addNames(memberType, names);
+                    });
+                }
+            );
+        }
+    }
+
+    if (debugPrint) {
+        graph.allTypesUnordered().forEach(t => {
+            const names = namesForType.get(t);
+            if (names === undefined) return;
+
+            const index = t.typeRef.getIndex();
+            console.log(`${index}: ${names === null ? "*** too many ***" : names.join(" ")}`);
+        });
+    }
+
+    // null means there are too many
+    let directAlternativesForType = Map<Type, OrderedSet<string> | null>();
+
+    // FIXME: maybe do this last, so these names get considered last for naming?
+    graph.allTypesUnordered().forEach(t => {
+        const names = namesForType.get(t);
+        if (names === undefined) return;
+        if (names === null) {
+            directAlternativesForType = directAlternativesForType.set(t, null);
+            return;
+        }
+        let alternatives = directAlternativesForType.get(t);
+        if (alternatives === null) return;
+        if (alternatives === undefined) {
+            alternatives = OrderedSet();
+        }
+
+        alternatives = alternatives.union(names.map(name => `${name}_${t.kind}`));
+        directAlternativesForType = directAlternativesForType.set(t, alternatives);
+    });
+
+    let ancestorAlternativesForType = Map<Type, OrderedSet<string> | null>();
+    let pairsProcessed = Map<Type | undefined, Set<Type>>();
+
+    function addAlternatives(
+        existing: OrderedSet<string> | undefined,
+        alternatives: string[]
+    ): OrderedSet<string> | undefined | null {
+        if (alternatives.length === 0) {
+            return existing;
+        }
+
+        if (existing === undefined) {
+            existing = OrderedSet();
+        }
+        existing = existing.union(OrderedSet(alternatives));
+        if (existing.size < tooManyNamesThreshold) {
+            return existing;
+        }
+        return null;
+    }
+
+    function processType(ancestor: Type | undefined, t: Type, alternativeSuffix: string | undefined) {
+        const names = defined(namesForType.get(t));
+
+        let processedEntry = pairsProcessed.get(ancestor);
+        if (processedEntry === undefined) processedEntry = Set();
+        if (processedEntry.has(t)) return;
+        processedEntry = processedEntry.add(t);
+        pairsProcessed = pairsProcessed.set(ancestor, processedEntry);
+
+        let ancestorAlternatives = ancestorAlternativesForType.get(t);
+        let directAlternatives = directAlternativesForType.get(t);
+        if (names === null) {
+            ancestorAlternatives = null;
+            directAlternatives = null;
+        } else {
+            if (ancestor !== undefined && ancestorAlternatives !== null) {
+                const ancestorNames = namesForType.get(ancestor);
+                if (ancestorNames === null) {
+                    ancestorAlternatives = null;
+                } else if (ancestorNames !== undefined) {
+                    const alternatives: string[] = [];
+                    names.forEach(name => {
+                        alternatives.push(...ancestorNames.map(an => `${an}_${name}`).toArray());
+                        // FIXME: add alternatives with the suffix here, too?
+
+                        alternatives.push(...ancestorNames.map(an => `${an}_${name}_${t.kind}`).toArray());
+                        // FIXME: add alternatives with the suffix here, too?
+                    });
+
+                    ancestorAlternatives = addAlternatives(ancestorAlternatives, alternatives);
+                }
+            }
+
+            if (alternativeSuffix !== undefined && directAlternatives !== null) {
+                const alternatives: string[] = [];
+                names.forEach(name => {
+                    // FIXME: we should only add these for names we couldn't singularize
+                    alternatives.push(`${name}_${alternativeSuffix}`);
+                });
+
+                directAlternatives = addAlternatives(directAlternatives, alternatives);
+            }
+        }
+
+        if (ancestorAlternatives !== undefined) {
+            ancestorAlternativesForType = ancestorAlternativesForType.set(t, ancestorAlternatives);
+        }
+        if (directAlternatives !== undefined) {
+            directAlternativesForType = directAlternativesForType.set(t, directAlternatives);
+        }
+
+        if (t instanceof ObjectType) {
+            const properties = t.getProperties().sortBy((_, n) => n);
+            properties.forEach(property => processType(t, property.type, undefined));
+
+            const values = t.getAdditionalProperties();
+            if (values !== undefined) {
+                processType(t, values, "value");
+            }
+        } else {
+            matchCompoundType(
+                t,
+                arrayType => {
+                    processType(t, arrayType.items, "element");
+                },
+                _classType => panic("We handled this above"),
+                _mapType => panic("We handled this above"),
+                _objectType => panic("We handled this above"),
+                unionType => {
+                    const members = unionType.members.sortBy(member => member.kind);
+                    members.forEach(memberType => processType(t, memberType, undefined));
+                }
+            );
+        }
+    }
+
+    graph.topLevels.forEach(t => {
+        processType(undefined, t, undefined);
+    });
+
+    graph.allTypesUnordered().forEach(t => {
+        const names = namesForType.get(t);
+        if (names === undefined) return;
+
+        let typeNames: TypeNames;
+        if (names === null) {
+            typeNames = new TooManyTypeNames(true);
+        } else {
+            const ancestorAlternatives = ancestorAlternativesForType.get(t);
+            const directAlternatives = directAlternativesForType.get(t);
+
+            let alternatives: OrderedSet<string> | undefined;
+            if (ancestorAlternatives === null && directAlternatives === null) {
+                alternatives = undefined;
+            } else {
+                if (isCollection(ancestorAlternatives)) {
+                    alternatives = ancestorAlternatives;
+                } else {
+                    alternatives = OrderedSet();
+                }
+
+                if (isCollection(directAlternatives)) {
+                    alternatives = alternatives.union(directAlternatives);
+                }
+            }
+
+            typeNames = TypeNames.make(names, alternatives, true);
+        }
+
+        setNames(t, t.hasNames ? t.getNames().add(typeNames) : typeNames);
     });
 }

--- a/src/GatherNames.ts
+++ b/src/GatherNames.ts
@@ -24,6 +24,14 @@ export function gatherNames(graph: TypeGraph, debugPrint: boolean): void {
     let namesForType = Map<Type, OrderedSet<string> | null>();
 
     function addNames(t: Type, names: OrderedSet<string> | null) {
+        // Always use the type's given names if it has some
+        if (t.hasNames) {
+            const originalNames = t.getNames();
+            if (!originalNames.areInferred) {
+                names = originalNames.names;
+            }
+        }
+
         const oldNames = namesForType.get(t);
         if (oldNames === null) return;
 

--- a/src/GraphQL.ts
+++ b/src/GraphQL.ts
@@ -68,7 +68,7 @@ function makeNames(name: string, fieldName: string | null, containingTypeName: s
     if (fieldName) alternatives.push(fieldName);
     if (containingTypeName) alternatives.push(`${containingTypeName}_${name}`);
     if (fieldName && containingTypeName) alternatives.push(`${containingTypeName}_${fieldName}`);
-    return namesTypeAttributeKind.makeAttributes(new TypeNames(OrderedSet([name]), OrderedSet(alternatives), false));
+    return namesTypeAttributeKind.makeAttributes(TypeNames.make(OrderedSet([name]), OrderedSet(alternatives), false));
 }
 
 function makeNullable(
@@ -424,7 +424,7 @@ export function makeGraphQLQueryTypes(
         const dataType = query.makeType(builder, odn, queryName);
         const errorType = builder.getClassType(
             namesTypeAttributeKind.makeAttributes(
-                new TypeNames(OrderedSet(["error"]), OrderedSet(["graphQLError"]), false)
+                TypeNames.make(OrderedSet(["error"]), OrderedSet(["graphQLError"]), false)
             ),
             OrderedMap({ message: new ClassProperty(builder.getStringType(undefined, undefined), false) })
         );
@@ -432,7 +432,7 @@ export function makeGraphQLQueryTypes(
         builder.addAttributes(
             errorArray,
             namesTypeAttributeKind.makeAttributes(
-                new TypeNames(OrderedSet(["errors"]), OrderedSet(["graphQLErrors"]), false)
+                TypeNames.make(OrderedSet(["errors"]), OrderedSet(["graphQLErrors"]), false)
             )
         );
         const t = builder.getClassType(

--- a/src/JSONSchemaInput.ts
+++ b/src/JSONSchemaInput.ts
@@ -423,7 +423,7 @@ function makeAttributes(schema: StringMap, loc: Location, attributes: TypeAttrib
         }
 
         if (typeof title === "string") {
-            return new TypeNames(OrderedSet([title]), OrderedSet(), schema.$ref !== undefined);
+            return TypeNames.make(OrderedSet([title]), OrderedSet(), schema.$ref !== undefined);
         } else {
             return typeNames.makeInferred();
         }
@@ -756,7 +756,7 @@ export async function addTypesInSchema(
             const [target, newLoc] = await resolveVirtualRef(loc, virtualRef);
             const attributes = modifyTypeNames(typeAttributes, tn => {
                 if (!defined(tn).areInferred) return tn;
-                return new TypeNames(OrderedSet([newLoc.canonicalRef.name]), OrderedSet(), true);
+                return TypeNames.make(OrderedSet([newLoc.canonicalRef.name]), OrderedSet(), true);
             });
             types.push(await toType(target, newLoc, attributes));
         }

--- a/src/TypeGraph.ts
+++ b/src/TypeGraph.ts
@@ -430,9 +430,8 @@ export function optionalToNullable(
                 } else {
                     members = OrderedSet([builder.reconstituteType(t), nullType]);
                 }
-                const attributes = namesTypeAttributeKind.setDefaultInAttributes(
-                    t.getAttributes(),
-                    () => new TypeNames(OrderedSet([name]), OrderedSet(), true)
+                const attributes = namesTypeAttributeKind.setDefaultInAttributes(t.getAttributes(), () =>
+                    TypeNames.make(OrderedSet([name]), OrderedSet(), true)
                 );
                 ref = builder.getUnionType(attributes, members);
             }

--- a/src/UnifyClasses.ts
+++ b/src/UnifyClasses.ts
@@ -67,9 +67,8 @@ function getCliqueProperties(
 
     const unifiedPropertiesArray = properties.map(([name, types, isOptional]) => {
         let attributes = combineTypeAttributesOfTypes(types);
-        attributes = namesTypeAttributeKind.setDefaultInAttributes(
-            attributes,
-            () => new TypeNames(OrderedSet([name]), OrderedSet(), true)
+        attributes = namesTypeAttributeKind.setDefaultInAttributes(attributes, () =>
+            TypeNames.make(OrderedSet([name]), OrderedSet(), true)
         );
         return [name, new ClassProperty(makePropertyType(attributes, types), isOptional)] as [string, ClassProperty];
     });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -425,7 +425,8 @@ function makeOptionDefinitions(targetLanguages: TargetLanguage[]): OptionDefinit
             name: "debug",
             type: String,
             typeLabel: "OPTIONS",
-            description: "Comma separated debug options: print-graph, provenance, print-reconstitution"
+            description:
+                "Comma separated debug options: print-graph, provenance, print-reconstitution, print-gather-names"
         },
         {
             name: "telemetry",
@@ -742,6 +743,7 @@ export async function makeQuicktypeOptions(
     let debugPrintGraph = false;
     let checkProvenance = false;
     let debugPrintReconstitution = false;
+    let debugPrintGatherNames = false;
     if (options.debug !== undefined) {
         const components = options.debug.split(",");
         for (let component of components) {
@@ -750,6 +752,8 @@ export async function makeQuicktypeOptions(
                 debugPrintGraph = true;
             } else if (component === "print-reconstitution") {
                 debugPrintReconstitution = true;
+            } else if (component === "print-gather-names") {
+                debugPrintGatherNames = true;
             } else if (component === "provenance") {
                 checkProvenance = true;
             } else {
@@ -782,7 +786,8 @@ export async function makeQuicktypeOptions(
         schemaStore: new FetchingJSONSchemaStore(),
         debugPrintGraph,
         checkProvenance,
-        debugPrintReconstitution
+        debugPrintReconstitution,
+        debugPrintGatherNames
     };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import { TypeInference } from "./Inference";
 import { inferMaps } from "./InferMaps";
 import { TypeBuilder } from "./TypeBuilder";
 import { TypeGraph, noneToAny, optionalToNullable, removeIndirectionIntersections } from "./TypeGraph";
-import { makeNamesTypeAttributes } from "./TypeNames";
+import { makeNamesTypeAttributes, initTypeNames } from "./TypeNames";
 import { makeGraphQLQueryTypes } from "./GraphQL";
 import { gatherNames } from "./GatherNames";
 import { inferEnums, flattenStrings } from "./InferEnums";
@@ -64,6 +64,7 @@ export interface Options {
     debugPrintGraph: boolean;
     checkProvenance: boolean;
     debugPrintReconstitution: boolean;
+    debugPrintGatherNames: boolean;
 }
 
 const defaultOptions: Options = {
@@ -86,7 +87,8 @@ const defaultOptions: Options = {
     schemaStore: undefined,
     debugPrintGraph: false,
     checkProvenance: false,
-    debugPrintReconstitution: false
+    debugPrintReconstitution: false,
+    debugPrintGatherNames: false
 };
 
 export class Run {
@@ -244,7 +246,7 @@ export class Run {
         if (this._options.debugPrintGraph) {
             console.log("\n# gather names");
         }
-        gatherNames(graph);
+        gatherNames(graph, this._options.debugPrintGatherNames);
         if (this._options.debugPrintGraph) {
             graph.printGraph();
         }
@@ -260,6 +262,8 @@ export class Run {
     }
 
     public async run(): Promise<OrderedMap<string, SerializedRenderResult>> {
+        initTypeNames();
+
         const targetLanguage = getTargetLanguage(this._options.lang);
         let needIR =
             targetLanguage.names.indexOf("schema") < 0 ||


### PR DESCRIPTION
The complexity of the new algorithm should be lower, and we put a cap
on the number of names we gather for a type before we assign a random
name (20 currently).