### PR TITLE
Convert Renderer closures into methods

### DIFF
--- a/src/quicktype-core/ConvenienceRenderer.ts
+++ b/src/quicktype-core/ConvenienceRenderer.ts
@@ -241,18 +241,18 @@ export abstract class ConvenienceRenderer extends Renderer {
         );
     }
 
-    private addDependenciesForNamedType = (type: Type, named: Name): void => {
+    private addDependenciesForNamedType(type: Type, named: Name): void {
         const dependencyNames = this.makeNamedTypeDependencyNames(type, named);
         for (const dn of dependencyNames) {
             this.globalNamespace.add(dn);
         }
-    };
+    }
 
     protected makeNameForTopLevel(_t: Type, givenName: string, _maybeNamedType: Type | undefined): Name {
         return new SimpleName([givenName], defined(this._namedTypeNamer), topLevelNameOrder);
     }
 
-    private addNameForTopLevel = (type: Type, givenName: string): Name => {
+    private addNameForTopLevel(type: Type, givenName: string): Name {
         const maybeNamedType = this.namedTypeToNameForTopLevel(type);
         const name = this.makeNameForTopLevel(type, givenName, maybeNamedType);
         this.globalNamespace.add(name);
@@ -267,7 +267,7 @@ export abstract class ConvenienceRenderer extends Renderer {
         }
 
         return name;
-    };
+    }
 
     private makeNameForType(t: Type, namer: Namer, givenOrder: number, inferredOrder: number): Name {
         const names = t.getNames();
@@ -279,7 +279,7 @@ export abstract class ConvenienceRenderer extends Renderer {
         return this.makeNameForType(t, defined(this._namedTypeNamer), givenNameOrder, inferredNameOrder);
     }
 
-    private addNameForNamedType = (type: Type): Name => {
+    private addNameForNamedType(type: Type): Name {
         const existing = this.nameStoreView.tryGet(type);
         if (existing !== undefined) return existing;
 
@@ -289,7 +289,7 @@ export abstract class ConvenienceRenderer extends Renderer {
 
         this.nameStoreView.set(type, name);
         return name;
-    };
+    }
 
     protected get typesWithNamedTransformations(): ReadonlyMap<Type, Name> {
         return defined(this._namesForTransformations);
@@ -385,7 +385,7 @@ export abstract class ConvenienceRenderer extends Renderer {
         return [];
     }
 
-    private addPropertyNames = (o: ObjectType, className: Name): void => {
+    private addPropertyNames(o: ObjectType, className: Name): void {
         const { forbiddenNames, forbiddenNamespaces } = this.processForbiddenWordsInfo(
             this.forbiddenForObjectProperties(o, className),
             "forbidden-for-properties"
@@ -413,7 +413,7 @@ export abstract class ConvenienceRenderer extends Renderer {
             return name;
         });
         defined(this._propertyNamesStoreView).set(o, names);
-    };
+    }
 
     protected makeNameForUnionMember(u: UnionType, unionName: Name, t: Type): Name {
         const [assignedName, isFixed] = unionMemberName(u, t, this.targetLanguage.name);
@@ -426,7 +426,7 @@ export abstract class ConvenienceRenderer extends Renderer {
         });
     }
 
-    private addUnionMemberNames = (u: UnionType, unionName: Name): void => {
+    private addUnionMemberNames(u: UnionType, unionName: Name): void {
         const memberNamer = this._unionMemberNamer;
         if (memberNamer === null) return;
 
@@ -447,7 +447,7 @@ export abstract class ConvenienceRenderer extends Renderer {
             names.set(t, ns.add(name));
         }
         defined(this._memberNamesStoreView).set(u, names);
-    };
+    }
 
     protected makeNameForEnumCase(
         e: EnumType,
@@ -464,7 +464,7 @@ export abstract class ConvenienceRenderer extends Renderer {
     }
 
     // FIXME: this is very similar to addPropertyNameds and addUnionMemberNames
-    private addEnumCaseNames = (e: EnumType, enumName: Name): void => {
+    private addEnumCaseNames(e: EnumType, enumName: Name): void {
         if (this._enumCaseNamer === null) return;
 
         const { forbiddenNames, forbiddenNamespaces } = this.processForbiddenWordsInfo(
@@ -491,7 +491,7 @@ export abstract class ConvenienceRenderer extends Renderer {
             names.set(caseName, ns.add(name));
         }
         defined(this._caseNamesStoreView).set(e, names);
-    };
+    }
 
     private childrenOfType(t: Type): ReadonlySet<Type> {
         const names = this.names;
@@ -541,9 +541,9 @@ export abstract class ConvenienceRenderer extends Renderer {
         return this.enums.size > 0;
     }
 
-    protected proposedUnionMemberNameForTypeKind = (_kind: TypeKind): string | null => {
+    protected proposedUnionMemberNameForTypeKind(_kind: TypeKind): string | null {
         return null;
-    };
+    }
 
     protected proposeUnionMemberName(
         _u: UnionType,
@@ -586,9 +586,9 @@ export abstract class ConvenienceRenderer extends Renderer {
         return typeNameForUnionMember(fieldType);
     }
 
-    protected nameForNamedType = (t: Type): Name => {
+    protected nameForNamedType(t: Type): Name {
         return this.nameStoreView.get(t);
-    };
+    }
 
     protected isForwardDeclaredType(t: Type): boolean {
         return defined(this._declarationIR).forwardedTypes.has(t);
@@ -640,9 +640,9 @@ export abstract class ConvenienceRenderer extends Renderer {
         );
     }
 
-    setAlphabetizeProperties = (value: boolean): void => {
+    setAlphabetizeProperties(value: boolean): void {
         this._alphabetizeProperties = value;
-    };
+    }
 
     protected forEachClassProperty(
         o: ObjectType,
@@ -664,13 +664,13 @@ export abstract class ConvenienceRenderer extends Renderer {
         }
     }
 
-    protected nameForUnionMember = (u: UnionType, t: Type): Name => {
+    protected nameForUnionMember(u: UnionType, t: Type): Name {
         return defined(
             defined(this._memberNamesStoreView)
                 .get(u)
                 .get(t)
         );
-    };
+    }
 
     protected nameForEnumCase(e: EnumType, caseName: string): Name {
         const caseNames = defined(this._caseNamesStoreView).get(e);
@@ -784,9 +784,9 @@ export abstract class ConvenienceRenderer extends Renderer {
     // You should never have to use this to produce parts of your generated
     // code.  If you need to modify a Name, for example to change its casing,
     // use `modifySource`.
-    protected sourcelikeToString = (src: Sourcelike): string => {
+    protected sourcelikeToString(src: Sourcelike): string {
         return serializeRenderResult(sourcelikeToSource(src), this.names, "").lines.join("\n");
-    };
+    }
 
     protected get commentLineStart(): string {
         return "// ";
@@ -898,7 +898,7 @@ export abstract class ConvenienceRenderer extends Renderer {
             processed.add(process(t));
         }
 
-        for (;;) {
+        for (; ;) {
             const maybeType = queue.pop();
             if (maybeType === undefined) {
                 break;

--- a/src/quicktype-core/language/Dart.ts
+++ b/src/quicktype-core/language/Dart.ts
@@ -340,7 +340,7 @@ export class DartRenderer extends ConvenienceRenderer {
         );
     }
 
-    protected toDynamicExpression = (t: Type, ...dynamic: Sourcelike[]): Sourcelike => {
+    protected toDynamicExpression(t: Type, ...dynamic: Sourcelike[]): Sourcelike {
         return matchType<Sourcelike>(
             t,
             _anyType => dynamic,
@@ -361,7 +361,7 @@ export class DartRenderer extends ConvenienceRenderer {
                 return [dynamic, " == null ? null : ", this.toDynamicExpression(maybeNullable, dynamic)];
             }
         );
-    };
+    }
 
     protected emitClassDefinition(c: ClassType, className: Name): void {
         this.emitDescription(this.descriptionForType(c));

--- a/src/quicktype-core/language/Elm.ts
+++ b/src/quicktype-core/language/Elm.ts
@@ -269,10 +269,10 @@ export class ElmRenderer extends ConvenienceRenderer {
         }
     }
 
-    private decoderNameForNamedType = (t: Type): Name => {
+    private decoderNameForNamedType(t: Type): Name {
         const name = this.nameForNamedType(t);
         return defined(this._namedTypeDependents.get(name)).decoder;
-    };
+    }
 
     private decoderNameForType(t: Type, noOptional: boolean = false): MultiWord {
         return matchType<MultiWord>(
@@ -312,10 +312,10 @@ export class ElmRenderer extends ConvenienceRenderer {
         }
     }
 
-    private encoderNameForNamedType = (t: Type): Name => {
+    private encoderNameForNamedType(t: Type): Name {
         const name = this.nameForNamedType(t);
         return defined(this._namedTypeDependents.get(name)).encoder;
-    };
+    }
 
     private encoderNameForType(t: Type, noOptional: boolean = false): MultiWord {
         return matchType<MultiWord>(
@@ -355,11 +355,11 @@ export class ElmRenderer extends ConvenienceRenderer {
         }
     }
 
-    private emitTopLevelDefinition = (t: Type, topLevelName: Name): void => {
+    private emitTopLevelDefinition(t: Type, topLevelName: Name): void {
         this.emitLine("type alias ", topLevelName, " = ", this.elmType(t).source);
-    };
+    }
 
-    private emitClassDefinition = (c: ClassType, className: Name): void => {
+    private emitClassDefinition(c: ClassType, className: Name): void {
         let description = this.descriptionForType(c);
         this.forEachClassProperty(c, "none", (name, jsonName) => {
             const propertyDescription = this.descriptionForClassProperty(c, jsonName);
@@ -387,9 +387,9 @@ export class ElmRenderer extends ConvenienceRenderer {
             }
             this.emitLine("}");
         });
-    };
+    }
 
-    private emitEnumDefinition = (e: EnumType, enumName: Name): void => {
+    private emitEnumDefinition(e: EnumType, enumName: Name): void {
         this.emitDescription(this.descriptionForType(e));
         this.emitLine("type ", enumName);
         this.indent(() => {
@@ -400,9 +400,9 @@ export class ElmRenderer extends ConvenienceRenderer {
                 onFirst = false;
             });
         });
-    };
+    }
 
-    private emitUnionDefinition = (u: UnionType, unionName: Name): void => {
+    private emitUnionDefinition(u: UnionType, unionName: Name): void {
         this.emitDescription(this.descriptionForType(u));
         this.emitLine("type ", unionName);
         this.indent(() => {
@@ -417,9 +417,9 @@ export class ElmRenderer extends ConvenienceRenderer {
                 onFirst = false;
             });
         });
-    };
+    }
 
-    private emitTopLevelFunctions = (t: Type, topLevelName: Name): void => {
+    private emitTopLevelFunctions(t: Type, topLevelName: Name): void {
         const { encoder, decoder } = defined(this._topLevelDependents.get(topLevelName));
         if (this.namedTypeToNameForTopLevel(t) === undefined) {
             this.emitLine(defined(decoder), " : Jdec.Decoder ", topLevelName);
@@ -428,9 +428,9 @@ export class ElmRenderer extends ConvenienceRenderer {
         }
         this.emitLine(encoder, " : ", topLevelName, " -> String");
         this.emitLine(encoder, " r = Jenc.encode 0 (", this.encoderNameForType(t).source, " r)");
-    };
+    }
 
-    private emitClassFunctions = (c: ClassType, className: Name): void => {
+    private emitClassFunctions(c: ClassType, className: Name): void {
         const decoderName = this.decoderNameForNamedType(c);
         this.emitLine(decoderName, " : Jdec.Decoder ", className);
         this.emitLine(decoderName, " =");
@@ -465,9 +465,9 @@ export class ElmRenderer extends ConvenienceRenderer {
                 this.emitLine("]");
             });
         });
-    };
+    }
 
-    private emitEnumFunctions = (e: EnumType, enumName: Name): void => {
+    private emitEnumFunctions(e: EnumType, enumName: Name): void {
         const decoderName = this.decoderNameForNamedType(e);
         this.emitLine(decoderName, " : Jdec.Decoder ", enumName);
         this.emitLine(decoderName, " =");
@@ -497,9 +497,9 @@ export class ElmRenderer extends ConvenienceRenderer {
                 this.emitLine(name, ' -> Jenc.string "', stringEscape(jsonName), '"');
             });
         });
-    };
+    }
 
-    private emitUnionFunctions = (u: UnionType, unionName: Name): void => {
+    private emitUnionFunctions(u: UnionType, unionName: Name): void {
         // We need arrays first, then strings, and integers before doubles.
         function sortOrder(_: Name, t: Type): string {
             if (t.kind === "array") {
@@ -547,7 +547,7 @@ export class ElmRenderer extends ConvenienceRenderer {
                 }
             });
         });
-    };
+    }
 
     protected emitSourceStructure(): void {
         const exports: Sourcelike[] = [];

--- a/src/quicktype-core/language/Elm.ts
+++ b/src/quicktype-core/language/Elm.ts
@@ -625,26 +625,26 @@ import Dict exposing (Dict, map, toList)`);
 
         this.forEachTopLevel(
             "leading-and-interposing",
-            this.emitTopLevelDefinition,
+            (t: Type, topLevelName: Name) => this.emitTopLevelDefinition(t, topLevelName),
             t => this.namedTypeToNameForTopLevel(t) === undefined
         );
         this.forEachNamedType(
             "leading-and-interposing",
-            this.emitClassDefinition,
-            this.emitEnumDefinition,
-            this.emitUnionDefinition
+            (c: ClassType, className: Name) => this.emitClassDefinition(c, className),
+            (e: EnumType, enumName: Name) => this.emitEnumDefinition(e, enumName),
+            (u: UnionType, unionName: Name) => this.emitUnionDefinition(u, unionName)
         );
 
         if (this._options.justTypes) return;
 
         this.ensureBlankLine();
         this.emitLine("-- decoders and encoders");
-        this.forEachTopLevel("leading-and-interposing", this.emitTopLevelFunctions);
+        this.forEachTopLevel("leading-and-interposing", (t: Type, topLevelName: Name) => this.emitTopLevelFunctions(t, topLevelName));
         this.forEachNamedType(
             "leading-and-interposing",
-            this.emitClassFunctions,
-            this.emitEnumFunctions,
-            this.emitUnionFunctions
+            (c: ClassType, className: Name) => this.emitClassFunctions(c, className),
+            (e: EnumType, enumName: Name) => this.emitEnumFunctions(e, enumName),
+            (u: UnionType, unionName: Name) => this.emitUnionFunctions(u, unionName)
         );
         this.ensureBlankLine();
 

--- a/src/quicktype-core/language/Golang.ts
+++ b/src/quicktype-core/language/Golang.ts
@@ -344,12 +344,12 @@ export class GoRenderer extends ConvenienceRenderer {
         }
         this.forEachTopLevel(
             "leading-and-interposing",
-            this.emitTopLevel,
+            (t, name) => this.emitTopLevel(t, name),
             t => !this._options.justTypes || this.namedTypeToNameForTopLevel(t) === undefined
         );
-        this.forEachObject("leading-and-interposing", this.emitClass);
-        this.forEachEnum("leading-and-interposing", this.emitEnum);
-        this.forEachUnion("leading-and-interposing", this.emitUnion);
+        this.forEachObject("leading-and-interposing", (c: ClassType, className: Name) => this.emitClass(c, className));
+        this.forEachEnum("leading-and-interposing", (u: EnumType, enumName: Name) => this.emitEnum(u, enumName));
+        this.forEachUnion("leading-and-interposing", (u: UnionType, unionName: Name) => this.emitUnion(u, unionName));
 
         if (this._options.justTypes) return;
 

--- a/src/quicktype-core/language/Golang.ts
+++ b/src/quicktype-core/language/Golang.ts
@@ -129,28 +129,28 @@ export class GoRenderer extends ConvenienceRenderer {
         return [unmarshalName];
     }
 
-    private emitBlock = (line: Sourcelike, f: () => void): void => {
+    private emitBlock(line: Sourcelike, f: () => void): void {
         this.emitLine(line, " {");
         this.indent(f);
         this.emitLine("}");
-    };
+    }
 
-    private emitFunc = (decl: Sourcelike, f: () => void): void => {
+    private emitFunc(decl: Sourcelike, f: () => void): void {
         this.emitBlock(["func ", decl], f);
-    };
+    }
 
-    private emitStruct = (name: Name, table: Sourcelike[][]): void => {
+    private emitStruct(name: Name, table: Sourcelike[][]): void {
         this.emitBlock(["type ", name, " struct"], () => this.emitTable(table));
-    };
+    }
 
-    private nullableGoType = (t: Type, withIssues: boolean): Sourcelike => {
+    private nullableGoType(t: Type, withIssues: boolean): Sourcelike {
         const goType = this.goType(t, withIssues);
         if (isValueType(t)) {
             return ["*", goType];
         } else {
             return goType;
         }
-    };
+    }
 
     private propertyGoType(cp: ClassProperty): Sourcelike {
         const t = cp.type;
@@ -163,7 +163,7 @@ export class GoRenderer extends ConvenienceRenderer {
         return this.goType(t, true);
     }
 
-    private goType = (t: Type, withIssues: boolean = false): Sourcelike => {
+    private goType(t: Type, withIssues: boolean = false): Sourcelike {
         return matchType<Sourcelike>(
             t,
             _anyType => maybeAnnotated(withIssues, anyTypeIssueAnnotation, "interface{}"),
@@ -191,9 +191,9 @@ export class GoRenderer extends ConvenienceRenderer {
                 return this.nameForNamedType(unionType);
             }
         );
-    };
+    }
 
-    private emitTopLevel = (t: Type, name: Name): void => {
+    private emitTopLevel(t: Type, name: Name): void {
         const unmarshalName = defined(this._topLevelUnmarshalNames.get(name));
         if (this.namedTypeToNameForTopLevel(t) === undefined) {
             this.emitLine("type ", name, " ", this.goType(t));
@@ -211,9 +211,9 @@ export class GoRenderer extends ConvenienceRenderer {
         this.emitFunc(["(r *", name, ") Marshal() ([]byte, error)"], () => {
             this.emitLine("return json.Marshal(r)");
         });
-    };
+    }
 
-    private emitClass = (c: ClassType, className: Name): void => {
+    private emitClass(c: ClassType, className: Name): void {
         let columns: Sourcelike[][] = [];
         this.forEachClassProperty(c, "none", (name, jsonName, p) => {
             const goType = this.propertyGoType(p);
@@ -223,9 +223,9 @@ export class GoRenderer extends ConvenienceRenderer {
         });
         this.emitDescription(this.descriptionForType(c));
         this.emitStruct(className, columns);
-    };
+    }
 
-    private emitEnum = (e: EnumType, enumName: Name): void => {
+    private emitEnum(e: EnumType, enumName: Name): void {
         this.emitDescription(this.descriptionForType(e));
         this.emitLine("type ", enumName, " string");
         this.emitLine("const (");
@@ -235,9 +235,9 @@ export class GoRenderer extends ConvenienceRenderer {
             })
         );
         this.emitLine(")");
-    };
+    }
 
-    private emitUnion = (u: UnionType, unionName: Name): void => {
+    private emitUnion(u: UnionType, unionName: Name): void {
         const [hasNull, nonNulls] = removeNullFromUnion(u);
         const isNullableArg = hasNull !== null ? "true" : "false";
 
@@ -318,7 +318,7 @@ export class GoRenderer extends ConvenienceRenderer {
             const args = makeArgs(fn => ["x.", fn], (_, fn) => ["x.", fn, " != nil, x.", fn]);
             this.emitLine("return marshalUnion(", args, ")");
         });
-    };
+    }
 
     protected emitSourceStructure(): void {
         if (this.leadingComments !== undefined) {

--- a/src/quicktype-core/language/JSONSchema.ts
+++ b/src/quicktype-core/language/JSONSchema.ts
@@ -84,11 +84,11 @@ export class JSONSchemaRenderer extends ConvenienceRenderer {
         return null;
     }
 
-    private nameForType = (t: Type): string => {
+    private nameForType(t: Type): string {
         return defined(this.names.get(this.nameForNamedType(t)));
-    };
+    }
 
-    private makeOneOf = (types: ReadonlySet<Type>): Schema => {
+    private makeOneOf(types: ReadonlySet<Type>): Schema {
         const first = iterableFirst(types);
         if (first === undefined) {
             return panic("Must have at least one type for oneOf");
@@ -97,7 +97,7 @@ export class JSONSchemaRenderer extends ConvenienceRenderer {
             return this.schemaForType(first);
         }
         return { anyOf: Array.from(types).map(this.schemaForType) };
-    };
+    }
 
     private makeRef(t: Type): Schema {
         return { $ref: `#/definitions/${this.nameForType(t)}` };
@@ -110,7 +110,7 @@ export class JSONSchemaRenderer extends ConvenienceRenderer {
         }
     }
 
-    private schemaForType = (t: Type): Schema => {
+    private schemaForType(t: Type): Schema {
         const schema = matchTypeExhaustive<{ [name: string]: any }>(
             t,
             _noneType => {
@@ -146,7 +146,7 @@ export class JSONSchemaRenderer extends ConvenienceRenderer {
             this.addAttributesToSchema(t, schema);
         }
         return schema;
-    };
+    }
 
     private definitionForObject(o: ObjectType, title: string | undefined): Schema {
         let properties: Schema | undefined;

--- a/src/quicktype-core/language/JSONSchema.ts
+++ b/src/quicktype-core/language/JSONSchema.ts
@@ -96,7 +96,7 @@ export class JSONSchemaRenderer extends ConvenienceRenderer {
         if (types.size === 1) {
             return this.schemaForType(first);
         }
-        return { anyOf: Array.from(types).map(this.schemaForType) };
+        return { anyOf: Array.from(types).map((t: Type) => this.schemaForType(t)) };
     }
 
     private makeRef(t: Type): Schema {

--- a/src/quicktype-core/language/JavaScript.ts
+++ b/src/quicktype-core/language/JavaScript.ts
@@ -144,7 +144,7 @@ export class JavaScriptRenderer extends ConvenienceRenderer {
             mapType => ["m(", this.typeMapTypeFor(mapType.values), ")"],
             _enumType => panic("We handled this above"),
             unionType => {
-                const children = Array.from(unionType.getChildren()).map(this.typeMapTypeFor);
+                const children = Array.from(unionType.getChildren()).map((type: Type) => this.typeMapTypeFor(type));
                 return ["u(", ...arrayIntercalate(", ", children), ")"];
             }
         );

--- a/src/quicktype-core/language/JavaScript.ts
+++ b/src/quicktype-core/language/JavaScript.ts
@@ -127,7 +127,7 @@ export class JavaScriptRenderer extends ConvenienceRenderer {
         this.emitCommentLines(lines, " * ", "/**", " */");
     }
 
-    typeMapTypeFor = (t: Type): Sourcelike => {
+    typeMapTypeFor(t: Type): Sourcelike {
         if (["class", "object", "enum"].indexOf(t.kind) >= 0) {
             return ['r("', this.nameForNamedType(t), '")'];
         }
@@ -148,7 +148,7 @@ export class JavaScriptRenderer extends ConvenienceRenderer {
                 return ["u(", ...arrayIntercalate(", ", children), ")"];
             }
         );
-    };
+    }
 
     typeMapTypeForProperty(p: ClassProperty): Sourcelike {
         const typeMap = this.typeMapTypeFor(p.type);
@@ -164,7 +164,7 @@ export class JavaScriptRenderer extends ConvenienceRenderer {
         this.emitLine("}", end);
     }
 
-    emitTypeMap = () => {
+    emitTypeMap() {
         const { any: anyAnnotation } = this.typeAnnotations;
 
         this.emitBlock(`const typeMap${anyAnnotation} = `, ";", () => {
@@ -198,7 +198,7 @@ export class JavaScriptRenderer extends ConvenienceRenderer {
                 this.emitLine("],");
             });
         });
-    };
+    }
 
     protected deserializerFunctionName(name: Name): Sourcelike {
         return ["to", name];

--- a/src/quicktype-core/language/Objective-C.ts
+++ b/src/quicktype-core/language/Objective-C.ts
@@ -293,11 +293,11 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
         this.emitCommentLines(lines, "/// ");
     }
 
-    protected emitBlock = (line: Sourcelike, f: () => void): void => {
+    protected emitBlock(line: Sourcelike, f: () => void): void {
         this.emitLine(line, " {");
         this.indent(f);
         this.emitLine("}");
-    };
+    }
 
     protected emitMethod(declaration: Sourcelike, f: () => void) {
         this.emitLine(declaration);
@@ -306,12 +306,12 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
         this.emitLine("}");
     }
 
-    protected emitExtraComments = (...comments: Sourcelike[]) => {
+    protected emitExtraComments(...comments: Sourcelike[]) {
         if (!this._options.extraComments) return;
         for (const comment of comments) {
             this.emitLine("// ", comment);
         }
-    };
+    }
 
     protected startFile(basename: Sourcelike, extension: string): void {
         assert(this._currentFilename === undefined, "Previous file wasn't finished");
@@ -344,7 +344,7 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
         );
     }
 
-    protected objcType = (t: Type, nullableOrBoxed: boolean = false): [Sourcelike, string] => {
+    protected objcType(t: Type, nullableOrBoxed: boolean = false): [Sourcelike, string] {
         return matchType<[Sourcelike, string]>(
             t,
             _anyType => ["id", ""],
@@ -371,9 +371,9 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
                 return nullable !== null ? this.objcType(nullable, true) : ["id", ""];
             }
         );
-    };
+    }
 
-    private jsonType = (t: Type): [Sourcelike, string] => {
+    private jsonType(t: Type): [Sourcelike, string] {
         return matchType<[Sourcelike, string]>(
             t,
             _anyType => ["id", ""],
@@ -392,9 +392,9 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
                 return nullable !== null ? this.jsonType(nullable) : ["id", ""];
             }
         );
-    };
+    }
 
-    protected fromDynamicExpression = (t: Type, ...dynamic: Sourcelike[]): Sourcelike => {
+    protected fromDynamicExpression(t: Type, ...dynamic: Sourcelike[]): Sourcelike {
         return matchType<Sourcelike>(
             t,
             _anyType => dynamic,
@@ -412,9 +412,9 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
                 return nullable !== null ? this.fromDynamicExpression(nullable, dynamic) : dynamic;
             }
         );
-    };
+    }
 
-    protected toDynamicExpression = (t: Type, typed: Sourcelike): Sourcelike => {
+    protected toDynamicExpression(t: Type, typed: Sourcelike): Sourcelike {
         return matchType<Sourcelike>(
             t,
             _anyType => ["NSNullify(", typed, ")"],
@@ -454,7 +454,7 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
                 }
             }
         );
-    };
+    }
 
     protected implicitlyConvertsFromJSON(t: Type): boolean {
         if (t instanceof ClassType) {
@@ -484,7 +484,7 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
         return this.implicitlyConvertsFromJSON(t) && "bool" !== t.kind;
     }
 
-    protected emitPropertyAssignment = (propertyName: Name, jsonName: string, propertyType: Type) => {
+    protected emitPropertyAssignment(propertyName: Name, jsonName: string, propertyType: Type) {
         const name = ["_", propertyName];
         matchType(
             propertyType,
@@ -518,14 +518,14 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
                 }
             }
         );
-    };
+    }
 
