### PR TITLE
Don't give most type attributes to the any types

### DIFF
--- a/src/quicktype-core/Transformers.ts
+++ b/src/quicktype-core/Transformers.ts
@@ -922,6 +922,10 @@ class TransformationTypeAttributeKind extends TypeAttributeKind<Transformation> 
         super("transformation");
     }
 
+    appliesToTypeKind(_kind: TypeKind): boolean {
+        return true;
+    }
+
     get inIdentity(): boolean {
         return true;
     }

--- a/src/quicktype-core/TypeAttributes.ts
+++ b/src/quicktype-core/TypeAttributes.ts
@@ -2,11 +2,15 @@ import stringHash = require("string-hash");
 import { mapFilterMap, mapFilter, mapTranspose, mapMap } from "collection-utils";
 
 import { panic, assert } from "./support/Support";
-import { Type } from "./Type";
+import { Type, TypeKind } from "./Type";
 import { BaseGraphRewriteBuilder } from "./GraphRewriting";
 
 export class TypeAttributeKind<T> {
     constructor(readonly name: string) {}
+
+    appliesToTypeKind(kind: TypeKind): boolean {
+        return kind !== "any";
+    }
 
     combine(_attrs: T[]): T {
         return panic(`Cannot combine type attribute ${this.name}`);


### PR DESCRIPTION
If the intersection of two object types is built, all
attributes that aren't present in both types are
interesected with the "any" type.  If there are names
attached to "any", that leads to stupid naming results.

Now we only give the provenance attribute to "any".