### PR TITLE
Make emitMark available to extending Renderers

### DIFF
--- a/src/quicktype-core/language/Objective-C.ts
+++ b/src/quicktype-core/language/Objective-C.ts
@@ -804,7 +804,7 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
         this.emitLine("@end");
     };
 
-    private emitMark = (label: string) => {
+    protected emitMark = (label: string) => {
         this.ensureBlankLine();
         this.emitLine(`#pragma mark - ${label}`);
         this.ensureBlankLine();


### PR DESCRIPTION
It may be worth considering making most, if not all, `private` methods `protected` so that these renderers can be easily extended.