### PR TITLE
Don't emit module exports is justTypes is true

### DIFF
--- a/src/quicktype-core/language/TypeScriptFlow.ts
+++ b/src/quicktype-core/language/TypeScriptFlow.ts
@@ -208,6 +208,14 @@ export abstract class TypeScriptFlowBaseRenderer extends JavaScriptRenderer {
         if (this._tsFlowOptions.justTypes) return;
         super.emitConvertModule();
     }
+
+    protected emitModuleExports(): void {
+        if (this._tsFlowOptions.justTypes) {
+            return;
+        } else {
+            super.emitModuleExports();
+        }
+    }
 }
 
 export class TypeScriptRenderer extends TypeScriptFlowBaseRenderer {


### PR DESCRIPTION
This fixes a issue where the `--just-types` option was ignored for flow.