### PR TITLE
Add some type attributes earlier

### DIFF
--- a/src/GraphRewriting.ts
+++ b/src/GraphRewriting.ts
@@ -89,7 +89,7 @@ export class TypeReconstituter<TBuilder extends BaseGraphRewriteBuilder> {
     }
 
     getMapType(values: TypeRef): void {
-        this.registerAndAddAttributes(this.builderForNewType().getMapType(values, this._forwardingRef));
+        this.register(this.builderForNewType().getMapType(this._typeAttributes, values, this._forwardingRef));
     }
 
     getUniqueArrayType(): void {
@@ -191,8 +191,8 @@ export abstract class BaseGraphRewriteBuilder extends TypeBuilder implements Typ
         super(stringTypeMapping, alphabetizeProperties, false, false, graphHasProvenanceAttributes);
     }
 
-    reconstituteType(t: Type, forwardingRef?: TypeRef): TypeRef {
-        return this.reconstituteTypeRef(t.typeRef, undefined, forwardingRef);
+    reconstituteType(t: Type, attributes?: TypeAttributes, forwardingRef?: TypeRef): TypeRef {
+        return this.reconstituteTypeRef(t.typeRef, attributes, forwardingRef);
     }
 
     abstract lookupTypeRefs(typeRefs: TypeRef[], forwardingRef?: TypeRef, replaceSet?: boolean): TypeRef | undefined;

--- a/src/TypeBuilder.ts
+++ b/src/TypeBuilder.ts
@@ -265,7 +265,7 @@ export class TypeBuilder {
             return this.getStringType(attributes, stringTypes, forwardingRef);
         }
         return this.getOrAddType(
-            primitiveTypeIdentity(kind, emptyTypeAttributes),
+            primitiveTypeIdentity(kind, attributes),
             tr => new PrimitiveType(tr, kind),
             attributes,
             forwardingRef
@@ -320,11 +320,11 @@ export class TypeBuilder {
         return this.addType(forwardingRef, tr => new MapType(tr, undefined), undefined);
     }
 
-    getMapType(values: TypeRef, forwardingRef?: TypeRef): TypeRef {
+    getMapType(attributes: TypeAttributes, values: TypeRef, forwardingRef?: TypeRef): TypeRef {
         return this.getOrAddType(
-            mapTypeIdentify(emptyTypeAttributes, values),
+            mapTypeIdentify(attributes, values),
             tr => new MapType(tr, values),
-            undefined,
+            attributes,
             forwardingRef
         );
     }

--- a/src/UnifyClasses.ts
+++ b/src/UnifyClasses.ts
@@ -128,9 +128,7 @@ export class UnifyUnionBuilder extends UnionBuilder<TypeBuilder & TypeLookerUp, 
                     .map(o => defined(o.getAdditionalProperties()).typeRef)
             );
             const allPropertyTypes = propertyTypes.union(additionalPropertyTypes).toArray();
-            const tref = this.typeBuilder.getMapType(this._unifyTypes(allPropertyTypes));
-            this.typeBuilder.addAttributes(tref, typeAttributes);
-            return tref;
+            return this.typeBuilder.getMapType(typeAttributes, this._unifyTypes(allPropertyTypes));
         } else {
             const [properties, additionalProperties, lostTypeAttributes] = getCliqueProperties(objectTypes, types => {
                 assert(types.size > 0, "Property has no type");

--- a/src/rewrites/InferMaps.ts
+++ b/src/rewrites/InferMaps.ts
@@ -120,7 +120,8 @@ export function inferMaps(
         // Reconstituting a type means generating the "same" type in the new
         // type graph.  Except we don't get Type objects but TypeRef objects,
         // which is a type-to-be.
-        const tref = builder.getMapType(
+        return builder.getMapType(
+            c.getAttributes(),
             unifyTypes(
                 shouldBe,
                 c.getAttributes(),
@@ -130,8 +131,6 @@ export function inferMaps(
             ),
             forwardingRef
         );
-        builder.addAttributes(tref, c.getAttributes());
-        return tref;
     }
 
     const allClasses = graph.allNamedTypesSeparated().objects.filter(o => o instanceof ClassType) as OrderedSet<

--- a/src/rewrites/ReplaceObjectType.ts
+++ b/src/rewrites/ReplaceObjectType.ts
@@ -41,9 +41,7 @@ export function replaceObjectType(
         }
 
         if (properties.isEmpty()) {
-            const tref = builder.getMapType(reconstituteAdditionalProperties(), forwardingRef);
-            builder.addAttributes(tref, attributes);
-            return tref;
+            return builder.getMapType(attributes, reconstituteAdditionalProperties(), forwardingRef);
         }
 
         if (additionalProperties.kind === "any") {
@@ -75,9 +73,7 @@ export function replaceObjectType(
             */
         }
 
-        const mapType = builder.getMapType(union, forwardingRef);
-        builder.addAttributes(mapType, attributes);
-        return mapType;
+        return builder.getMapType(attributes, union, forwardingRef);
     }
 
     const allObjectTypes = graph.allTypesUnordered().filter(t => t.kind === "object") as Set<ObjectType>;

--- a/src/rewrites/ResolveIntersections.ts
+++ b/src/rewrites/ResolveIntersections.ts
@@ -334,9 +334,7 @@ export function resolveIntersections(
             return t;
         }
         if (members.size === 1) {
-            const single = builder.reconstituteType(defined(members.first()), forwardingRef);
-            builder.addAttributes(single, intersectionAttributes);
-            return single;
+            return builder.reconstituteType(defined(members.first()), intersectionAttributes, forwardingRef);
         }
 
         const accumulator = new IntersectionAccumulator();


### PR DESCRIPTION
If we add them too late then they can't contain identity
attributes, which made it fail with deployment-target.schema.