-    protected emitPrivateClassInterface = (_: ClassType, name: Name): void => {
+    protected emitPrivateClassInterface(_: ClassType, name: Name): void {
         this.emitLine("@interface ", name, " (JSONConversion)");
         this.emitLine("+ (instancetype)fromJSONDictionary:(NSDictionary *)dict;");
         this.emitLine("- (NSDictionary *)JSONDictionary;");
         this.emitLine("@end");
-    };
+    }
 
     protected pointerAwareTypeName(t: Type | [Sourcelike, string]): Sourcelike {
         const name = t instanceof Type ? this.objcType(t) : t;
@@ -630,7 +630,7 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
         });
     }
 
-    private emitClassInterface = (t: ClassType, className: Name): void => {
+    private emitClassInterface(t: ClassType, className: Name): void {
         const isTopLevel = mapContains(this.topLevels, t);
 
         this.emitDescription(this.descriptionForType(t));
@@ -664,7 +664,7 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
             this.emitLine("- (NSData *_Nullable)toData:(NSError *_Nullable *)error;");
         }
         this.emitLine("@end");
-    };
+    }
 
     protected hasIrregularProperties(t: ClassType) {
         let irregular = false;
@@ -683,7 +683,7 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
     }
 
     // TODO Implement NSCopying
-    private emitClassImplementation = (t: ClassType, className: Name): void => {
+    private emitClassImplementation(t: ClassType, className: Name): void {
         const isTopLevel = mapContains(this.topLevels, t);
 
         const hasIrregularProperties = this.hasIrregularProperties(t);
@@ -807,13 +807,13 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
         }
 
         this.emitLine("@end");
-    };
+    }
 
