### PR TITLE
Use transformation's target types in properties

### DIFF
--- a/test/inputs/schema/enum.4.json
+++ b/test/inputs/schema/enum.4.json
@@ -1,0 +1,4 @@
+{
+  "gve": "good",
+  "otherArr": ["foo", "bar", "if"]
+}

--- a/test/inputs/schema/enum.schema
+++ b/test/inputs/schema/enum.schema
@@ -1,29 +1,35 @@
 {
-    "type": "object",
-    "properties": {
-        "lvc": {
-            "enum": ["lawful", "neutral", "chaotic"]
-        },
-        "gve": {
-            "type": "string",
-            "enum": ["good", "neutral", "evil"]
-        },
-        "arr": {
-            "type": "array",
-            "items": {
-                "oneOf": [
-                    {
-                        "enum": ["foo", "bar", "if"]
-                    },
-                    {
-                        "type": "integer"
-                    }
-                ]
-            }
-        },
-        "for": {
-            "type": "string"
-        }
+  "type": "object",
+  "properties": {
+    "lvc": {
+      "enum": ["lawful", "neutral", "chaotic"]
     },
-    "required": ["gve"]
+    "gve": {
+      "type": "string",
+      "enum": ["good", "neutral", "evil"]
+    },
+    "arr": {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          {
+            "enum": ["foo", "bar", "if"]
+          },
+          {
+            "type": "integer"
+          }
+        ]
+      }
+    },
+    "otherArr": {
+      "type": "array",
+      "items": {
+        "enum": ["foo", "bar", "if"]
+      }
+    },
+    "for": {
+      "type": "string"
+    }
+  },
+  "required": ["gve"]
 }


### PR DESCRIPTION
If we don't, we end up with the non-transformed source types, such
as "string" for enums, or "object" for unions.