### PR TITLE
Replace string-hash with a Java compatible version

### DIFF
--- a/build/quicktype-core/package-lock.json
+++ b/build/quicktype-core/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "quicktype-core",
-    "version": "4.0.0",
+    "version": "5.0.29",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -28,14 +28,8 @@
             "integrity": "sha512-WR/XtQMjTx4phclpWhfuoFURYPOwiBZD89gCCTG6RETzE70AZPAGGJ0h/t+a/E27MCVf1s2Z+wvH1pVTyckIcA==",
             "dev": true
         },
-        "@types/string-hash": {
-            "version": "1.1.1",
-            "resolved": "https://msmobilecenter.pkgs.visualstudio.com/_packaging/MobileCenter/npm/registry/@types/string-hash/-/string-hash-1.1.1.tgz",
-            "integrity": "sha512-ijt3zdHi2DmZxQpQTmozXszzDo78V4R3EdvX0jFMfnMH2ZzQSmCbaWOMPGXFUYSzSIdStv78HDjg32m5dxc+tA=="
-        },
         "@types/urijs": {
-            "version": "github:quicktype/types-urijs#a23603a04e31e883a92244bff8515e3d841a8b98",
-            "from": "github:quicktype/types-urijs"
+            "version": "github:quicktype/types-urijs#a23603a04e31e883a92244bff8515e3d841a8b98"
         },
         "acorn": {
             "version": "5.5.3",
@@ -60,7 +54,7 @@
             "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
             "dev": true,
             "requires": {
-                "sprintf-js": "~1.0.2"
+                "sprintf-js": "1.0.3"
             }
         },
         "babel-code-frame": {
@@ -69,9 +63,9 @@
             "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
             "dev": true,
             "requires": {
-                "chalk": "^1.1.3",
-                "esutils": "^2.0.2",
-                "js-tokens": "^3.0.2"
+                "chalk": "1.1.3",
+                "esutils": "2.0.2",
+                "js-tokens": "3.0.2"
             },
             "dependencies": {
                 "chalk": {
@@ -80,11 +74,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^2.2.1",
-                        "escape-string-regexp": "^1.0.2",
-                        "has-ansi": "^2.0.0",
-                        "strip-ansi": "^3.0.0",
-                        "supports-color": "^2.0.0"
+                        "ansi-styles": "2.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "2.0.0"
                     }
                 }
             }
@@ -101,7 +95,7 @@
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "dev": true,
             "requires": {
-                "balanced-match": "^1.0.0",
+                "balanced-match": "1.0.0",
                 "concat-map": "0.0.1"
             }
         },
