### PR TITLE
Use a fixed Ubuntu version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial
+FROM ubuntu:xenial-20180412
 
 ENV workdir /app
 


### PR DESCRIPTION
So we don't have to constantly rebuild the docker image.