### PR TITLE
Option to make Swift types conform to Equatable and/or Hashable

### DIFF
--- a/src/quicktype-core/language/Swift.ts
+++ b/src/quicktype-core/language/Swift.ts
@@ -59,8 +59,8 @@ export const swiftOptions = {
         "internal",
         "secondary"
     ),
-    equatable: new BooleanOption("equatable", "Types conform to the Equatable protocol.", false),
-    hashable: new BooleanOption("hashable", "Types conform to the Hashable protocol.", false)
+    equatable: new BooleanOption("equatable", "Make types Equatable", false, "secondary"),
+    hashable: new BooleanOption("hashable", "Make types Hashable", false, "secondary")
 };
 
 // These are all recognized by Swift as ISO8601 date-times:

--- a/src/quicktype-core/language/Swift.ts
+++ b/src/quicktype-core/language/Swift.ts
@@ -860,11 +860,11 @@ encoder.dateEncodingStrategy = .formatted(formatter)`);
             this.ensureBlankLine();
             this.emitMultiline(`${this.accessLevel}class JSONNull: Codable, Hashable {
     
-    static func == (lhs: JSONNull, rhs: JSONNull) -> Bool {
+    public static func == (lhs: JSONNull, rhs: JSONNull) -> Bool {
         return true
     }
                 
-    var hashValue: Int {
+    public var hashValue: Int {
         return 0
     }
 

--- a/src/quicktype-core/language/Swift.ts
+++ b/src/quicktype-core/language/Swift.ts
@@ -458,7 +458,7 @@ export class SwiftRenderer extends ConvenienceRenderer {
     };
 
     private getProtocolString = (): Sourcelike => {
-        let protocols: string[] = [];
+        const protocols: string[] = [];
         if (!this._options.justTypes) {
             protocols.push("Codable");
         }
@@ -708,7 +708,7 @@ encoder.dateEncodingStrategy = .formatted(formatter)`);
     private renderEnumDefinition = (e: EnumType, enumName: Name): void => {
         this.emitDescription(this.descriptionForType(e));
 
-        let protocols: string[] = [];
+        const protocols: string[] = [];
         if (!this._options.justTypes) {
             protocols.push("String"); // Not a protocol
             protocols.push("Codable");
@@ -722,7 +722,7 @@ encoder.dateEncodingStrategy = .formatted(formatter)`);
             protocols.push("Hashable");
         }
 
-        let protocolString = protocols.length > 0 ? ": " + protocols.join(", ") : "";
+        const protocolString = protocols.length > 0 ? ": " + protocols.join(", ") : "";
 
         if (this._options.justTypes) {
             this.emitBlockWithAccess(["enum ", enumName, protocolString], () => {

--- a/src/quicktype-core/language/Swift.ts
+++ b/src/quicktype-core/language/Swift.ts
@@ -59,7 +59,7 @@ export const swiftOptions = {
         "internal",
         "secondary"
     ),
-    equatable: new BooleanOption("equatable", "Make types Equatable", false, "secondary"),
+    equatable: new BooleanOption("equatable", "Make types Equatable", true, "secondary"),
     hashable: new BooleanOption("hashable", "Make types Hashable", false, "secondary")
 };
 

--- a/src/quicktype-core/language/Swift.ts
+++ b/src/quicktype-core/language/Swift.ts
@@ -447,6 +447,13 @@ export class SwiftRenderer extends ConvenienceRenderer {
                     this.emitLine("//   }");
                 });
             }
+
+            if (this._options.protocol.hashable || this._options.protocol.equatable) {
+                this.emitLine("//");
+                this.emitLine("// Hashable or Equatable:");
+                this.emitLine("// The compiler will not be able to synthesize conformance to Hashable or Equatable");
+                this.emitLine("// for types that require the use of JSONAny.");
+            }
         }
         this.ensureBlankLine();
         this.emitLine("import Foundation");

--- a/src/quicktype-core/language/Swift.ts
+++ b/src/quicktype-core/language/Swift.ts
@@ -463,12 +463,11 @@ export class SwiftRenderer extends ConvenienceRenderer {
             protocols.push("Codable");
         }
 
-        if (this._options.equatable) {
-            protocols.push("Equatable");
-        }
-
+        // Hashable implies Equatable, so only one is necessary.
         if (this._options.hashable) {
             protocols.push("Hashable");
+        } else if (this._options.equatable) {
+            protocols.push("Equatable");
         }
 
         return protocols.length > 0 ? ": " + protocols.join(", ") : "";
@@ -714,12 +713,11 @@ encoder.dateEncodingStrategy = .formatted(formatter)`);
             protocols.push("Codable");
         }
 
-        if (this._options.equatable) {
-            protocols.push("Equatable");
-        }
-
+        // Hashable implies Equatable, so only one is necessary.
         if (this._options.hashable) {
             protocols.push("Hashable");
+        } else if (this._options.equatable) {
+            protocols.push("Equatable");
         }
 
         const protocolString = protocols.length > 0 ? ": " + protocols.join(", ") : "";

--- a/src/quicktype-core/language/Swift.ts
+++ b/src/quicktype-core/language/Swift.ts
@@ -854,7 +854,16 @@ encoder.dateEncodingStrategy = .formatted(formatter)`);
         if (this._needAny || this._needNull) {
             this.emitMark("Encode/decode helpers");
             this.ensureBlankLine();
-            this.emitMultiline(`${this.accessLevel}class JSONNull: Codable {
+            this.emitMultiline(`${this.accessLevel}class JSONNull: Codable, Hashable {
+    
+    static func == (lhs: JSONNull, rhs: JSONNull) -> Bool {
+        return true
+    }
+                
+    var hashValue: Int {
+        return 0
+    }
+
     public init() {}
     
     public required init(from decoder: Decoder) throws {

--- a/src/quicktype-core/language/Swift.ts
+++ b/src/quicktype-core/language/Swift.ts
@@ -63,7 +63,7 @@ export const swiftOptions = {
         ["none", { equatable: false, hashable: false }],
         ["equatable", { equatable: true, hashable: false }],
         ["hashable", { equatable: false, hashable: true }]
-    ])
+    ], "none", "secondary")
 };
 
 // These are all recognized by Swift as ISO8601 date-times:

