### PR TITLE
Remove the BOM from JSON input

### DIFF
--- a/src/cli/NodeIO.ts
+++ b/src/cli/NodeIO.ts
@@ -14,7 +14,7 @@ export async function readableFromFileOrURL(fileOrURL: string): Promise<Readable
             const response = await fetch(fileOrURL);
             return response.body;
         } else if (fs.existsSync(fileOrURL)) {
-            return fs.createReadStream(fileOrURL);
+            return fs.createReadStream(fileOrURL, "utf8");
         }
     } catch (e) {
         const message = typeof e.message === "string" ? e.message : "Unknown error";

--- a/src/quicktype-core/support/Support.ts
+++ b/src/quicktype-core/support/Support.ts
@@ -110,6 +110,10 @@ export function inflateBase64(encoded: string): string {
 
 export function parseJSON(text: string, description: string, address: string = "<unknown>"): any {
     try {
+        // https://gist.github.com/pbakondy/f5045eff725193dad9c7
+        if (text.charCodeAt(0) === 0xfeff) {
+            text = text.slice(1);
+        }
         return JSON.parse(text);
     } catch (e) {
         let message: string;


### PR DESCRIPTION
This isn't technically required, since the JSON RFC forbids BOMs in
JSON, but it doesn't cost us anything, and we fail with a terrible error
message if a BOM is present.