### PR TITLE
Make various Objective C methods protected and exported

### DIFF
--- a/src/quicktype-core/TypeUtils.ts
+++ b/src/quicktype-core/TypeUtils.ts
@@ -108,6 +108,10 @@ export function combineTypeAttributesOfTypes(combinationKind: CombinationKind, t
     return combineTypeAttributes(combinationKind, Array.from(types).map(t => t.getAttributes()));
 }
 
+export function isAnyOrNull(t: Type): boolean {
+    return t.kind === "any" || t.kind === "null";
+}
+
 // FIXME: We shouldn't have to sort here.  This is just because we're not getting
 // back the right order from JSON Schema, due to the changes the intersection types
 // introduced.

--- a/src/quicktype-core/language/Objective-C.ts
+++ b/src/quicktype-core/language/Objective-C.ts
@@ -2,7 +2,7 @@ import { iterableSome, iterableFirst, mapContains, mapFirst, mapSome } from "col
 
 import { TargetLanguage } from "../TargetLanguage";
 import { Type, ClassType, EnumType, ArrayType, MapType, UnionType, ClassProperty } from "../Type";
-import { matchType, nullableFromUnion } from "../TypeUtils";
+import { matchType, nullableFromUnion, isAnyOrNull } from "../TypeUtils";
 import { Name, Namer, funPrefixNamer } from "../Naming";
 import { Sourcelike, modifySource } from "../Source";
 import {
@@ -209,10 +209,6 @@ function isPartCharacter(utf16Unit: number): boolean {
 }
 
 const legalizeName = utf16LegalizeCharacters(isPartCharacter);
-
-export function isAnyOrNull(t: Type): boolean {
-    return t.kind === "any" || t.kind === "null";
-}
 
 const staticEnumValuesIdentifier = "values";
 const forbiddenForEnumCases = ["new", staticEnumValuesIdentifier];


### PR DESCRIPTION
As an extension to https://github.com/quicktype/quicktype/pull/1078, this PR opens up various methods to make it easier to extend the Objective C renderer.

Happy to discuss whether any of these API changes don't make sense.