--- a/src/quicktype-core/language/Swift.ts
+++ b/src/quicktype-core/language/Swift.ts
@@ -59,8 +59,11 @@ export const swiftOptions = {
         "internal",
         "secondary"
     ),
-    equatable: new BooleanOption("equatable", "Make types Equatable", true, "secondary"),
-    hashable: new BooleanOption("hashable", "Make types Hashable", false, "secondary")
+    protocol: new EnumOption("protocol", "Make types implement protocol", [
+        ["none", { equatable: false, hashable: false }],
+        ["equatable", { equatable: true, hashable: false }],
+        ["hashable", { equatable: false, hashable: true }]
+    ])
 };
 
 // These are all recognized by Swift as ISO8601 date-times:
@@ -98,8 +101,7 @@ export class SwiftTargetLanguage extends TargetLanguage {
             swiftOptions.alamofire,
             swiftOptions.linux,
             swiftOptions.namedTypePrefix,
-            swiftOptions.equatable,
-            swiftOptions.hashable
+            swiftOptions.protocol,
         ];
     }
 
@@ -463,10 +465,11 @@ export class SwiftRenderer extends ConvenienceRenderer {
             protocols.push("Codable");
         }
 
-        // Hashable implies Equatable, so only one is necessary.
-        if (this._options.hashable) {
+        if (this._options.protocol.hashable) {
             protocols.push("Hashable");
-        } else if (this._options.equatable) {
+        }
+
+        if (this._options.protocol.equatable) {
             protocols.push("Equatable");
         }
 
@@ -713,10 +716,11 @@ encoder.dateEncodingStrategy = .formatted(formatter)`);
             protocols.push("Codable");
         }
 
-        // Hashable implies Equatable, so only one is necessary.
-        if (this._options.hashable) {
+        if (this._options.protocol.hashable) {
             protocols.push("Hashable");
-        } else if (this._options.equatable) {
+        }
+
+        if (this._options.protocol.equatable) {
             protocols.push("Equatable");
         }
 

--- a/src/quicktype-core/language/Swift.ts
+++ b/src/quicktype-core/language/Swift.ts
@@ -451,8 +451,9 @@ export class SwiftRenderer extends ConvenienceRenderer {
             if (this._options.protocol.hashable || this._options.protocol.equatable) {
                 this.emitLine("//");
                 this.emitLine("// Hashable or Equatable:");
-                this.emitLine("// The compiler will not be able to synthesize conformance to Hashable or Equatable");
-                this.emitLine("// for types that require the use of JSONAny.");
+                this.emitLine("// The compiler will not be able to synthesize the implementation of Hashable or Equatable");
+                this.emitLine("// for types that require the use of JSONAny, nor will the implementation of Hashable be");
+                this.emitLine("// synthesized for types that have collections (such as arrays or dictionaries).");
             }
         }
         this.ensureBlankLine();

--- a/test/inputs/json/samples/simple-object.json
+++ b/test/inputs/json/samples/simple-object.json
@@ -1,0 +1,5 @@
+{
+    "title": "Lorem ipsum",
+    "date": 1500137916,
+    "validity": false
+}

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -476,9 +476,8 @@ export const SwiftLanguage: Language = {
     { "url-session": "true" },
     { "access-level": "internal" },
     { "access-level": "public" },
-    { "protocol": "none" },
     { "protocol": "equatable" },
-    { "protocol": "hashable" }
+    ["simple-object.json", { "protocol": "hashable" }]
   ],
   sourceFiles: ["src/language/Swift.ts"]
 };

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -475,7 +475,11 @@ export const SwiftLanguage: Language = {
     { density: "normal" },
     { "url-session": "true" },
     { "access-level": "internal" },
-    { "access-level": "public" }
+    { "access-level": "public" },
+    { "equatable": "true" },
+    { "equatable": "false" },
+    { "hashable": "true" },
+    { "hashable": "false" }
   ],
   sourceFiles: ["src/language/Swift.ts"]
 };

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -476,10 +476,9 @@ export const SwiftLanguage: Language = {
     { "url-session": "true" },
     { "access-level": "internal" },
     { "access-level": "public" },
-    { "equatable": "true" },
-    { "equatable": "false" },
-    { "hashable": "true" },
-    { "hashable": "false" }
+    { "protocol": "none" },
+    { "protocol": "equatable" },
+    { "protocol": "hashable" }
   ],
   sourceFiles: ["src/language/Swift.ts"]
 };


### PR DESCRIPTION
In response to #794 .

This adds two CLI options for Swift targets.
`--equatable` makes types conform to `Equatable` and `--hashable` makes types conform to `Hashable`. Having the two as separate options allows for more flexibility.

In Swift 4.1, the implementation of these protocols will (in some cases) be synthesized by the compiler. 