@@ -110,10 +104,10 @@
             "resolved": "https://registry.npmjs.org/brfs/-/brfs-1.6.1.tgz",
             "integrity": "sha512-OfZpABRQQf+Xsmju8XE9bDjs+uU4vLREGolP7bDgcpsI17QREyZ4Bl+2KLxxx1kCgA0fAIhKQBaBYh+PEcCqYQ==",
             "requires": {
-                "quote-stream": "^1.0.1",
-                "resolve": "^1.1.5",
-                "static-module": "^2.2.0",
-                "through2": "^2.0.0"
+                "quote-stream": "1.0.2",
+                "resolve": "1.7.1",
+                "static-module": "2.2.5",
+                "through2": "2.0.3"
             }
         },
         "buffer-equal": {
@@ -138,9 +132,9 @@
             "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
             "dev": true,
             "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
+                "ansi-styles": "3.2.1",
+                "escape-string-regexp": "1.0.5",
+                "supports-color": "5.4.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -149,7 +143,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "^1.9.0"
+                        "color-convert": "1.9.1"
                     }
                 },
                 "supports-color": {
@@ -158,19 +152,15 @@
                     "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "3.0.0"
                     }
                 }
             }
         },
         "collection-utils": {
-            "version": "0.0.10",
-            "resolved": "https://registry.npmjs.org/collection-utils/-/collection-utils-0.0.10.tgz",
-            "integrity": "sha512-/lJDI7S9/UvFSzrFLg9k0pWOEyfLf5/3BmNrCraID4XZJ3zc3Rurok2JCcjKnVAjEQKdXjTz3CgKsCzYfJ97XQ==",
-            "requires": {
-                "@types/string-hash": "^1.1.1",
-                "string-hash": "^1.1.3"
-            }
+            "version": "0.0.12",
+            "resolved": "https://registry.npmjs.org/collection-utils/-/collection-utils-0.0.12.tgz",
+            "integrity": "sha512-WudnnB+VTgXiH5WYGtMsN8JaemvtT9aQTm+b1EVkd++oAvVx0Z6cN6UhVZ/tGKvysFiIa1IFbF9RL2QGmi2k4w=="
         },
         "color-convert": {
             "version": "1.9.1",
@@ -178,7 +168,7 @@
             "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
             "dev": true,
             "requires": {
-                "color-name": "^1.1.1"
+                "color-name": "1.1.3"
             }
         },
         "color-name": {
@@ -204,10 +194,10 @@
             "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
             "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
             "requires": {
-                "buffer-from": "^1.0.0",
-                "inherits": "^2.0.3",
-                "readable-stream": "^2.2.2",
-                "typedarray": "^0.0.6"
+                "buffer-from": "1.0.0",
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6",
+                "typedarray": "0.0.6"
             }
         },
         "convert-source-map": {
@@ -236,7 +226,7 @@
             "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
             "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
             "requires": {
-                "readable-stream": "^2.0.2"
+                "readable-stream": "2.3.6"
             }
         },
         "escape-string-regexp": {
@@ -250,11 +240,11 @@
             "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
             "integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
             "requires": {
-                "esprima": "^3.1.3",
-                "estraverse": "^4.2.0",
-                "esutils": "^2.0.2",
-                "optionator": "^0.8.1",
-                "source-map": "~0.6.1"
+                "esprima": "3.1.3",
+                "estraverse": "4.2.0",
+                "esutils": "2.0.2",
+                "optionator": "0.8.2",
+                "source-map": "0.6.1"
             }
         },
         "esprima": {
@@ -277,10 +267,10 @@
             "resolved": "https://registry.npmjs.org/falafel/-/falafel-2.1.0.tgz",
             "integrity": "sha1-lrsXdh2rqU9G0AFzizzt86Z/4Gw=",
             "requires": {
-                "acorn": "^5.0.0",
-                "foreach": "^2.0.5",
+                "acorn": "5.5.3",
+                "foreach": "2.0.5",
                 "isarray": "0.0.1",
-                "object-keys": "^1.0.6"
+                "object-keys": "1.0.11"
             },
             "dependencies": {
                 "isarray": {
@@ -317,12 +307,12 @@
             "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
             "dev": true,
             "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
+                "fs.realpath": "1.0.0",
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
             }
         },
         "has": {
@@ -330,7 +320,7 @@
             "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
             "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
             "requires": {
-                "function-bind": "^1.0.2"
+                "function-bind": "1.1.1"
             }
         },
         "has-ansi": {
@@ -339,7 +329,7 @@
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
             "dev": true,
             "requires": {
-                "ansi-regex": "^2.0.0"
+                "ansi-regex": "2.1.1"
             }
         },
         "has-flag": {
@@ -354,8 +344,8 @@
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "dev": true,
             "requires": {
-                "once": "^1.3.0",
-                "wrappy": "1"
+                "once": "1.4.0",
+                "wrappy": "1.0.2"
             }
         },
         "inherits": {
@@ -385,8 +375,8 @@
             "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
             "dev": true,
             "requires": {
-                "argparse": "^1.0.7",
-                "esprima": "^4.0.0"
+                "argparse": "1.0.10",
+                "esprima": "4.0.0"
             },
             "dependencies": {
                 "esprima": {
@@ -402,8 +392,8 @@
             "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
             "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
             "requires": {
-                "prelude-ls": "~1.1.2",
-                "type-check": "~0.3.2"
+                "prelude-ls": "1.1.2",
+                "type-check": "0.3.2"
             }
         },
         "magic-string": {
@@ -411,7 +401,7 @@
             "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
             "integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
             "requires": {
-                "vlq": "^0.2.2"
+                "vlq": "0.2.3"
             }
         },
         "merge-source-map": {
@@ -419,7 +409,7 @@
             "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.0.4.tgz",
             "integrity": "sha1-pd5GU42uhNQRTMXqArR3KmNGcB8=",
             "requires": {
-                "source-map": "^0.5.6"
+                "source-map": "0.5.7"
             },
             "dependencies": {
                 "source-map": {
@@ -435,7 +425,7 @@
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
             "dev": true,
             "requires": {
-                "brace-expansion": "^1.1.7"
+                "brace-expansion": "1.1.11"
             }
         },
         "minimist": {
@@ -459,7 +449,7 @@
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "dev": true,
             "requires": {
-                "wrappy": "1"
+                "wrappy": "1.0.2"
             }
         },
         "optionator": {
@@ -467,12 +457,12 @@
             "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
             "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
             "requires": {
-                "deep-is": "~0.1.3",
-                "fast-levenshtein": "~2.0.4",
-                "levn": "~0.3.0",
-                "prelude-ls": "~1.1.2",
-                "type-check": "~0.3.2",
-                "wordwrap": "~1.0.0"
+                "deep-is": "0.1.3",
+                "fast-levenshtein": "2.0.6",
+                "levn": "0.3.0",
+                "prelude-ls": "1.1.2",
+                "type-check": "0.3.2",
+                "wordwrap": "1.0.0"
             }
         },
         "pako": {
@@ -517,8 +507,8 @@
             "integrity": "sha1-hJY/jJwmuULhU/7rU6rnRlK34LI=",
             "requires": {
                 "buffer-equal": "0.0.1",
-                "minimist": "^1.1.3",
-                "through2": "^2.0.0"
+                "minimist": "1.2.0",
+                "through2": "2.0.3"
             }
         },
         "readable-stream": {
@@ -526,13 +516,13 @@
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
             "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
             "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "1.0.0",
+                "process-nextick-args": "2.0.0",
+                "safe-buffer": "5.1.2",
+                "string_decoder": "1.1.1",
+                "util-deprecate": "1.0.2"
             }
         },
         "resolve": {
@@ -540,7 +530,7 @@
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
             "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
             "requires": {
-                "path-parse": "^1.0.5"
+                "path-parse": "1.0.5"
             }
         },
         "safe-buffer": {
@@ -576,7 +566,7 @@
             "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.0.0.tgz",
             "integrity": "sha512-6flshd3F1Gwm+Ksxq463LtFd1liC77N/PX1FVVc3OzL3hAmo2fwHFbuArkcfi7s9rTNsLEhcRmXGFZhlgy40uw==",
             "requires": {
-                "escodegen": "^1.8.1"
+                "escodegen": "1.9.1"
             }
         },
         "static-module": {
@@ -584,20 +574,20 @@
             "resolved": "https://registry.npmjs.org/static-module/-/static-module-2.2.5.tgz",
             "integrity": "sha512-D8vv82E/Kpmz3TXHKG8PPsCPg+RAX6cbCOyvjM6x04qZtQ47EtJFVwRsdov3n5d6/6ynrOY9XB4JkaZwB2xoRQ==",
             "requires": {
-                "concat-stream": "~1.6.0",
-                "convert-source-map": "^1.5.1",
-                "duplexer2": "~0.1.4",
-                "escodegen": "~1.9.0",
-                "falafel": "^2.1.0",
-                "has": "^1.0.1",
-                "magic-string": "^0.22.4",
+                "concat-stream": "1.6.2",
+                "convert-source-map": "1.5.1",
+                "duplexer2": "0.1.4",
+                "escodegen": "1.9.1",
+                "falafel": "2.1.0",
+                "has": "1.0.1",
+                "magic-string": "0.22.5",
                 "merge-source-map": "1.0.4",
-                "object-inspect": "~1.4.0",
-                "quote-stream": "~1.0.2",
-                "readable-stream": "~2.3.3",
-                "shallow-copy": "~0.0.1",
-                "static-eval": "^2.0.0",
-                "through2": "~2.0.3"
+                "object-inspect": "1.4.1",
+                "quote-stream": "1.0.2",
+                "readable-stream": "2.3.6",
+                "shallow-copy": "0.0.1",
+                "static-eval": "2.0.0",
+                "through2": "2.0.3"
             }
         },
         "stream-json": {
@@ -605,21 +595,16 @@
             "resolved": "https://registry.npmjs.org/stream-json/-/stream-json-0.5.2.tgz",
             "integrity": "sha512-/QlOLybrc6LkH/oVgXo1lJ8oemRIze/grdpfssLn1Pm8nZVhW4VMOqDDYGaORPodQFxiDEUquQJER5LiBu8Ehg==",
             "requires": {
-                "parser-toolkit": ">=0.0.3"
+                "parser-toolkit": "0.0.5"
             }
-        },
-        "string-hash": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
-            "integrity": "sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs="
         },
         "string-to-stream": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/string-to-stream/-/string-to-stream-1.1.1.tgz",
             "integrity": "sha512-QySF2+3Rwq0SdO3s7BAp4x+c3qsClpPQ6abAmb0DGViiSBAkT5kL6JT2iyzEVP+T1SmzHrQD1TwlP9QAHCc+Sw==",
             "requires": {
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.1.0"
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6"
             }
         },
         "string_decoder": {
@@ -627,7 +612,7 @@
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
             "requires": {
-                "safe-buffer": "~5.1.0"
+                "safe-buffer": "5.1.2"
             }
         },
         "strip-ansi": {
@@ -636,7 +621,7 @@
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "dev": true,
             "requires": {
-                "ansi-regex": "^2.0.0"
+                "ansi-regex": "2.1.1"
             }
         },
         "supports-color": {
@@ -650,8 +635,8 @@
             "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
             "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
             "requires": {
-                "readable-stream": "^2.1.5",
-                "xtend": "~4.0.1"
+                "readable-stream": "2.3.6",
+                "xtend": "4.0.1"
             }
         },
         "tiny-inflate": {
@@ -671,18 +656,18 @@
             "integrity": "sha1-EeJrzLiK+gLdDZlWyuPUVAtfVMM=",
             "dev": true,
             "requires": {
-                "babel-code-frame": "^6.22.0",
-                "builtin-modules": "^1.1.1",
-                "chalk": "^2.3.0",
-                "commander": "^2.12.1",
-                "diff": "^3.2.0",
-                "glob": "^7.1.1",
-                "js-yaml": "^3.7.0",
-                "minimatch": "^3.0.4",
-                "resolve": "^1.3.2",
-                "semver": "^5.3.0",
-                "tslib": "^1.8.0",
-                "tsutils": "^2.12.1"
+                "babel-code-frame": "6.26.0",
+                "builtin-modules": "1.1.1",
+                "chalk": "2.4.1",
+                "commander": "2.15.1",
+                "diff": "3.5.0",
+                "glob": "7.1.2",
+                "js-yaml": "3.11.0",
+                "minimatch": "3.0.4",
+                "resolve": "1.7.1",
+                "semver": "5.5.0",
+                "tslib": "1.9.1",
+                "tsutils": "2.27.1"
             }
         },
         "tsutils": {
@@ -691,7 +676,7 @@
             "integrity": "sha512-AE/7uzp32MmaHvNNFES85hhUDHFdFZp6OAiZcd6y4ZKKIg6orJTm8keYWBhIhrJQH3a4LzNKat7ZPXZt5aTf6w==",
             "dev": true,
             "requires": {
-                "tslib": "^1.8.1"
+                "tslib": "1.9.1"
             }
         },
         "type-check": {
@@ -699,7 +684,7 @@
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
             "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
             "requires": {
-                "prelude-ls": "~1.1.2"
+                "prelude-ls": "1.1.2"
             }
         },
         "typedarray": {
@@ -715,10 +700,9 @@
         },
         "unicode-properties": {
             "version": "github:quicktype/unicode-properties#d5fddfea1ef9d05c6479a979e225476063e13f52",
-            "from": "github:quicktype/unicode-properties#dist",
             "requires": {
-                "brfs": "^1.4.0",
-                "unicode-trie": "^0.3.0"
+                "brfs": "1.6.1",
+                "unicode-trie": "0.3.1"
             }
         },
         "unicode-trie": {
@@ -726,8 +710,8 @@
             "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-0.3.1.tgz",
             "integrity": "sha1-1nHd3YkQGgi6w3tqUWEBBgIFIIU=",
             "requires": {
-                "pako": "^0.2.5",
-                "tiny-inflate": "^1.0.0"
+                "pako": "0.2.9",
+                "tiny-inflate": "1.0.2"
             },
             "dependencies": {
                 "pako": {

--- a/build/quicktype-core/package.in.json
+++ b/build/quicktype-core/package.in.json
@@ -14,12 +14,11 @@
     },
     "dependencies": {
         "@types/urijs": "github:quicktype/types-urijs",
-        "collection-utils": "0.0.10",
+        "collection-utils": "0.0.12",
         "js-base64": "^2.4.3",
         "pako": "^1.0.6",
         "pluralize": "^7.0.0",
         "stream-json": "0.5.2",
-        "string-hash": "^1.1.3",
         "string-to-stream": "^1.1.0",
         "unicode-properties": "github:quicktype/unicode-properties#dist",
         "urijs": "^1.19.1"
@@ -29,7 +28,6 @@
         "@types/node": "^8.10.10",
         "@types/pako": "^1.0.0",
         "@types/pluralize": "0.0.28",
-        "@types/string-hash": "^1.1.1",
         "typescript": "~2.8.3",
         "tslint": "^5.9.1"
     },

--- a/build/quicktype-graphql-input/package-lock.json
+++ b/build/quicktype-graphql-input/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "quicktype-graphql-input",
-    "version": "0.0.4",
+    "version": "0.0.7",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -15,11 +15,6 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.20.tgz",
             "integrity": "sha512-M7x8+5D1k/CuA6jhiwuSCmE8sbUWJF0wYsjcig9WrXvwUI5ArEoUBdOXpV4JcEMrLp02/QbDjw+kI+vQeKyQgg==",
             "dev": true
-        },
-        "@types/string-hash": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@types/string-hash/-/string-hash-1.1.1.tgz",
-            "integrity": "sha512-ijt3zdHi2DmZxQpQTmozXszzDo78V4R3EdvX0jFMfnMH2ZzQSmCbaWOMPGXFUYSzSIdStv78HDjg32m5dxc+tA=="
         },
         "ansi-regex": {
             "version": "2.1.1",
@@ -39,7 +34,7 @@
             "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
             "dev": true,
             "requires": {
-                "sprintf-js": "~1.0.2"
+                "sprintf-js": "1.0.3"
             }
         },
         "babel-code-frame": {
@@ -48,9 +43,9 @@
             "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
             "dev": true,
             "requires": {
-                "chalk": "^1.1.3",
-                "esutils": "^2.0.2",
-                "js-tokens": "^3.0.2"
+                "chalk": "1.1.3",
+                "esutils": "2.0.2",
+                "js-tokens": "3.0.2"
             },
             "dependencies": {
                 "chalk": {
@@ -59,11 +54,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^2.2.1",
-                        "escape-string-regexp": "^1.0.2",
-                        "has-ansi": "^2.0.0",
-                        "strip-ansi": "^3.0.0",
-                        "supports-color": "^2.0.0"
+                        "ansi-styles": "2.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "2.0.0"
                     }
                 }
             }
@@ -80,7 +75,7 @@
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "dev": true,
             "requires": {
-                "balanced-match": "^1.0.0",
+                "balanced-match": "1.0.0",
                 "concat-map": "0.0.1"
             }
         },
@@ -96,9 +91,9 @@
             "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
             "dev": true,
             "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
+                "ansi-styles": "3.2.1",
+                "escape-string-regexp": "1.0.5",
+                "supports-color": "5.4.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -107,7 +102,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "^1.9.0"
+                        "color-convert": "1.9.2"
                     }
                 },
                 "supports-color": {
@@ -116,19 +111,15 @@
                     "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "3.0.0"
                     }
                 }
             }
         },
         "collection-utils": {
-            "version": "0.0.10",
-            "resolved": "https://registry.npmjs.org/collection-utils/-/collection-utils-0.0.10.tgz",
-            "integrity": "sha512-/lJDI7S9/UvFSzrFLg9k0pWOEyfLf5/3BmNrCraID4XZJ3zc3Rurok2JCcjKnVAjEQKdXjTz3CgKsCzYfJ97XQ==",
-            "requires": {
-                "@types/string-hash": "^1.1.1",
-                "string-hash": "^1.1.3"
-            }
+            "version": "0.0.12",
+            "resolved": "https://registry.npmjs.org/collection-utils/-/collection-utils-0.0.12.tgz",
+            "integrity": "sha512-WudnnB+VTgXiH5WYGtMsN8JaemvtT9aQTm+b1EVkd++oAvVx0Z6cN6UhVZ/tGKvysFiIa1IFbF9RL2QGmi2k4w=="
         },
         "color-convert": {
             "version": "1.9.2",
@@ -193,12 +184,12 @@
             "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
             "dev": true,
             "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
+                "fs.realpath": "1.0.0",
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
             }
         },
         "graphql": {
@@ -215,7 +206,7 @@
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
             "dev": true,
             "requires": {
-                "ansi-regex": "^2.0.0"
+                "ansi-regex": "2.1.1"
             }
         },
         "has-flag": {
@@ -230,8 +221,8 @@
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "dev": true,
             "requires": {
-                "once": "^1.3.0",
-                "wrappy": "1"
+                "once": "1.4.0",
+                "wrappy": "1.0.2"
             }
         },
         "inherits": {
@@ -257,8 +248,8 @@
             "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
             "dev": true,
             "requires": {
-                "argparse": "^1.0.7",
-                "esprima": "^4.0.0"
+                "argparse": "1.0.10",
+                "esprima": "4.0.0"
             }
         },
         "minimatch": {
@@ -267,7 +258,7 @@
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
             "dev": true,
             "requires": {
-                "brace-expansion": "^1.1.7"
+                "brace-expansion": "1.1.11"
             }
         },
         "once": {
@@ -276,7 +267,7 @@
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "dev": true,
             "requires": {
-                "wrappy": "1"
+                "wrappy": "1.0.2"
             }
         },
         "path-is-absolute": {
@@ -294,16 +285,15 @@
         "quicktype-core": {
             "version": "file:../quicktype-core",
             "requires": {
-                "@types/urijs": "github:quicktype/types-urijs",
+                "@types/urijs": "1.0.1",
                 "collection-utils": "0.0.10",
-                "js-base64": "^2.4.3",
-                "pako": "^1.0.6",
-                "pluralize": "^7.0.0",
+                "js-base64": "2.4.5",
+                "pako": "1.0.6",
+                "pluralize": "7.0.0",
                 "stream-json": "0.5.2",
-                "string-hash": "^1.1.3",
-                "string-to-stream": "^1.1.0",
-                "unicode-properties": "github:quicktype/unicode-properties#dist",
-                "urijs": "^1.19.1"
+                "string-to-stream": "1.1.1",
+                "unicode-properties": "1.1.0",
+                "urijs": "1.19.1"
             },
             "dependencies": {
                 "@types/js-base64": {
@@ -328,7 +318,6 @@
                 },
                 "@types/urijs": {
                     "version": "1.0.1",
-                    "from": "github:quicktype/types-urijs",
                     "bundled": true
                 },
                 "acorn": {
@@ -347,27 +336,27 @@
                     "version": "1.0.10",
                     "bundled": true,
                     "requires": {
-                        "sprintf-js": "~1.0.2"
+                        "sprintf-js": "1.0.3"
                     }
                 },
                 "babel-code-frame": {
                     "version": "6.26.0",
                     "bundled": true,
                     "requires": {
-                        "chalk": "^1.1.3",
-                        "esutils": "^2.0.2",
-                        "js-tokens": "^3.0.2"
+                        "chalk": "1.1.3",
+                        "esutils": "2.0.2",
+                        "js-tokens": "3.0.2"
                     },
                     "dependencies": {
                         "chalk": {
                             "version": "1.1.3",
                             "bundled": true,
                             "requires": {
-                                "ansi-styles": "^2.2.1",
-                                "escape-string-regexp": "^1.0.2",
-                                "has-ansi": "^2.0.0",
-                                "strip-ansi": "^3.0.0",
-                                "supports-color": "^2.0.0"
+                                "ansi-styles": "2.2.1",
+                                "escape-string-regexp": "1.0.5",
+                                "has-ansi": "2.0.0",
+                                "strip-ansi": "3.0.1",
+                                "supports-color": "2.0.0"
                             }
                         }
                     }
@@ -380,7 +369,7 @@
                     "version": "1.1.11",
                     "bundled": true,
                     "requires": {
-                        "balanced-match": "^1.0.0",
+                        "balanced-match": "1.0.0",
                         "concat-map": "0.0.1"
                     }
                 },
@@ -388,10 +377,10 @@
                     "version": "1.6.1",
                     "bundled": true,
                     "requires": {
-                        "quote-stream": "^1.0.1",
-                        "resolve": "^1.1.5",
-                        "static-module": "^2.2.0",
-                        "through2": "^2.0.0"
+                        "quote-stream": "1.0.2",
+                        "resolve": "1.7.1",
+                        "static-module": "2.2.5",
+                        "through2": "2.0.3"
                     }
                 },
                 "buffer-equal": {
@@ -410,23 +399,23 @@
                     "version": "2.4.1",
                     "bundled": true,
                     "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
+                        "ansi-styles": "3.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.4.0"
                     },
                     "dependencies": {
                         "ansi-styles": {
                             "version": "3.2.1",
                             "bundled": true,
                             "requires": {
-                                "color-convert": "^1.9.0"
+                                "color-convert": "1.9.1"
                             }
                         },
                         "supports-color": {
                             "version": "5.4.0",
                             "bundled": true,
                             "requires": {
-                                "has-flag": "^3.0.0"
+                                "has-flag": "3.0.0"
                             }
                         }
                     }
@@ -435,15 +424,15 @@
                     "version": "0.0.10",
                     "bundled": true,
                     "requires": {
-                        "@types/string-hash": "^1.1.1",
-                        "string-hash": "^1.1.3"
+                        "@types/string-hash": "1.1.1",
+                        "string-hash": "1.1.3"
                     }
                 },
                 "color-convert": {
                     "version": "1.9.1",
                     "bundled": true,
                     "requires": {
-                        "color-name": "^1.1.1"
+                        "color-name": "1.1.3"
                     }
                 },
                 "color-name": {
@@ -462,10 +451,10 @@
                     "version": "1.6.2",
                     "bundled": true,
                     "requires": {
-                        "buffer-from": "^1.0.0",
-                        "inherits": "^2.0.3",
-                        "readable-stream": "^2.2.2",
-                        "typedarray": "^0.0.6"
+                        "buffer-from": "1.0.0",
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.6",
+                        "typedarray": "0.0.6"
                     }
                 },
                 "convert-source-map": {
@@ -488,7 +477,7 @@
                     "version": "0.1.4",
                     "bundled": true,
                     "requires": {
-                        "readable-stream": "^2.0.2"
+                        "readable-stream": "2.3.6"
                     }
                 },
                 "escape-string-regexp": {
@@ -499,11 +488,11 @@
                     "version": "1.9.1",
                     "bundled": true,
                     "requires": {
-                        "esprima": "^3.1.3",
-                        "estraverse": "^4.2.0",
-                        "esutils": "^2.0.2",
-                        "optionator": "^0.8.1",
-                        "source-map": "~0.6.1"
+                        "esprima": "3.1.3",
+                        "estraverse": "4.2.0",
+                        "esutils": "2.0.2",
+                        "optionator": "0.8.2",
+                        "source-map": "0.6.1"
                     }
                 },
                 "esprima": {
@@ -522,10 +511,10 @@
                     "version": "2.1.0",
                     "bundled": true,
                     "requires": {
-                        "acorn": "^5.0.0",
-                        "foreach": "^2.0.5",
+                        "acorn": "5.5.3",
+                        "foreach": "2.0.5",
                         "isarray": "0.0.1",
-                        "object-keys": "^1.0.6"
+                        "object-keys": "1.0.11"
                     },
                     "dependencies": {
                         "isarray": {
@@ -554,26 +543,26 @@
                     "version": "7.1.2",
                     "bundled": true,
                     "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
                     }
                 },
                 "has": {
                     "version": "1.0.1",
                     "bundled": true,
                     "requires": {
-                        "function-bind": "^1.0.2"
+                        "function-bind": "1.1.1"
                     }
                 },
                 "has-ansi": {
                     "version": "2.0.0",
                     "bundled": true,
                     "requires": {
-                        "ansi-regex": "^2.0.0"
+                        "ansi-regex": "2.1.1"
                     }
                 },
                 "has-flag": {
@@ -584,8 +573,8 @@
                     "version": "1.0.6",
                     "bundled": true,
                     "requires": {
-                        "once": "^1.3.0",
-                        "wrappy": "1"
+                        "once": "1.4.0",
+                        "wrappy": "1.0.2"
                     }
                 },
                 "inherits": {
@@ -608,8 +597,8 @@
                     "version": "3.11.0",
                     "bundled": true,
                     "requires": {
-                        "argparse": "^1.0.7",
-                        "esprima": "^4.0.0"
+                        "argparse": "1.0.10",
+                        "esprima": "4.0.0"
                     },
                     "dependencies": {
                         "esprima": {
@@ -622,22 +611,22 @@
                     "version": "0.3.0",
                     "bundled": true,
                     "requires": {
-                        "prelude-ls": "~1.1.2",
-                        "type-check": "~0.3.2"
+                        "prelude-ls": "1.1.2",
+                        "type-check": "0.3.2"
                     }
                 },
                 "magic-string": {
                     "version": "0.22.5",
                     "bundled": true,
                     "requires": {
-                        "vlq": "^0.2.2"
+                        "vlq": "0.2.3"
                     }
                 },
                 "merge-source-map": {
                     "version": "1.0.4",
                     "bundled": true,
                     "requires": {
-                        "source-map": "^0.5.6"
+                        "source-map": "0.5.7"
                     },
                     "dependencies": {
                         "source-map": {
@@ -650,7 +639,7 @@
                     "version": "3.0.4",
                     "bundled": true,
                     "requires": {
-                        "brace-expansion": "^1.1.7"
+                        "brace-expansion": "1.1.11"
                     }
                 },
                 "minimist": {
@@ -669,19 +658,19 @@
                     "version": "1.4.0",
                     "bundled": true,
                     "requires": {
-                        "wrappy": "1"
+                        "wrappy": "1.0.2"
                     }
                 },
                 "optionator": {
                     "version": "0.8.2",
                     "bundled": true,
                     "requires": {
-                        "deep-is": "~0.1.3",
-                        "fast-levenshtein": "~2.0.4",
-                        "levn": "~0.3.0",
-                        "prelude-ls": "~1.1.2",
-                        "type-check": "~0.3.2",
-                        "wordwrap": "~1.0.0"
+                        "deep-is": "0.1.3",
+                        "fast-levenshtein": "2.0.6",
+                        "levn": "0.3.0",
+                        "prelude-ls": "1.1.2",
+                        "type-check": "0.3.2",
+                        "wordwrap": "1.0.0"
                     }
                 },
                 "pako": {
@@ -717,28 +706,28 @@
                     "bundled": true,
                     "requires": {
                         "buffer-equal": "0.0.1",
-                        "minimist": "^1.1.3",
-                        "through2": "^2.0.0"
+                        "minimist": "1.2.0",
+                        "through2": "2.0.3"
                     }
                 },
                 "readable-stream": {
                     "version": "2.3.6",
                     "bundled": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.0",
+                        "safe-buffer": "5.1.2",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
                     }
                 },
                 "resolve": {
                     "version": "1.7.1",
                     "bundled": true,
                     "requires": {
-                        "path-parse": "^1.0.5"
+                        "path-parse": "1.0.5"
                     }
                 },
                 "safe-buffer": {
@@ -766,34 +755,34 @@
                     "version": "2.0.0",
                     "bundled": true,
                     "requires": {
-                        "escodegen": "^1.8.1"
+                        "escodegen": "1.9.1"
                     }
                 },
                 "static-module": {
                     "version": "2.2.5",
                     "bundled": true,
                     "requires": {
-                        "concat-stream": "~1.6.0",
-                        "convert-source-map": "^1.5.1",
-                        "duplexer2": "~0.1.4",
-                        "escodegen": "~1.9.0",
-                        "falafel": "^2.1.0",
-                        "has": "^1.0.1",
-                        "magic-string": "^0.22.4",
+                        "concat-stream": "1.6.2",
+                        "convert-source-map": "1.5.1",
+                        "duplexer2": "0.1.4",
+                        "escodegen": "1.9.1",
+                        "falafel": "2.1.0",
+                        "has": "1.0.1",
+                        "magic-string": "0.22.5",
                         "merge-source-map": "1.0.4",
-                        "object-inspect": "~1.4.0",
-                        "quote-stream": "~1.0.2",
-                        "readable-stream": "~2.3.3",
-                        "shallow-copy": "~0.0.1",
-                        "static-eval": "^2.0.0",
-                        "through2": "~2.0.3"
+                        "object-inspect": "1.4.1",
+                        "quote-stream": "1.0.2",
+                        "readable-stream": "2.3.6",
+                        "shallow-copy": "0.0.1",
+                        "static-eval": "2.0.0",
+                        "through2": "2.0.3"
                     }
                 },
                 "stream-json": {
                     "version": "0.5.2",
                     "bundled": true,
                     "requires": {
-                        "parser-toolkit": ">=0.0.3"
+                        "parser-toolkit": "0.0.5"
                     }
                 },
                 "string-hash": {
@@ -804,22 +793,22 @@
                     "version": "1.1.1",
                     "bundled": true,
                     "requires": {
-                        "inherits": "^2.0.1",
-                        "readable-stream": "^2.1.0"
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.6"
                     }
                 },
                 "string_decoder": {
                     "version": "1.1.1",
                     "bundled": true,
                     "requires": {
-                        "safe-buffer": "~5.1.0"
+                        "safe-buffer": "5.1.2"
                     }
                 },
                 "strip-ansi": {
                     "version": "3.0.1",
                     "bundled": true,
                     "requires": {
-                        "ansi-regex": "^2.0.0"
+                        "ansi-regex": "2.1.1"
                     }
                 },
                 "supports-color": {
@@ -830,8 +819,8 @@
                     "version": "2.0.3",
                     "bundled": true,
                     "requires": {
-                        "readable-stream": "^2.1.5",
-                        "xtend": "~4.0.1"
+                        "readable-stream": "2.3.6",
+                        "xtend": "4.0.1"
                     }
                 },
                 "tiny-inflate": {
@@ -846,32 +835,32 @@
                     "version": "5.10.0",
                     "bundled": true,
                     "requires": {
-                        "babel-code-frame": "^6.22.0",
-                        "builtin-modules": "^1.1.1",
-                        "chalk": "^2.3.0",
-                        "commander": "^2.12.1",
-                        "diff": "^3.2.0",
-                        "glob": "^7.1.1",
-                        "js-yaml": "^3.7.0",
-                        "minimatch": "^3.0.4",
-                        "resolve": "^1.3.2",
-                        "semver": "^5.3.0",
-                        "tslib": "^1.8.0",
-                        "tsutils": "^2.12.1"
+                        "babel-code-frame": "6.26.0",
+                        "builtin-modules": "1.1.1",
+                        "chalk": "2.4.1",
+                        "commander": "2.15.1",
+                        "diff": "3.5.0",
+                        "glob": "7.1.2",
+                        "js-yaml": "3.11.0",
+                        "minimatch": "3.0.4",
+                        "resolve": "1.7.1",
+                        "semver": "5.5.0",
+                        "tslib": "1.9.1",
+                        "tsutils": "2.27.1"
                     }
                 },
                 "tsutils": {
                     "version": "2.27.1",
                     "bundled": true,
                     "requires": {
-                        "tslib": "^1.8.1"
+                        "tslib": "1.9.1"
                     }
                 },
                 "type-check": {
                     "version": "0.3.2",
                     "bundled": true,
                     "requires": {
-                        "prelude-ls": "~1.1.2"
+                        "prelude-ls": "1.1.2"
                     }
                 },
                 "typedarray": {
@@ -884,19 +873,18 @@
                 },
                 "unicode-properties": {
                     "version": "1.1.0",
-                    "from": "github:quicktype/unicode-properties#dist",
                     "bundled": true,
                     "requires": {
-                        "brfs": "^1.4.0",
-                        "unicode-trie": "^0.3.0"
+                        "brfs": "1.6.1",
+                        "unicode-trie": "0.3.1"
                     }
                 },
                 "unicode-trie": {
                     "version": "0.3.1",
                     "bundled": true,
                     "requires": {
-                        "pako": "^0.2.5",
-                        "tiny-inflate": "^1.0.0"
+                        "pako": "0.2.9",
+                        "tiny-inflate": "1.0.2"
                     },
                     "dependencies": {
                         "pako": {
@@ -937,7 +925,7 @@
             "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
             "dev": true,
             "requires": {
-                "path-parse": "^1.0.5"
+                "path-parse": "1.0.5"
             }
         },
         "semver": {
@@ -952,18 +940,13 @@
             "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
             "dev": true
         },
-        "string-hash": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
-            "integrity": "sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs="
-        },
         "strip-ansi": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "dev": true,
             "requires": {
-                "ansi-regex": "^2.0.0"
+                "ansi-regex": "2.1.1"
             }
         },
         "supports-color": {
@@ -984,18 +967,18 @@
             "integrity": "sha1-EeJrzLiK+gLdDZlWyuPUVAtfVMM=",
             "dev": true,
             "requires": {
-                "babel-code-frame": "^6.22.0",
-                "builtin-modules": "^1.1.1",
-                "chalk": "^2.3.0",
-                "commander": "^2.12.1",
-                "diff": "^3.2.0",
-                "glob": "^7.1.1",
-                "js-yaml": "^3.7.0",
-                "minimatch": "^3.0.4",
-                "resolve": "^1.3.2",
-                "semver": "^5.3.0",
-                "tslib": "^1.8.0",
-                "tsutils": "^2.12.1"
+                "babel-code-frame": "6.26.0",
+                "builtin-modules": "1.1.1",
+                "chalk": "2.4.1",
+                "commander": "2.15.1",
+                "diff": "3.5.0",
+                "glob": "7.1.2",
+                "js-yaml": "3.12.0",
+                "minimatch": "3.0.4",
+                "resolve": "1.8.1",
+                "semver": "5.5.0",
+                "tslib": "1.9.2",
+                "tsutils": "2.27.1"
             }
         },
         "tsutils": {
@@ -1004,7 +987,7 @@
             "integrity": "sha512-AE/7uzp32MmaHvNNFES85hhUDHFdFZp6OAiZcd6y4ZKKIg6orJTm8keYWBhIhrJQH3a4LzNKat7ZPXZt5aTf6w==",
             "dev": true,
             "requires": {
-                "tslib": "^1.8.1"
+                "tslib": "1.9.2"
             }
         },
         "typescript": {

--- a/build/quicktype-graphql-input/package.in.json
+++ b/build/quicktype-graphql-input/package.in.json
@@ -13,7 +13,7 @@
     },
     "dependencies": {
         "quicktype-core": "the build script replaces this",
-        "collection-utils": "0.0.10",
+        "collection-utils": "0.0.12",
         "graphql": "^0.11.7"
     },
     "devDependencies": {

--- a/build/quicktype-typescript-input/package-lock.json
+++ b/build/quicktype-typescript-input/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "quicktype-typescript-input",
-    "version": "0.0.6",
+    "version": "0.0.8",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -27,7 +27,7 @@
             "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
             "dev": true,
             "requires": {
-                "sprintf-js": "~1.0.2"
+                "sprintf-js": "1.0.3"
             }
         },
         "babel-code-frame": {
@@ -36,9 +36,9 @@
             "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
             "dev": true,
             "requires": {
-                "chalk": "^1.1.3",
-                "esutils": "^2.0.2",
-                "js-tokens": "^3.0.2"
+                "chalk": "1.1.3",
+                "esutils": "2.0.2",
+                "js-tokens": "3.0.2"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -53,11 +53,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^2.2.1",
-                        "escape-string-regexp": "^1.0.2",
-                        "has-ansi": "^2.0.0",
-                        "strip-ansi": "^3.0.0",
-                        "supports-color": "^2.0.0"
+                        "ansi-styles": "2.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "2.0.0"
                     }
                 },
                 "strip-ansi": {
@@ -66,7 +66,7 @@
                     "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^2.0.0"
+                        "ansi-regex": "2.1.1"
                     }
                 }
             }
@@ -81,7 +81,7 @@
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "requires": {
-                "balanced-match": "^1.0.0",
+                "balanced-match": "1.0.0",
                 "concat-map": "0.0.1"
             }
         },
@@ -102,9 +102,9 @@
             "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
             "dev": true,
             "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
+                "ansi-styles": "3.2.1",
+                "escape-string-regexp": "1.0.5",
+                "supports-color": "5.4.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -113,7 +113,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "^1.9.0"
+                        "color-convert": "1.9.2"
                     }
                 },
                 "supports-color": {
@@ -122,7 +122,7 @@
                     "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "3.0.0"
                     }
                 }
             }
