### PR TITLE
Support Sourcelike descriptions

### DIFF
--- a/src/quicktype-core/ConvenienceRenderer.ts
+++ b/src/quicktype-core/ConvenienceRenderer.ts
@@ -793,7 +793,7 @@ export abstract class ConvenienceRenderer extends Renderer {
     }
 
     protected emitCommentLines(
-        lines: string[],
+        lines: Sourcelike[],
         lineStart?: string,
         beforeLine?: string,
         afterLine?: string,
@@ -811,10 +811,10 @@ export abstract class ConvenienceRenderer extends Renderer {
         let first = true;
         for (const line of lines) {
             let start = first ? firstLineStart : lineStart;
-            if (line === "") {
+            if (this.sourcelikeToString(line) === "") {
                 start = trimEnd(start);
             }
-            this.emitLine(start, trimEnd(line));
+            this.emitLine(start, line);
             first = false;
         }
         if (afterLine !== undefined) {
@@ -822,13 +822,13 @@ export abstract class ConvenienceRenderer extends Renderer {
         }
     }
 
-    protected emitDescription(description: string[] | undefined): void {
+    protected emitDescription(description: Sourcelike[] | undefined): void {
         if (description === undefined) return;
         // FIXME: word-wrap
         this.emitDescriptionBlock(description);
     }
 
-    protected emitDescriptionBlock(lines: string[]): void {
+    protected emitDescriptionBlock(lines: Sourcelike[]): void {
         this.emitCommentLines(lines);
     }
 

--- a/src/quicktype-core/language/CPlusPlus.ts
+++ b/src/quicktype-core/language/CPlusPlus.ts
@@ -544,7 +544,7 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
         return kind === "class";
     }
 
-    protected emitDescriptionBlock(lines: string[]): void {
+    protected emitDescriptionBlock(lines: Sourcelike[]): void {
         this.emitCommentLines(lines, " * ", "/**", " */");
     }
 

--- a/src/quicktype-core/language/CSharp.ts
+++ b/src/quicktype-core/language/CSharp.ts
@@ -374,7 +374,7 @@ export class CSharpRenderer extends ConvenienceRenderer {
         return ["public ", csType, " ", name, " { get; set; }"];
     }
 
-    protected emitDescriptionBlock(lines: string[]): void {
+    protected emitDescriptionBlock(lines: Sourcelike[]): void {
         const start = "/// <summary>";
         if (this._csOptions.dense) {
             this.emitLine(start, lines.join("; "), "</summary>");

--- a/src/quicktype-core/language/Dart.ts
+++ b/src/quicktype-core/language/Dart.ts
@@ -274,7 +274,7 @@ export class DartRenderer extends ConvenienceRenderer {
         this.emitLine("import 'dart:convert';");
     }
 
-    protected emitDescriptionBlock(lines: string[]): void {
+    protected emitDescriptionBlock(lines: Sourcelike[]): void {
         this.emitCommentLines(lines, " * ", "/**", " */");
     }
 

--- a/src/quicktype-core/language/Elm.ts
+++ b/src/quicktype-core/language/Elm.ts
@@ -224,7 +224,7 @@ export class ElmRenderer extends ConvenienceRenderer {
         return "-- ";
     }
 
-    protected emitDescriptionBlock(lines: string[]): void {
+    protected emitDescriptionBlock(lines: Sourcelike[]): void {
         if (lines.length === 1) {
             this.emitLine("{-| ", lines[0], " -}");
         } else {

--- a/src/quicktype-core/language/Java.ts
+++ b/src/quicktype-core/language/Java.ts
@@ -295,7 +295,7 @@ export class JavaRenderer extends ConvenienceRenderer {
         this.ensureBlankLine();
     }
 
-    protected emitDescriptionBlock(lines: string[]): void {
+    protected emitDescriptionBlock(lines: Sourcelike[]): void {
         this.emitCommentLines(lines, " * ", "/**", " */");
     }
 

--- a/src/quicktype-core/language/JavaScript.ts
+++ b/src/quicktype-core/language/JavaScript.ts
@@ -123,7 +123,7 @@ export class JavaScriptRenderer extends ConvenienceRenderer {
         return super.makeNameForProperty(c, className, p, jsonName, undefined);
     }
 
-    protected emitDescriptionBlock(lines: string[]): void {
+    protected emitDescriptionBlock(lines: Sourcelike[]): void {
         this.emitCommentLines(lines, " * ", "/**", " */");
     }
 

--- a/src/quicktype-core/language/Kotlin.ts
+++ b/src/quicktype-core/language/Kotlin.ts
@@ -206,7 +206,7 @@ export class KotlinRenderer extends ConvenienceRenderer {
         return upperNamingFunction;
     }
 
-    protected emitDescriptionBlock(lines: string[]): void {
+    protected emitDescriptionBlock(lines: Sourcelike[]): void {
         this.emitCommentLines(lines, " * ", "/**", " */");
     }
 

--- a/src/quicktype-core/language/Objective-C.ts
+++ b/src/quicktype-core/language/Objective-C.ts
@@ -293,7 +293,7 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
         return type;
     }
 
-    protected emitDescriptionBlock(lines: string[]): void {
+    protected emitDescriptionBlock(lines: Sourcelike[]): void {
         this.emitCommentLines(lines, "/// ");
     }
 

--- a/src/quicktype-core/language/Python.ts
+++ b/src/quicktype-core/language/Python.ts
@@ -272,7 +272,7 @@ export class PythonRenderer extends ConvenienceRenderer {
         return "# ";
     }
 
-    protected emitDescriptionBlock(lines: string[]): void {
+    protected emitDescriptionBlock(lines: Sourcelike[]): void {
         if (lines.length === 1) {
             this.emitLine('"""', lines[0], '"""');
         } else {

--- a/src/quicktype-core/language/Swift.ts
+++ b/src/quicktype-core/language/Swift.ts
@@ -313,7 +313,7 @@ export class SwiftRenderer extends ConvenienceRenderer {
         return kind === "array" || kind === "map";
     }
 
-    protected emitDescriptionBlock(lines: string[]): void {
+    protected emitDescriptionBlock(lines: Sourcelike[]): void {
         this.emitCommentLines(lines, "/// ");
     }
 


### PR DESCRIPTION
This PR switches the type of `emitCommentLines` and the various `emitDescription` methods from `string[]` to `Sourcelike[]`.

As an example, this is useful for emitting javadoc which may rely on rendering `Sourcelike` inputs. For example:

```
this.emitDescriptionBlock(['@param ', paramName, ' foos the bar'])
```