### PR TITLE
Make emitMapFunction and implicitlyConverts functions protected

### DIFF
--- a/src/quicktype-core/language/Objective-C.ts
+++ b/src/quicktype-core/language/Objective-C.ts
@@ -456,7 +456,7 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
         );
     };
 
-    private implicitlyConvertsFromJSON(t: Type): boolean {
+    protected implicitlyConvertsFromJSON(t: Type): boolean {
         if (t instanceof ClassType) {
             return false;
         } else if (t instanceof EnumType) {
@@ -480,7 +480,7 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
         }
     }
 
-    private implicitlyConvertsToJSON(t: Type): boolean {
+    protected implicitlyConvertsToJSON(t: Type): boolean {
         return this.implicitlyConvertsFromJSON(t) && "bool" !== t.kind;
     }
 
@@ -1049,7 +1049,7 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
         return iterableSome(this.typeGraph.allTypesUnordered(), needsMap);
     }
 
-    private emitMapFunction = () => {
+    protected emitMapFunction = () => {
         if (this.needsMap) {
             this.emitMultiline(`static id map(id collection, id (^f)(id value)) {
     id result = nil;


### PR DESCRIPTION
As another extension to https://github.com/quicktype/quicktype/pull/1082, this PR updates the access modifier on a few more functions to make them `protected`.