### PR TITLE
Don't singularize property type names in JSON Schema

### DIFF
--- a/src/quicktype-core/input/JSONSchemaInput.ts
+++ b/src/quicktype-core/input/JSONSchemaInput.ts
@@ -1,4 +1,3 @@
-import * as pluralize from "pluralize";
 import * as URI from "urijs";
 import {
     setFilter,
@@ -643,7 +642,7 @@ async function addTypesInSchema(
             const t = await toType(
                 checkJSONSchema(propSchema, propLoc.canonicalRef),
                 propLoc,
-                makeNamesTypeAttributes(pluralize.singular(propName), true)
+                makeNamesTypeAttributes(propName, true)
             );
             const isOptional = !required.has(propName);
             return typeBuilder.makeClassProperty(t, isOptional);


### PR DESCRIPTION
Only types of array and map items should be singularized.