### PR TITLE
[Java] Fix bug that always uses 'instantiateMapper' in Converter.java even when there are multiple classes being converted.

### DIFF
--- a/src/Language/Java.ts
+++ b/src/Language/Java.ts
@@ -632,12 +632,12 @@ export class JavaRenderer extends ConvenienceRenderer {
                 );
                 this.ensureBlankLine();
                 this.emitBlock(["private static ObjectReader ", this.readerGetterName(topLevelName), "()"], () => {
-                    this.emitLine("if (", readerName, " == null) ", this.methodName("instantiate", "Mapper", topLevelName), ";");
+                    this.emitLine("if (", readerName, " == null) ", this.methodName("instantiate", "Mapper", topLevelName), "();");
                     this.emitLine("return ", readerName, ";");
                 });
                 this.ensureBlankLine();
                 this.emitBlock(["private static ObjectWriter ", this.writerGetterName(topLevelName), "()"], () => {
-                    this.emitLine("if (", writerName, " == null) ", this.methodName("instantiate", "Mapper", topLevelName), ";");
+                    this.emitLine("if (", writerName, " == null) ", this.methodName("instantiate", "Mapper", topLevelName), "();");
                     this.emitLine("return ", writerName, ";");
                 });
             });

--- a/src/Language/Java.ts
+++ b/src/Language/Java.ts
@@ -632,12 +632,12 @@ export class JavaRenderer extends ConvenienceRenderer {
                 );
                 this.ensureBlankLine();
                 this.emitBlock(["private static ObjectReader ", this.readerGetterName(topLevelName), "()"], () => {
-                    this.emitLine("if (", readerName, " == null) instantiateMapper();");
+                    this.emitLine("if (", readerName, " == null) ", this.methodName("instantiate", "Mapper", topLevelName), ";");
                     this.emitLine("return ", readerName, ";");
                 });
                 this.ensureBlankLine();
                 this.emitBlock(["private static ObjectWriter ", this.writerGetterName(topLevelName), "()"], () => {
-                    this.emitLine("if (", writerName, " == null) instantiateMapper();");
+                    this.emitLine("if (", writerName, " == null) ", this.methodName("instantiate", "Mapper", topLevelName), ";");
                     this.emitLine("return ", writerName, ";");
                 });
             });


### PR DESCRIPTION
## Issue
Converter.java would use 'instantiateMapper' method even when there were multiple classes being converted with Converter.java. This caused a compilation error because the methods available are 'instantiate{Name}Mapper' where {Name} is a name of a generated class, and instantiateMapper is not found.

## Testing
jsons contains multiple json files
`script/quicktype -o javas/* -l java jsons`
`javac ...`
> No compilation error

jsons contains a single json file
`script/quicktype -o javas/* -l java jsons`
`javac ...`
> No compliation error