-    protected emitMark = (label: string) => {
+    protected emitMark(label: string) {
         this.ensureBlankLine();
         this.emitLine(`#pragma mark - ${label}`);
         this.ensureBlankLine();
-    };
+    }
 
     protected variableNameForTopLevel(name: Name): Sourcelike {
         const camelCaseName = modifySource(serialized => {
@@ -1049,7 +1049,7 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
         return iterableSome(this.typeGraph.allTypesUnordered(), needsMap);
     }
 
-    protected emitMapFunction = () => {
+    protected emitMapFunction() {
         if (this.needsMap) {
             this.emitMultiline(`static id map(id collection, id (^f)(id value)) {
     id result = nil;
@@ -1063,5 +1063,5 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
     return result;
 }`);
         }
-    };
+    }
 }

--- a/src/quicktype-core/language/Objective-C.ts
+++ b/src/quicktype-core/language/Objective-C.ts
@@ -968,7 +968,7 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
             }
 
             this.emitMark("Object interfaces");
-            this.forEachNamedType("leading-and-interposing", this.emitClassInterface, () => null, () => null);
+            this.forEachNamedType("leading-and-interposing", (c: ClassType, className: Name) => this.emitClassInterface(c, className), () => null, () => null);
 
             this.ensureBlankLine();
             this.emitLine("NS_ASSUME_NONNULL_END");