@@ -132,9 +132,9 @@
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
             "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
             "requires": {
-                "string-width": "^2.1.1",
-                "strip-ansi": "^4.0.0",
-                "wrap-ansi": "^2.0.0"
+                "string-width": "2.1.1",
+                "strip-ansi": "4.0.0",
+                "wrap-ansi": "2.1.0"
             }
         },
         "code-point-at": {
@@ -173,9 +173,9 @@
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
             "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
             "requires": {
-                "lru-cache": "^4.0.1",
-                "shebang-command": "^1.2.0",
-                "which": "^1.2.9"
+                "lru-cache": "4.1.3",
+                "shebang-command": "1.2.0",
+                "which": "1.3.1"
             }
         },
         "decamelize": {
@@ -212,13 +212,13 @@
             "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
             "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
             "requires": {
-                "cross-spawn": "^5.0.1",
-                "get-stream": "^3.0.0",
-                "is-stream": "^1.1.0",
-                "npm-run-path": "^2.0.0",
-                "p-finally": "^1.0.0",
-                "signal-exit": "^3.0.0",
-                "strip-eof": "^1.0.0"
+                "cross-spawn": "5.1.0",
+                "get-stream": "3.0.0",
+                "is-stream": "1.1.0",
+                "npm-run-path": "2.0.2",
+                "p-finally": "1.0.0",
+                "signal-exit": "3.0.2",
+                "strip-eof": "1.0.0"
             }
         },
         "find-up": {
@@ -226,7 +226,7 @@
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
             "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
             "requires": {
-                "locate-path": "^2.0.0"
+                "locate-path": "2.0.0"
             }
         },
         "fs.realpath": {
@@ -249,12 +249,12 @@
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
             "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
             "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
+                "fs.realpath": "1.0.0",
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
             }
         },
         "has-ansi": {
@@ -263,7 +263,7 @@
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
             "dev": true,
             "requires": {
-                "ansi-regex": "^2.0.0"
+                "ansi-regex": "2.1.1"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -285,8 +285,8 @@
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "requires": {
-                "once": "^1.3.0",
-                "wrappy": "1"
+                "once": "1.4.0",
+                "wrappy": "1.0.2"
             }
         },
         "inherits": {
@@ -326,8 +326,8 @@
             "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
             "dev": true,
             "requires": {
-                "argparse": "^1.0.7",
-                "esprima": "^4.0.0"
+                "argparse": "1.0.10",
+                "esprima": "4.0.0"
             }
         },
         "json-stable-stringify": {
@@ -335,7 +335,7 @@
             "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
             "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
             "requires": {
-                "jsonify": "~0.0.0"
+                "jsonify": "0.0.0"
             }
         },
         "jsonify": {
@@ -348,7 +348,7 @@
             "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
             "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
             "requires": {
-                "invert-kv": "^1.0.0"
+                "invert-kv": "1.0.0"
             }
         },
         "locate-path": {
@@ -356,8 +356,8 @@
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
             "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
             "requires": {
-                "p-locate": "^2.0.0",
-                "path-exists": "^3.0.0"
+                "p-locate": "2.0.0",
+                "path-exists": "3.0.0"
             }
         },
         "lru-cache": {
@@ -365,8 +365,8 @@
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
             "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
             "requires": {
-                "pseudomap": "^1.0.2",
-                "yallist": "^2.1.2"
+                "pseudomap": "1.0.2",
+                "yallist": "2.1.2"
             }
         },
         "mem": {
@@ -374,7 +374,7 @@
             "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
             "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
             "requires": {
-                "mimic-fn": "^1.0.0"
+                "mimic-fn": "1.2.0"
             }
         },
         "mimic-fn": {
@@ -387,7 +387,7 @@
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
             "requires": {
-                "brace-expansion": "^1.1.7"
+                "brace-expansion": "1.1.11"
             }
         },
         "npm-run-path": {
@@ -395,7 +395,7 @@
             "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
             "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
             "requires": {
-                "path-key": "^2.0.0"
+                "path-key": "2.0.1"
             }
         },
         "number-is-nan": {
@@ -408,7 +408,7 @@
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "requires": {
-                "wrappy": "1"
+                "wrappy": "1.0.2"
             }
         },
         "os-locale": {
@@ -416,9 +416,9 @@
             "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
             "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
             "requires": {
-                "execa": "^0.7.0",
-                "lcid": "^1.0.0",
-                "mem": "^1.1.0"
+                "execa": "0.7.0",
+                "lcid": "1.0.0",
+                "mem": "1.1.0"
             }
         },
         "p-finally": {
@@ -431,7 +431,7 @@
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
             "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
             "requires": {
-                "p-try": "^1.0.0"
+                "p-try": "1.0.0"
             }
         },
         "p-locate": {
@@ -439,7 +439,7 @@
             "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
             "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
             "requires": {
-                "p-limit": "^1.1.0"
+                "p-limit": "1.3.0"
             }
         },
         "p-try": {
@@ -476,16 +476,15 @@
         "quicktype-core": {
             "version": "file:../quicktype-core",
             "requires": {
-                "@types/urijs": "github:quicktype/types-urijs",
+                "@types/urijs": "1.0.1",
                 "collection-utils": "0.0.10",
-                "js-base64": "^2.4.3",
-                "pako": "^1.0.6",
-                "pluralize": "^7.0.0",
+                "js-base64": "2.4.5",
+                "pako": "1.0.6",
+                "pluralize": "7.0.0",
                 "stream-json": "0.5.2",
-                "string-hash": "^1.1.3",
-                "string-to-stream": "^1.1.0",
-                "unicode-properties": "github:quicktype/unicode-properties#dist",
-                "urijs": "^1.19.1"
+                "string-to-stream": "1.1.1",
+                "unicode-properties": "1.1.0",
+                "urijs": "1.19.1"
             },
             "dependencies": {
                 "@types/js-base64": {
@@ -510,7 +509,6 @@
                 },
                 "@types/urijs": {
                     "version": "1.0.1",
-                    "from": "github:quicktype/types-urijs",
                     "bundled": true
                 },
                 "acorn": {
@@ -529,27 +527,27 @@
                     "version": "1.0.10",
                     "bundled": true,
                     "requires": {
-                        "sprintf-js": "~1.0.2"
+                        "sprintf-js": "1.0.3"
                     }
                 },
                 "babel-code-frame": {
                     "version": "6.26.0",
                     "bundled": true,
                     "requires": {
-                        "chalk": "^1.1.3",
-                        "esutils": "^2.0.2",
-                        "js-tokens": "^3.0.2"
+                        "chalk": "1.1.3",
+                        "esutils": "2.0.2",
+                        "js-tokens": "3.0.2"
                     },
                     "dependencies": {
                         "chalk": {
                             "version": "1.1.3",
                             "bundled": true,
                             "requires": {
-                                "ansi-styles": "^2.2.1",
-                                "escape-string-regexp": "^1.0.2",
-                                "has-ansi": "^2.0.0",
-                                "strip-ansi": "^3.0.0",
-                                "supports-color": "^2.0.0"
+                                "ansi-styles": "2.2.1",
+                                "escape-string-regexp": "1.0.5",
+                                "has-ansi": "2.0.0",
+                                "strip-ansi": "3.0.1",
+                                "supports-color": "2.0.0"
                             }
                         }
                     }
@@ -562,7 +560,7 @@
                     "version": "1.1.11",
                     "bundled": true,
                     "requires": {
-                        "balanced-match": "^1.0.0",
+                        "balanced-match": "1.0.0",
                         "concat-map": "0.0.1"
                     }
                 },
@@ -570,10 +568,10 @@
                     "version": "1.6.1",
                     "bundled": true,
                     "requires": {
-                        "quote-stream": "^1.0.1",
-                        "resolve": "^1.1.5",
-                        "static-module": "^2.2.0",
-                        "through2": "^2.0.0"
+                        "quote-stream": "1.0.2",
+                        "resolve": "1.7.1",
+                        "static-module": "2.2.5",
+                        "through2": "2.0.3"
                     }
                 },
                 "buffer-equal": {
@@ -592,23 +590,23 @@
                     "version": "2.4.1",
                     "bundled": true,
                     "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
+                        "ansi-styles": "3.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.4.0"
                     },
                     "dependencies": {
                         "ansi-styles": {
                             "version": "3.2.1",
                             "bundled": true,
                             "requires": {
-                                "color-convert": "^1.9.0"
+                                "color-convert": "1.9.1"
                             }
                         },
                         "supports-color": {
                             "version": "5.4.0",
                             "bundled": true,
                             "requires": {
-                                "has-flag": "^3.0.0"
+                                "has-flag": "3.0.0"
                             }
                         }
                     }
@@ -617,15 +615,15 @@
                     "version": "0.0.10",
                     "bundled": true,
                     "requires": {
-                        "@types/string-hash": "^1.1.1",
-                        "string-hash": "^1.1.3"
+                        "@types/string-hash": "1.1.1",
+                        "string-hash": "1.1.3"
                     }
                 },
                 "color-convert": {
                     "version": "1.9.1",
                     "bundled": true,
                     "requires": {
-                        "color-name": "^1.1.1"
+                        "color-name": "1.1.3"
                     }
                 },
                 "color-name": {
@@ -644,10 +642,10 @@
                     "version": "1.6.2",
                     "bundled": true,
                     "requires": {
-                        "buffer-from": "^1.0.0",
-                        "inherits": "^2.0.3",
-                        "readable-stream": "^2.2.2",
-                        "typedarray": "^0.0.6"
+                        "buffer-from": "1.0.0",
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.6",
+                        "typedarray": "0.0.6"
                     }
                 },
                 "convert-source-map": {
@@ -670,7 +668,7 @@
                     "version": "0.1.4",
                     "bundled": true,
                     "requires": {
-                        "readable-stream": "^2.0.2"
+                        "readable-stream": "2.3.6"
                     }
                 },
                 "escape-string-regexp": {
@@ -681,11 +679,11 @@
                     "version": "1.9.1",
                     "bundled": true,
                     "requires": {
-                        "esprima": "^3.1.3",
-                        "estraverse": "^4.2.0",
-                        "esutils": "^2.0.2",
-                        "optionator": "^0.8.1",
-                        "source-map": "~0.6.1"
+                        "esprima": "3.1.3",
+                        "estraverse": "4.2.0",
+                        "esutils": "2.0.2",
+                        "optionator": "0.8.2",
+                        "source-map": "0.6.1"
                     }
                 },
                 "esprima": {
@@ -704,10 +702,10 @@
                     "version": "2.1.0",
                     "bundled": true,
                     "requires": {
-                        "acorn": "^5.0.0",
-                        "foreach": "^2.0.5",
+                        "acorn": "5.5.3",
+                        "foreach": "2.0.5",
                         "isarray": "0.0.1",
-                        "object-keys": "^1.0.6"
+                        "object-keys": "1.0.11"
                     },
                     "dependencies": {
                         "isarray": {
@@ -736,26 +734,26 @@
                     "version": "7.1.2",
                     "bundled": true,
                     "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
                     }
                 },
                 "has": {
                     "version": "1.0.1",
                     "bundled": true,
                     "requires": {
-                        "function-bind": "^1.0.2"
+                        "function-bind": "1.1.1"
                     }
                 },
                 "has-ansi": {
                     "version": "2.0.0",
                     "bundled": true,
                     "requires": {
-                        "ansi-regex": "^2.0.0"
+                        "ansi-regex": "2.1.1"
                     }
                 },
                 "has-flag": {
@@ -766,8 +764,8 @@
                     "version": "1.0.6",
                     "bundled": true,
                     "requires": {
-                        "once": "^1.3.0",
-                        "wrappy": "1"
+                        "once": "1.4.0",
+                        "wrappy": "1.0.2"
                     }
                 },
                 "inherits": {
@@ -790,8 +788,8 @@
                     "version": "3.11.0",
                     "bundled": true,
                     "requires": {
-                        "argparse": "^1.0.7",
-                        "esprima": "^4.0.0"
+                        "argparse": "1.0.10",
+                        "esprima": "4.0.0"
                     },
                     "dependencies": {
                         "esprima": {
@@ -804,22 +802,22 @@
                     "version": "0.3.0",
                     "bundled": true,
                     "requires": {
-                        "prelude-ls": "~1.1.2",
-                        "type-check": "~0.3.2"
+                        "prelude-ls": "1.1.2",
+                        "type-check": "0.3.2"
                     }
                 },
                 "magic-string": {
                     "version": "0.22.5",
                     "bundled": true,
                     "requires": {
-                        "vlq": "^0.2.2"
+                        "vlq": "0.2.3"
                     }
                 },
                 "merge-source-map": {
                     "version": "1.0.4",
                     "bundled": true,
                     "requires": {
-                        "source-map": "^0.5.6"
+                        "source-map": "0.5.7"
                     },
                     "dependencies": {
                         "source-map": {
@@ -832,7 +830,7 @@
                     "version": "3.0.4",
                     "bundled": true,
                     "requires": {
-                        "brace-expansion": "^1.1.7"
+                        "brace-expansion": "1.1.11"
                     }
                 },
                 "minimist": {
@@ -851,19 +849,19 @@
                     "version": "1.4.0",
                     "bundled": true,
                     "requires": {
-                        "wrappy": "1"
+                        "wrappy": "1.0.2"
                     }
                 },
                 "optionator": {
                     "version": "0.8.2",
                     "bundled": true,
                     "requires": {
-                        "deep-is": "~0.1.3",
-                        "fast-levenshtein": "~2.0.4",
-                        "levn": "~0.3.0",
-                        "prelude-ls": "~1.1.2",
-                        "type-check": "~0.3.2",
-                        "wordwrap": "~1.0.0"
+                        "deep-is": "0.1.3",
+                        "fast-levenshtein": "2.0.6",
+                        "levn": "0.3.0",
+                        "prelude-ls": "1.1.2",
+                        "type-check": "0.3.2",
+                        "wordwrap": "1.0.0"
                     }
                 },
                 "pako": {
@@ -899,28 +897,28 @@
                     "bundled": true,
                     "requires": {
                         "buffer-equal": "0.0.1",
-                        "minimist": "^1.1.3",
-                        "through2": "^2.0.0"
+                        "minimist": "1.2.0",
+                        "through2": "2.0.3"
                     }
                 },
                 "readable-stream": {
                     "version": "2.3.6",
                     "bundled": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.0",
+                        "safe-buffer": "5.1.2",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
                     }
                 },
                 "resolve": {
                     "version": "1.7.1",
                     "bundled": true,
                     "requires": {
-                        "path-parse": "^1.0.5"
+                        "path-parse": "1.0.5"
                     }
                 },
                 "safe-buffer": {
@@ -948,34 +946,34 @@
                     "version": "2.0.0",
                     "bundled": true,
                     "requires": {
-                        "escodegen": "^1.8.1"
+                        "escodegen": "1.9.1"
                     }
                 },
                 "static-module": {
                     "version": "2.2.5",
                     "bundled": true,
                     "requires": {
-                        "concat-stream": "~1.6.0",
-                        "convert-source-map": "^1.5.1",
-                        "duplexer2": "~0.1.4",
-                        "escodegen": "~1.9.0",
-                        "falafel": "^2.1.0",
-                        "has": "^1.0.1",
-                        "magic-string": "^0.22.4",
+                        "concat-stream": "1.6.2",
+                        "convert-source-map": "1.5.1",
+                        "duplexer2": "0.1.4",
+                        "escodegen": "1.9.1",
+                        "falafel": "2.1.0",
+                        "has": "1.0.1",
+                        "magic-string": "0.22.5",
                         "merge-source-map": "1.0.4",
-                        "object-inspect": "~1.4.0",
-                        "quote-stream": "~1.0.2",
-                        "readable-stream": "~2.3.3",
-                        "shallow-copy": "~0.0.1",
-                        "static-eval": "^2.0.0",
-                        "through2": "~2.0.3"
+                        "object-inspect": "1.4.1",
+                        "quote-stream": "1.0.2",
+                        "readable-stream": "2.3.6",
+                        "shallow-copy": "0.0.1",
+                        "static-eval": "2.0.0",
+                        "through2": "2.0.3"
                     }
                 },
                 "stream-json": {
                     "version": "0.5.2",
                     "bundled": true,
                     "requires": {
-                        "parser-toolkit": ">=0.0.3"
+                        "parser-toolkit": "0.0.5"
                     }
                 },
                 "string-hash": {
@@ -986,22 +984,22 @@
                     "version": "1.1.1",
                     "bundled": true,
                     "requires": {
-                        "inherits": "^2.0.1",
-                        "readable-stream": "^2.1.0"
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.6"
                     }
                 },
                 "string_decoder": {
                     "version": "1.1.1",
                     "bundled": true,
                     "requires": {
-                        "safe-buffer": "~5.1.0"
+                        "safe-buffer": "5.1.2"
                     }
                 },
                 "strip-ansi": {
                     "version": "3.0.1",
                     "bundled": true,
                     "requires": {
-                        "ansi-regex": "^2.0.0"
+                        "ansi-regex": "2.1.1"
                     }
                 },
                 "supports-color": {
@@ -1012,8 +1010,8 @@
                     "version": "2.0.3",
                     "bundled": true,
                     "requires": {
-                        "readable-stream": "^2.1.5",
-                        "xtend": "~4.0.1"
+                        "readable-stream": "2.3.6",
+                        "xtend": "4.0.1"
                     }
                 },
                 "tiny-inflate": {
@@ -1028,32 +1026,32 @@
                     "version": "5.10.0",
                     "bundled": true,
                     "requires": {
-                        "babel-code-frame": "^6.22.0",
-                        "builtin-modules": "^1.1.1",
-                        "chalk": "^2.3.0",
-                        "commander": "^2.12.1",
-                        "diff": "^3.2.0",
-                        "glob": "^7.1.1",
-                        "js-yaml": "^3.7.0",
-                        "minimatch": "^3.0.4",
-                        "resolve": "^1.3.2",
-                        "semver": "^5.3.0",
-                        "tslib": "^1.8.0",
-                        "tsutils": "^2.12.1"
+                        "babel-code-frame": "6.26.0",
+                        "builtin-modules": "1.1.1",
+                        "chalk": "2.4.1",
+                        "commander": "2.15.1",
+                        "diff": "3.5.0",
+                        "glob": "7.1.2",
+                        "js-yaml": "3.11.0",
+                        "minimatch": "3.0.4",
+                        "resolve": "1.7.1",
+                        "semver": "5.5.0",
+                        "tslib": "1.9.1",
+                        "tsutils": "2.27.1"
                     }
                 },
                 "tsutils": {
                     "version": "2.27.1",
                     "bundled": true,
                     "requires": {
-                        "tslib": "^1.8.1"
+                        "tslib": "1.9.1"
                     }
                 },
                 "type-check": {
                     "version": "0.3.2",
                     "bundled": true,
                     "requires": {
-                        "prelude-ls": "~1.1.2"
+                        "prelude-ls": "1.1.2"
                     }
                 },
                 "typedarray": {
@@ -1066,19 +1064,18 @@
                 },
                 "unicode-properties": {
                     "version": "1.1.0",
-                    "from": "github:quicktype/unicode-properties#dist",
                     "bundled": true,
                     "requires": {
-                        "brfs": "^1.4.0",
-                        "unicode-trie": "^0.3.0"
+                        "brfs": "1.6.1",
+                        "unicode-trie": "0.3.1"
                     }
                 },
                 "unicode-trie": {
                     "version": "0.3.1",
                     "bundled": true,
                     "requires": {
-                        "pako": "^0.2.5",
-                        "tiny-inflate": "^1.0.0"
+                        "pako": "0.2.9",
+                        "tiny-inflate": "1.0.2"
                     },
                     "dependencies": {
                         "pako": {
@@ -1129,7 +1126,7 @@
             "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
             "dev": true,
             "requires": {
-                "path-parse": "^1.0.5"
+                "path-parse": "1.0.5"
             }
         },
         "semver": {
@@ -1148,7 +1145,7 @@
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
             "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
             "requires": {
-                "shebang-regex": "^1.0.0"
+                "shebang-regex": "1.0.0"
             }
         },
         "shebang-regex": {
@@ -1172,8 +1169,8 @@
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
             "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
             "requires": {
-                "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^4.0.0"
+                "is-fullwidth-code-point": "2.0.0",
+                "strip-ansi": "4.0.0"
             }
         },
         "strip-ansi": {
@@ -1181,7 +1178,7 @@
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
             "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
             "requires": {
-                "ansi-regex": "^3.0.0"
+                "ansi-regex": "3.0.0"
             }
         },
         "strip-eof": {
@@ -1207,18 +1204,18 @@
             "integrity": "sha1-EeJrzLiK+gLdDZlWyuPUVAtfVMM=",
             "dev": true,
             "requires": {
-                "babel-code-frame": "^6.22.0",
-                "builtin-modules": "^1.1.1",
-                "chalk": "^2.3.0",
-                "commander": "^2.12.1",
-                "diff": "^3.2.0",
-                "glob": "^7.1.1",
-                "js-yaml": "^3.7.0",
-                "minimatch": "^3.0.4",
-                "resolve": "^1.3.2",
-                "semver": "^5.3.0",
-                "tslib": "^1.8.0",
-                "tsutils": "^2.12.1"
+                "babel-code-frame": "6.26.0",
+                "builtin-modules": "1.1.1",
+                "chalk": "2.4.1",
+                "commander": "2.15.1",
+                "diff": "3.5.0",
+                "glob": "7.1.2",
+                "js-yaml": "3.12.0",
+                "minimatch": "3.0.4",
+                "resolve": "1.8.1",
+                "semver": "5.5.0",
+                "tslib": "1.9.2",
+                "tsutils": "2.27.1"
             }
         },
         "tsutils": {
@@ -1227,7 +1224,7 @@
             "integrity": "sha512-AE/7uzp32MmaHvNNFES85hhUDHFdFZp6OAiZcd6y4ZKKIg6orJTm8keYWBhIhrJQH3a4LzNKat7ZPXZt5aTf6w==",
             "dev": true,
             "requires": {
-                "tslib": "^1.8.1"
+                "tslib": "1.9.2"
             }
         },
         "typescript": {
@@ -1237,12 +1234,11 @@
         },
         "typescript-json-schema": {
             "version": "github:quicktype/typescript-json-schema#d16083d29c8b6702c666a981fa6b21113300c059",
-            "from": "github:quicktype/typescript-json-schema#d16083d29c8b6702c666a981fa6b21113300c059",
             "requires": {
-                "glob": "~7.1.2",
-                "json-stable-stringify": "^1.0.1",
-                "typescript": "~2.8.3",
-                "yargs": "^11.0.0"
+                "glob": "7.1.2",
+                "json-stable-stringify": "1.0.1",
+                "typescript": "2.8.4",
+                "yargs": "11.0.0"
             }
         },
         "which": {
@@ -1250,7 +1246,7 @@
             "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
             "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
             "requires": {
-                "isexe": "^2.0.0"
+                "isexe": "2.0.0"
             }
         },
         "which-module": {
@@ -1263,8 +1259,8 @@
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
             "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
             "requires": {
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1"
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -1277,7 +1273,7 @@
                     "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                     "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                     "requires": {
-                        "number-is-nan": "^1.0.0"
+                        "number-is-nan": "1.0.1"
                     }
                 },
                 "string-width": {
@@ -1285,9 +1281,9 @@
                     "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
                     "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                     "requires": {
-                        "code-point-at": "^1.0.0",
-                        "is-fullwidth-code-point": "^1.0.0",
-                        "strip-ansi": "^3.0.0"
+                        "code-point-at": "1.1.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
                     }
                 },
                 "strip-ansi": {
@@ -1295,7 +1291,7 @@
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                     "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                     "requires": {
-                        "ansi-regex": "^2.0.0"
+                        "ansi-regex": "2.1.1"
                     }
                 }
             }
@@ -1320,18 +1316,18 @@
             "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.0.0.tgz",
             "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
             "requires": {
-                "cliui": "^4.0.0",
-                "decamelize": "^1.1.1",
-                "find-up": "^2.1.0",
-                "get-caller-file": "^1.0.1",
-                "os-locale": "^2.0.0",
-                "require-directory": "^2.1.1",
-                "require-main-filename": "^1.0.1",
-                "set-blocking": "^2.0.0",
-                "string-width": "^2.0.0",
-                "which-module": "^2.0.0",
-                "y18n": "^3.2.1",
-                "yargs-parser": "^9.0.2"
+                "cliui": "4.1.0",
+                "decamelize": "1.2.0",
+                "find-up": "2.1.0",
+                "get-caller-file": "1.0.2",
+                "os-locale": "2.1.0",
+                "require-directory": "2.1.1",
+                "require-main-filename": "1.0.1",
+                "set-blocking": "2.0.0",
+                "string-width": "2.1.1",
+                "which-module": "2.0.0",
+                "y18n": "3.2.1",
+                "yargs-parser": "9.0.2"
             }
         },
         "yargs-parser": {
@@ -1339,7 +1335,7 @@
             "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
             "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
             "requires": {
-                "camelcase": "^4.1.0"
+                "camelcase": "4.1.0"
             }
         }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -127,11 +127,6 @@
         "@types/node": "8.10.13"
       }
     },
-    "@types/string-hash": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@types/string-hash/-/string-hash-1.1.1.tgz",
-      "integrity": "sha512-ijt3zdHi2DmZxQpQTmozXszzDo78V4R3EdvX0jFMfnMH2ZzQSmCbaWOMPGXFUYSzSIdStv78HDjg32m5dxc+tA=="
-    },
     "@types/universal-analytics": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/@types/universal-analytics/-/universal-analytics-0.4.2.tgz",
@@ -1341,13 +1336,9 @@
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "collection-utils": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/collection-utils/-/collection-utils-0.0.11.tgz",
-      "integrity": "sha512-QoOfEwSXcEa8hs3gwUVAzUwl9ymtfTBlcTBt/ddnxWP4aAfvPuHwBXsq38v38hRp8zDVdOr9Ql8/i479Trm0Ww==",
-      "requires": {
-        "@types/string-hash": "1.1.1",
-        "string-hash": "1.1.3"
-      }
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/collection-utils/-/collection-utils-0.0.12.tgz",
+      "integrity": "sha512-WudnnB+VTgXiH5WYGtMsN8JaemvtT9aQTm+b1EVkd++oAvVx0Z6cN6UhVZ/tGKvysFiIa1IFbF9RL2QGmi2k4w=="
     },
     "collection-visit": {
       "version": "1.0.0",
@@ -6512,11 +6503,6 @@
       "requires": {
         "readable-stream": "2.3.6"
       }
-    },
-    "string-hash": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
-      "integrity": "sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs="
     },
     "string-length": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     },
     "dependencies": {
         "chalk": "^2.4.1",
-        "collection-utils": "^0.0.11",
+        "collection-utils": "^0.0.12",
         "command-line-args": "^4.0.6",
-    "command-line-usage": "^5.0.5",
+        "command-line-usage": "^5.0.5",
         "graphql": "^0.11.7",
         "is-url": "^1.2.4",
         "js-base64": "^2.4.3",
@@ -30,7 +30,6 @@
         "pako": "^1.0.6",
         "pluralize": "^7.0.0",
         "stream-json": "0.5.2",
-        "string-hash": "^1.1.3",
         "string-to-stream": "^1.1.0",
         "typescript-json-schema": "quicktype/typescript-json-schema#d16083d29c8b6702c666a981fa6b21113300c059",
         "unicode-properties": "github:quicktype/unicode-properties#dist",
@@ -40,7 +39,6 @@
     },
     "devDependencies": {
         "@types/urijs": "github:quicktype/types-urijs",
-        "@types/string-hash": "^1.1.1",
         "@types/is-url": "^1.2.28",
         "@types/jest": "^22.2.0",
         "@types/lodash": "^4.14.108",
@@ -71,7 +69,9 @@
         "@types/pako": "^1.0.0",
         "@types/pluralize": "0.0.28"
     },
