### PR TITLE
Export javaNameStyle

### DIFF
--- a/src/quicktype-core/language/Java.ts
+++ b/src/quicktype-core/language/Java.ts
@@ -146,7 +146,7 @@ const legalizeName = utf16LegalizeCharacters(isPartCharacter);
 // we have to use namers to produce the getter and setter names - we can't
 // just capitalize and concatenate.
 // https://stackoverflow.com/questions/8277355/naming-convention-for-upper-case-abbreviations
-function javaNameStyle(startWithUpper: boolean, upperUnderscore: boolean, original: string): string {
+export function javaNameStyle(startWithUpper: boolean, upperUnderscore: boolean, original: string): string {
     const words = splitIntoWords(original);
     return combineWords(
         words,


### PR DESCRIPTION
For defining custom namers that generate valid Java identifiers.

My use case here is that I am generating a constant variable for each class property, and need to create a namer based on the property for each constant. For example, a class property `foo_bar` may have an associated `private static final String FOO_BAR_KEY = "hello world"`