@@ -1002,7 +1002,7 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
 
                 this.forEachNamedType(
                     "leading-and-interposing",
-                    this.emitPrivateClassInterface,
+                    (c: ClassType, className: Name) => this.emitPrivateClassInterface(c, className),
                     () => null,
                     () => null
                 );
@@ -1027,7 +1027,7 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
                 this.forEachTopLevel("leading-and-interposing", (t, n) => this.emitTopLevelFunctions(t, n));
             }
 
-            this.forEachNamedType("leading-and-interposing", this.emitClassImplementation, () => null, () => null);
+            this.forEachNamedType("leading-and-interposing", (c: ClassType, className: Name) => this.emitClassImplementation(c, className), () => null, () => null);
 
             if (!this._options.justTypes) {
                 this.ensureBlankLine();

--- a/src/quicktype-core/language/Rust.ts
+++ b/src/quicktype-core/language/Rust.ts
@@ -225,16 +225,16 @@ export class RustRenderer extends ConvenienceRenderer {
         return "/// ";
     }
 
-    private nullableRustType = (t: Type, withIssues: boolean): Sourcelike => {
+    private nullableRustType(t: Type, withIssues: boolean): Sourcelike {
         return ["Option<", this.breakCycle(t, withIssues), ">"];
-    };
+    }
 
     protected isImplicitCycleBreaker(t: Type): boolean {
         const kind = t.kind;
         return kind === "array" || kind === "map";
     }
 
-    private rustType = (t: Type, withIssues: boolean = false): Sourcelike => {
+    private rustType(t: Type, withIssues: boolean = false): Sourcelike {
         return matchType<Sourcelike>(
             t,
             _anyType => maybeAnnotated(withIssues, anyTypeIssueAnnotation, "Option<serde_json::Value>"),
@@ -263,14 +263,14 @@ export class RustRenderer extends ConvenienceRenderer {
                 return hasNull !== null ? (["Option<", name, ">"] as Sourcelike) : name;
             }
         );
-    };
+    }
 
-    private breakCycle = (t: Type, withIssues: boolean): any => {
+    private breakCycle(t: Type, withIssues: boolean): any {
         const rustType = this.rustType(t, withIssues);
         const isCycleBreaker = this.isCycleBreakerType(t);
 
         return isCycleBreaker ? ["Box<", rustType, ">"] : rustType;
-    };
+    }
 
     private emitRenameAttribute(propName: Name, jsonName: string) {
         const escapedName = rustStringEscape(jsonName);

--- a/src/quicktype-core/language/Swift.ts
+++ b/src/quicktype-core/language/Swift.ts
@@ -1160,15 +1160,15 @@ ${this.accessLevel}class JSONAny: Codable {
 
         this.forEachTopLevel(
             "leading",
-            this.renderTopLevelAlias,
+            (t: Type, name: Name) => this.renderTopLevelAlias(t, name),
             t => this.namedTypeToNameForTopLevel(t) === undefined
         );
 
         this.forEachNamedType(
             "leading-and-interposing",
-            this.renderClassDefinition,
-            this.renderEnumDefinition,
-            this.renderUnionDefinition
+            (c: ClassType, className: Name) => this.renderClassDefinition(c, className),
+            (e: EnumType, enumName: Name) => this.renderEnumDefinition(e, enumName),
+            (u: UnionType, unionName: Name) => this.renderUnionDefinition(u, unionName)
         );
 
         if (!this._options.justTypes) {
@@ -1178,14 +1178,14 @@ ${this.accessLevel}class JSONAny: Codable {
                 this.emitMark("Convenience initializers and mutators");
                 this.forEachNamedType(
                     "leading-and-interposing",
-                    this.emitConvenienceInitializersExtension,
+                    (c: ClassType, className: Name) => this.emitConvenienceInitializersExtension(c, className),
                     () => undefined,
                     () => undefined
                 );
                 this.ensureBlankLine();
                 this.forEachTopLevel(
                     "leading-and-interposing",
-                    this.emitTopLevelMapAndArrayConvenienceInitializerExtensions
+                    (t: Type, name: Name) => this.emitTopLevelMapAndArrayConvenienceInitializerExtensions(t, name)
                 );
             }
 

--- a/src/quicktype-core/language/Swift.ts
+++ b/src/quicktype-core/language/Swift.ts
@@ -324,20 +324,20 @@ export class SwiftRenderer extends ConvenienceRenderer {
         this.emitCommentLines(lines, "/// ");
     }
 
-    private emitBlock = (line: Sourcelike, f: () => void): void => {
+    private emitBlock(line: Sourcelike, f: () => void): void {
         this.emitLine(line, " {");
         this.indent(f);
         this.emitLine("}");
-    };
+    }
 
     private emitBlockWithAccess(line: Sourcelike, f: () => void): void {
         this.emitBlock([this.accessLevel, line], f);
     }
 
-    private justTypesCase = (justTypes: Sourcelike, notJustTypes: Sourcelike): Sourcelike => {
+    private justTypesCase(justTypes: Sourcelike, notJustTypes: Sourcelike): Sourcelike {
         if (this._options.justTypes) return justTypes;
         else return notJustTypes;
-    };
+    }
 
     protected swiftPropertyType(p: ClassProperty): Sourcelike {
         if (p.isOptional) {
@@ -390,7 +390,7 @@ export class SwiftRenderer extends ConvenienceRenderer {
         );
     }
 
-    protected proposedUnionMemberNameForTypeKind = (kind: TypeKind): string | null => {
+    protected proposedUnionMemberNameForTypeKind(kind: TypeKind): string | null {
         if (kind === "enum") {
             return "enumeration";
         }
@@ -398,9 +398,9 @@ export class SwiftRenderer extends ConvenienceRenderer {
             return "one_of";
         }
         return null;
-    };
+    }
 
-    private renderHeader = (): void => {
+    private renderHeader(): void {
         if (this.leadingComments !== undefined) {
             this.emitCommentLines(this.leadingComments);
         } else if (!this._options.justTypes) {
@@ -472,13 +472,13 @@ export class SwiftRenderer extends ConvenienceRenderer {
         if (!this._options.justTypes && this._options.alamofire) {
             this.emitLine("import Alamofire");
         }
-    };
+    }
 
-    private renderTopLevelAlias = (t: Type, name: Name): void => {
+    private renderTopLevelAlias(t: Type, name: Name): void {
         this.emitLine("typealias ", name, " = ", this.swiftType(t, true));
-    };
+    }
 
-    private getProtocolString = (): Sourcelike => {
+    private getProtocolString(): Sourcelike {
         const protocols: string[] = [];
         if (!this._options.justTypes) {
             protocols.push("Codable");
@@ -493,7 +493,7 @@ export class SwiftRenderer extends ConvenienceRenderer {
         }
 
         return protocols.length > 0 ? ": " + protocols.join(", ") : "";
-    };
+    }
 
     private getEnumPropertyGroups(c: ClassType) {
         type PropertyGroup = { name: Name; label?: string }[];
@@ -530,7 +530,7 @@ export class SwiftRenderer extends ConvenienceRenderer {
             : this._options.accessLevel + " ";
     }
 
-    private renderClassDefinition = (c: ClassType, className: Name): void => {
+    private renderClassDefinition(c: ClassType, className: Name): void {
         this.emitDescription(this.descriptionForType(c));
 
         const isClass = this._options.useClasses || this.isCycleBreakerType(c);
@@ -626,7 +626,7 @@ export class SwiftRenderer extends ConvenienceRenderer {
                 });
             }
         });
-    };
+    }
 
     private emitNewEncoderDecoder(): void {
         this.emitBlock("func newJSONDecoder() -> JSONDecoder", () => {
@@ -676,7 +676,7 @@ encoder.dateEncodingStrategy = .formatted(formatter)`);
         });
     }
 
-    private emitConvenienceInitializersExtension = (c: ClassType, className: Name): void => {
+    private emitConvenienceInitializersExtension(c: ClassType, className: Name): void {
         const isClass = this._options.useClasses || this.isCycleBreakerType(c);
         const convenience = isClass ? "convenience " : "";
 
@@ -724,9 +724,9 @@ encoder.dateEncodingStrategy = .formatted(formatter)`);
                 this.emitLine("return String(data: try self.jsonData(), encoding: encoding)");
             });
         });
-    };
+    }
 
-    private renderEnumDefinition = (e: EnumType, enumName: Name): void => {
+    private renderEnumDefinition(e: EnumType, enumName: Name): void {
         this.emitDescription(this.descriptionForType(e));
 
         const protocols: string[] = [];
@@ -758,9 +758,9 @@ encoder.dateEncodingStrategy = .formatted(formatter)`);
                 });
             });
         }
-    };
+    }
 
-    private renderUnionDefinition = (u: UnionType, unionName: Name): void => {
+    private renderUnionDefinition(u: UnionType, unionName: Name): void {
         function sortBy(t: Type): string {
             const kind = t.kind;
             if (kind === "class") return kind;
@@ -822,9 +822,9 @@ encoder.dateEncodingStrategy = .formatted(formatter)`);
                 });
             }
         });
-    };
+    }
 
-    private emitTopLevelMapAndArrayConvenienceInitializerExtensions = (t: Type, name: Name): void => {
+    private emitTopLevelMapAndArrayConvenienceInitializerExtensions(t: Type, name: Name): void {
         let extensionSource: Sourcelike;
 
         if (t instanceof ArrayType) {
@@ -859,9 +859,9 @@ encoder.dateEncodingStrategy = .formatted(formatter)`);
                 this.emitLine("return String(data: try self.jsonData(), encoding: encoding)");
             });
         });
-    };
+    }
 
-    private emitDecodingError = (name: Name): void => {
+    private emitDecodingError(name: Name): void {
         this.emitLine(
             "throw DecodingError.typeMismatch(",
             name,
@@ -869,7 +869,7 @@ encoder.dateEncodingStrategy = .formatted(formatter)`);
             name,
             '"))'
         );
-    };
+    }
 
     private emitSupportFunctions4 = (): void => {
         // This assumes that this method is called after declarations


### PR DESCRIPTION
This updates all closure-based methods from all the Renderers to use methods. This allows subclasses to extend these functions, which otherwise would not be accessible via `super`.

This PR should be squashed if merged.