### PR TITLE
Fix watch script directory

### DIFF
--- a/script/watch
+++ b/script/watch
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-watch "script/quicktype $@" src/quicktype-core/language
+watch "script/quicktype $@" src/

--- a/script/watch
+++ b/script/watch
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-watch "script/quicktype $@" src/language
+watch "script/quicktype $@" src/quicktype-core/language


### PR DESCRIPTION
`npm run start` doesn't work for me unless I switch the directories.
Could either @schani or @dvdsgl let me know if, with https://github.com/quicktype/quicktype/commit/23080ec8debf82cad1608deed3363cf97e05f6ff, this is the correct behavior?