-    "files": ["dist/**"],
+    "files": [
+        "dist/**"
+    ],
     "bin": "dist/cli/index.js",
     "jest": {
         "transform": {
@@ -83,6 +83,13 @@
             }
         },
         "testRegex": "(/__tests__/.*)\\.test\\.(tsx?)$",
-        "moduleFileExtensions": ["ts", "tsx", "js", "jsx", "json", "node"]
+        "moduleFileExtensions": [
+            "ts",
+            "tsx",
+            "js",
+            "jsx",
+            "json",
+            "node"
+        ]
     }
 }

--- a/src/quicktype-core/Transformers.ts
+++ b/src/quicktype-core/Transformers.ts
@@ -1,4 +1,3 @@
-import stringHash = require("string-hash");
 import {
     setUnionInto,
     areEqual,
@@ -6,7 +5,8 @@ import {
     definedMap,
     addHashCode,
     definedMapWithDefault,
-    arraySortByInto
+    arraySortByInto,
+    hashString
 } from "collection-utils";
 
 import { UnionType, Type, EnumType, PrimitiveType, TypeKind } from "./Type";
@@ -705,7 +705,7 @@ export class StringMatchTransformer extends MatchTransformer {
 
     hashCode(): number {
         const h = super.hashCode();
-        return addHashCode(h, stringHash(this.stringCase));
+        return addHashCode(h, hashString(this.stringCase));
     }
 
     protected debugDescription(): string {

--- a/src/quicktype-core/TypeAttributes.ts
+++ b/src/quicktype-core/TypeAttributes.ts
@@ -1,5 +1,4 @@
-import stringHash = require("string-hash");
-import { mapFilterMap, mapFilter, mapTranspose } from "collection-utils";
+import { mapFilterMap, mapFilter, mapTranspose, hashString } from "collection-utils";
 
 import { panic, assert } from "./support/Support";
 import { Type, TypeKind } from "./Type";
@@ -90,7 +89,7 @@ export class TypeAttributeKind<T> {
     }
 
     hashCode(): number {
-        return stringHash(this.name);
+        return hashString(this.name);
     }
 }
 

--- a/src/quicktype-core/input/CompressedJSON.ts
+++ b/src/quicktype-core/input/CompressedJSON.ts
@@ -1,7 +1,6 @@
 import * as stream from "stream";
 
-import stringHash = require("string-hash");
-import { addHashCode, hashCodeInit } from "collection-utils";
+import { addHashCode, hashCodeInit, hashString } from "collection-utils";
 
 import { defined, panic, assert } from "../support/Support";
 import { inferTransformedStringTypeKindForString } from "../StringTypes";
@@ -275,11 +274,11 @@ export class CompressedJSON {
     hashCode = (): number => {
         let hashAccumulator = hashCodeInit;
         for (const s of this._strings) {
-            hashAccumulator = addHashCode(hashAccumulator, stringHash(s));
+            hashAccumulator = addHashCode(hashAccumulator, hashString(s));
         }
 
         for (const s of Object.getOwnPropertyNames(this._stringIndexes).sort()) {
-            hashAccumulator = addHashCode(hashAccumulator, stringHash(s));
+            hashAccumulator = addHashCode(hashAccumulator, hashString(s));
             hashAccumulator = addHashCode(hashAccumulator, this._stringIndexes[s]);
         }
 

--- a/src/quicktype-core/input/JSONSchemaInput.ts
+++ b/src/quicktype-core/input/JSONSchemaInput.ts
@@ -1,6 +1,5 @@
 import * as pluralize from "pluralize";
 import * as URI from "urijs";
-import stringHash = require("string-hash");
 import {
     setFilter,
     EqualityMap,
@@ -19,7 +18,8 @@ import {
     hasOwnProperty,
     definedMap,
     addHashCode,
-    iterableFirst
+    iterableFirst,
+    hashString
 } from "collection-utils";
 
 import {
@@ -326,7 +326,7 @@ export class Ref {
                     acc = addHashCode(acc, pe.index);
                     break;
                 case PathElementKind.KeyOrIndex:
-                    acc = addHashCode(acc, stringHash(pe.key));
+                    acc = addHashCode(acc, hashString(pe.key));
                     break;
                 default:
                     break;
@@ -1092,7 +1092,7 @@ export class JSONSchemaInput implements Input<JSONSchemaSourceData> {
             enumValuesAttributeProducer,
             minMaxAttributeProducer,
             minMaxLengthAttributeProducer,
-            patternAttributeProducer,
+            patternAttributeProducer
         ].concat(additionalAttributeProducers);
     }
 


### PR DESCRIPTION
It is faster, removes a dependency that is unmaintained and license-less,
and doesnt make it harder to maintain.

See https://github.com/quicktype/collection-utils/pull/3