### PR TITLE
Acronym style

### DIFF
--- a/src/quicktype-core/language/Java.ts
+++ b/src/quicktype-core/language/Java.ts
@@ -23,11 +23,11 @@ import { BooleanOption, StringOption, Option, OptionValues, getOptionValues } fr
 import { anyTypeIssueAnnotation, nullTypeIssueAnnotation } from "../Annotation";
 import { defined, assert, assertNever } from "../support/Support";
 import { RenderContext } from "../Renderer";
-import { acronymOption, acronymStyle, acronymStyleOptions } from "../support/Acronyms";
+import { acronymOption, acronymStyle, AcronymStyleOptions } from "../support/Acronyms";
 
 export const javaOptions = {
     justTypes: new BooleanOption("just-types", "Plain types only", false),
-    acronymStyle: acronymOption(acronymStyleOptions.pascal),
+    acronymStyle: acronymOption(AcronymStyleOptions.Pascal),
     // FIXME: Do this via a configurable named eventually.
     packageName: new StringOption("package", "Generated package name", "NAME", "io.quicktype")
 };

--- a/src/quicktype-core/language/Java.ts
+++ b/src/quicktype-core/language/Java.ts
@@ -23,11 +23,11 @@ import { BooleanOption, StringOption, Option, OptionValues, getOptionValues } fr
 import { anyTypeIssueAnnotation, nullTypeIssueAnnotation } from "../Annotation";
 import { defined, assert, assertNever } from "../support/Support";
 import { RenderContext } from "../Renderer";
-import { acronymOption, acronymStyle } from "../support/Acronyms";
+import { acronymOption, acronymStyle, acronymStyleOptions } from "../support/Acronyms";
 
 export const javaOptions = {
     justTypes: new BooleanOption("just-types", "Plain types only", false),
-    acronymStyle: acronymOption,
+    acronymStyle: acronymOption(acronymStyleOptions.pascal),
     // FIXME: Do this via a configurable named eventually.
     packageName: new StringOption("package", "Generated package name", "NAME", "io.quicktype")
 };

--- a/src/quicktype-core/language/Java.ts
+++ b/src/quicktype-core/language/Java.ts
@@ -14,31 +14,20 @@ import {
     combineWords,
     allUpperWordStyle,
     firstUpperWordStyle,
-    allLowerWordStyle,
-    acronymStyleOptions,
-    acronymStyle
+    allLowerWordStyle
 } from "../support/Strings";
 import { Name, Namer, funPrefixNamer, DependencyName } from "../Naming";
 import { ConvenienceRenderer, ForbiddenWordsInfo } from "../ConvenienceRenderer";
 import { TargetLanguage } from "../TargetLanguage";
-import { BooleanOption, StringOption, Option, OptionValues, getOptionValues, EnumOption } from "../RendererOptions";
+import { BooleanOption, StringOption, Option, OptionValues, getOptionValues } from "../RendererOptions";
 import { anyTypeIssueAnnotation, nullTypeIssueAnnotation } from "../Annotation";
 import { defined, assert, assertNever } from "../support/Support";
 import { RenderContext } from "../Renderer";
+import { acronymOption, acronymStyle } from "../support/Acronyms";
 
 export const javaOptions = {
     justTypes: new BooleanOption("just-types", "Plain types only", false),
-    acronymStyle: new EnumOption(
-        "acronym-style",
-        "acronym naming convention",
-        [
-            ["originalWord", acronymStyleOptions.originalWord],
-            ["pascal", acronymStyleOptions.pascal],
-            ["camel", acronymStyleOptions.camel],
-            ["capitalize", acronymStyleOptions.capitalize]
-        ],
-        "pascal"
-    ),
+    acronymStyle: acronymOption,
     // FIXME: Do this via a configurable named eventually.
     packageName: new StringOption("package", "Generated package name", "NAME", "io.quicktype")
 };

--- a/src/quicktype-core/language/Java.ts
+++ b/src/quicktype-core/language/Java.ts
@@ -140,10 +140,6 @@ function isPartCharacter(codePoint: number): boolean {
 
 const legalizeName = utf16LegalizeCharacters(isPartCharacter);
 
-// FIXME: Handle acronyms consistently.  In particular, that means that
-// we have to use namers to produce the getter and setter names - we can't
-// just capitalize and concatenate.
-// https://stackoverflow.com/questions/8277355/naming-convention-for-upper-case-abbreviations
 export function javaNameStyle(
     startWithUpper: boolean,
     upperUnderscore: boolean,

--- a/src/quicktype-core/language/Java.ts
+++ b/src/quicktype-core/language/Java.ts
@@ -14,18 +14,31 @@ import {
     combineWords,
     allUpperWordStyle,
     firstUpperWordStyle,
-    allLowerWordStyle
+    allLowerWordStyle,
+    acronymStyleOptions,
+    acronymStyle
 } from "../support/Strings";
 import { Name, Namer, funPrefixNamer, DependencyName } from "../Naming";
 import { ConvenienceRenderer, ForbiddenWordsInfo } from "../ConvenienceRenderer";
 import { TargetLanguage } from "../TargetLanguage";
-import { BooleanOption, StringOption, Option, OptionValues, getOptionValues } from "../RendererOptions";
+import { BooleanOption, StringOption, Option, OptionValues, getOptionValues, EnumOption } from "../RendererOptions";
 import { anyTypeIssueAnnotation, nullTypeIssueAnnotation } from "../Annotation";
 import { defined, assert, assertNever } from "../support/Support";
 import { RenderContext } from "../Renderer";
 
 export const javaOptions = {
     justTypes: new BooleanOption("just-types", "Plain types only", false),
+    acronymStyle: new EnumOption(
+        "acronym-style",
+        "acronym naming convention",
+        [
+            ["originalWord", acronymStyleOptions.originalWord],
+            ["pascal", acronymStyleOptions.pascal],
+            ["camel", acronymStyleOptions.camel],
+            ["capitalize", acronymStyleOptions.capitalize]
+        ],
+        "pascal"
+    ),
     // FIXME: Do this via a configurable named eventually.
     packageName: new StringOption("package", "Generated package name", "NAME", "io.quicktype")
 };
@@ -36,7 +49,7 @@ export class JavaTargetLanguage extends TargetLanguage {
     }
 
     protected getOptions(): Option<any>[] {
-        return [javaOptions.packageName, javaOptions.justTypes];
+        return [javaOptions.packageName, javaOptions.justTypes, javaOptions.acronymStyle];
     }
 
     get supportsUnionsWithBothNumberTypes(): boolean {
@@ -125,10 +138,6 @@ const keywords = [
     "true"
 ];
 
-const typeNamingFunction = funPrefixNamer("types", n => javaNameStyle(true, false, n));
-const propertyNamingFunction = funPrefixNamer("properties", n => javaNameStyle(false, false, n));
-const enumCaseNamingFunction = funPrefixNamer("enum-cases", n => javaNameStyle(true, true, n));
-
 export const stringEscape = utf16ConcatMap(escapeNonPrintableMapper(isAscii, standardUnicodeHexEscape));
 
 function isStartCharacter(codePoint: number): boolean {
@@ -146,7 +155,12 @@ const legalizeName = utf16LegalizeCharacters(isPartCharacter);
 // we have to use namers to produce the getter and setter names - we can't
 // just capitalize and concatenate.
 // https://stackoverflow.com/questions/8277355/naming-convention-for-upper-case-abbreviations
-export function javaNameStyle(startWithUpper: boolean, upperUnderscore: boolean, original: string): string {
+export function javaNameStyle(
+    startWithUpper: boolean,
+    upperUnderscore: boolean,
+    original: string,
+    acronymsStyle: (s: string) => string = allUpperWordStyle
+): string {
     const words = splitIntoWords(original);
     return combineWords(
         words,
@@ -154,7 +168,7 @@ export function javaNameStyle(startWithUpper: boolean, upperUnderscore: boolean,
         upperUnderscore ? allUpperWordStyle : startWithUpper ? firstUpperWordStyle : allLowerWordStyle,
         upperUnderscore ? allUpperWordStyle : firstUpperWordStyle,
         upperUnderscore || startWithUpper ? allUpperWordStyle : allLowerWordStyle,
-        allUpperWordStyle,
+        acronymsStyle,
         upperUnderscore ? "_" : "",
         isStartCharacter
     );
@@ -182,19 +196,19 @@ export class JavaRenderer extends ConvenienceRenderer {
     }
 
     protected makeNamedTypeNamer(): Namer {
-        return typeNamingFunction;
+        return this.getNameStyling("typeNamingFunction");
     }
 
     protected namerForObjectProperty(): Namer {
-        return propertyNamingFunction;
+        return this.getNameStyling("propertyNamingFunction");
     }
 
     protected makeUnionMemberNamer(): Namer {
-        return propertyNamingFunction;
+        return this.getNameStyling("propertyNamingFunction");
     }
 
     protected makeEnumCaseNamer(): Namer {
-        return enumCaseNamingFunction;
+        return this.getNameStyling("enumCaseNamingFunction");
     }
 
     protected unionNeedsName(u: UnionType): boolean {
@@ -215,8 +229,16 @@ export class JavaRenderer extends ConvenienceRenderer {
         _jsonName: string,
         name: Name
     ): [Name, Name] {
-        const getterName = new DependencyName(propertyNamingFunction, name.order, lookup => `get_${lookup(name)}`);
-        const setterName = new DependencyName(propertyNamingFunction, name.order, lookup => `set_${lookup(name)}`);
+        const getterName = new DependencyName(
+            this.getNameStyling("propertyNamingFunction"),
+            name.order,
+            lookup => `get_${lookup(name)}`
+        );
+        const setterName = new DependencyName(
+            this.getNameStyling("propertyNamingFunction"),
+            name.order,
+            lookup => `set_${lookup(name)}`
+        );
         return [getterName, setterName];
     }
 
@@ -230,6 +252,21 @@ export class JavaRenderer extends ConvenienceRenderer {
         const getterAndSetterNames = this.makeNamesForPropertyGetterAndSetter(c, className, p, jsonName, name);
         this._gettersAndSettersForPropertyName.set(name, getterAndSetterNames);
         return getterAndSetterNames;
+    }
+
+    private getNameStyling(convention: string): Namer {
+        const styling: { [key: string]: Namer } = {
+            typeNamingFunction: funPrefixNamer("types", n =>
+                javaNameStyle(true, false, n, acronymStyle(this._options.acronymStyle))
+            ),
+            propertyNamingFunction: funPrefixNamer("properties", n =>
+                javaNameStyle(false, false, n, acronymStyle(this._options.acronymStyle))
+            ),
+            enumCaseNamingFunction: funPrefixNamer("enum-cases", n =>
+                javaNameStyle(true, true, n, acronymStyle(this._options.acronymStyle))
+            )
+        };
+        return styling[convention];
     }
 
     private fieldOrMethodName(methodName: string, topLevelName: Name): Sourcelike {

--- a/src/quicktype-core/language/Swift.ts
+++ b/src/quicktype-core/language/Swift.ts
@@ -40,7 +40,7 @@ import { RenderContext } from "../Renderer";
 import { StringTypeMapping } from "../TypeBuilder";
 import { panic } from "../support/Support";
 import { DefaultDateTimeRecognizer, DateTimeRecognizer } from "../DateTime";
-import { acronymOption, acronymStyle } from "../support/Acronyms";
+import { acronymOption, acronymStyle, acronymStyleOptions } from "../support/Acronyms";
 
 const MAX_SAMELINE_PROPERTIES = 4;
 
@@ -51,7 +51,7 @@ export const swiftOptions = {
     alamofire: new BooleanOption("alamofire", "Alamofire extensions", false),
     namedTypePrefix: new StringOption("type-prefix", "Prefix for type names", "PREFIX", "", "secondary"),
     useClasses: new EnumOption("struct-or-class", "Structs or classes", [["struct", false], ["class", true]]),
-    acronymStyle: acronymOption,
+    acronymStyle: acronymOption(acronymStyleOptions.pascal),
     dense: new EnumOption("density", "Code density", [["dense", true], ["normal", false]], "dense", "secondary"),
     linux: new BooleanOption("support-linux", "Support Linux", false, "secondary"),
     accessLevel: new EnumOption(

--- a/src/quicktype-core/language/Swift.ts
+++ b/src/quicktype-core/language/Swift.ts
@@ -34,14 +34,13 @@ import {
     allLowerWordStyle,
     allUpperWordStyle,
     camelCase,
-    addPrefixIfNecessary,
-    acronymStyleOptions,
-    acronymStyle
+    addPrefixIfNecessary
 } from "../support/Strings";
 import { RenderContext } from "../Renderer";
 import { StringTypeMapping } from "../TypeBuilder";
 import { panic } from "../support/Support";
 import { DefaultDateTimeRecognizer, DateTimeRecognizer } from "../DateTime";
+import { acronymOption, acronymStyle } from "../support/Acronyms";
 
 const MAX_SAMELINE_PROPERTIES = 4;
 
@@ -52,17 +51,7 @@ export const swiftOptions = {
     alamofire: new BooleanOption("alamofire", "Alamofire extensions", false),
     namedTypePrefix: new StringOption("type-prefix", "Prefix for type names", "PREFIX", "", "secondary"),
     useClasses: new EnumOption("struct-or-class", "Structs or classes", [["struct", false], ["class", true]]),
-    acronymStyle: new EnumOption(
-        "acronym-style",
-        "acronym naming convention",
-        [
-            ["originalWord", acronymStyleOptions.originalWord],
-            ["pascal", acronymStyleOptions.pascal],
-            ["camel", acronymStyleOptions.camel],
-            ["capitalize", acronymStyleOptions.capitalize]
-        ],
-        "pascal"
-    ),
+    acronymStyle: acronymOption,
     dense: new EnumOption("density", "Code density", [["dense", true], ["normal", false]], "dense", "secondary"),
     linux: new BooleanOption("support-linux", "Support Linux", false, "secondary"),
     accessLevel: new EnumOption(

--- a/src/quicktype-core/language/Swift.ts
+++ b/src/quicktype-core/language/Swift.ts
@@ -40,7 +40,7 @@ import { RenderContext } from "../Renderer";
 import { StringTypeMapping } from "../TypeBuilder";
 import { panic } from "../support/Support";
 import { DefaultDateTimeRecognizer, DateTimeRecognizer } from "../DateTime";
-import { acronymOption, acronymStyle, acronymStyleOptions } from "../support/Acronyms";
+import { acronymOption, acronymStyle, AcronymStyleOptions } from "../support/Acronyms";
 
 const MAX_SAMELINE_PROPERTIES = 4;
 
@@ -51,7 +51,7 @@ export const swiftOptions = {
     alamofire: new BooleanOption("alamofire", "Alamofire extensions", false),
     namedTypePrefix: new StringOption("type-prefix", "Prefix for type names", "PREFIX", "", "secondary"),
     useClasses: new EnumOption("struct-or-class", "Structs or classes", [["struct", false], ["class", true]]),
-    acronymStyle: acronymOption(acronymStyleOptions.pascal),
+    acronymStyle: acronymOption(AcronymStyleOptions.Pascal),
     dense: new EnumOption("density", "Code density", [["dense", true], ["normal", false]], "dense", "secondary"),
     linux: new BooleanOption("support-linux", "Support Linux", false, "secondary"),
     accessLevel: new EnumOption(

--- a/src/quicktype-core/support/Acronyms.ts
+++ b/src/quicktype-core/support/Acronyms.ts
@@ -1115,7 +1115,8 @@ export const acronymOption = new EnumOption(
         ["camel", acronymStyleOptions.camel],
         ["capitalize", acronymStyleOptions.capitalize]
     ],
-    "pascal"
+    "pascal",
+    "secondary"
 );
 
 export function acronymStyle(style: acronymStyleOptions): (s: string) => string {

--- a/src/quicktype-core/support/Acronyms.ts
+++ b/src/quicktype-core/support/Acronyms.ts
@@ -1110,7 +1110,7 @@ export const acronymOption = new EnumOption(
     "acronym-style",
     "acronym naming convention",
     [
-        ["originalWord", acronymStyleOptions.originalWord],
+        ["original", acronymStyleOptions.originalWord],
         ["pascal", acronymStyleOptions.pascal],
         ["camel", acronymStyleOptions.camel],
         ["capitalize", acronymStyleOptions.capitalize]

--- a/src/quicktype-core/support/Acronyms.ts
+++ b/src/quicktype-core/support/Acronyms.ts
@@ -1,5 +1,5 @@
 import { EnumOption } from "../RendererOptions";
-import { allUpperWordStyle, firstUpperWordStyle, capitalize, originalWord } from "./Strings";
+import { allUpperWordStyle, firstUpperWordStyle, capitalize, originalWord, allLowerWordStyle } from "./Strings";
 
 export const acronyms: string[] = [
     "aaa",
@@ -1099,32 +1099,36 @@ export const acronyms: string[] = [
     "zpl"
 ];
 
-export enum AcronymStyleOptions {
-    Pascal,
-    Camel,
-    Capitalize,
-    OriginalWord
+export enum acronymStyleOptions {
+    pascal = "pascal",
+    camel = "camel",
+    capitalize = "capitalize",
+    originalWord = "originalWord",
+    lower = "lowerCase"
 }
 
-export const acronymOption = new EnumOption(
-    "acronym-style",
-    "acronym naming convention",
-    [
-        ["original", AcronymStyleOptions.OriginalWord],
-        ["pascal", AcronymStyleOptions.Pascal],
-        ["camel", AcronymStyleOptions.Camel],
-        ["capitalize", AcronymStyleOptions.Capitalize]
-    ],
-    "pascal",
-    "secondary"
-);
+export const acronymOption = function(defaultOption: acronymStyleOptions) {
+    return new EnumOption(
+        "acronym-style",
+        "acronym naming convention",
+        [
+            [acronymStyleOptions.originalWord, acronymStyleOptions.originalWord],
+            [acronymStyleOptions.pascal, acronymStyleOptions.pascal],
+            [acronymStyleOptions.camel, acronymStyleOptions.camel],
+            [acronymStyleOptions.capitalize, acronymStyleOptions.capitalize],
+            [acronymStyleOptions.lower, acronymStyleOptions.lower]
+        ],
+        defaultOption
+    );
+};
 
-export function acronymStyle(style: AcronymStyleOptions): (s: string) => string {
+export function acronymStyle(style: acronymStyleOptions): (s: string) => string {
     const options: { [key: string]: (s: string) => string } = {
-        [AcronymStyleOptions.Pascal]: allUpperWordStyle,
-        [AcronymStyleOptions.Camel]: firstUpperWordStyle,
-        [AcronymStyleOptions.Capitalize]: capitalize,
-        [AcronymStyleOptions.OriginalWord]: originalWord
+        [acronymStyleOptions.pascal]: allUpperWordStyle,
+        [acronymStyleOptions.camel]: firstUpperWordStyle,
+        [acronymStyleOptions.capitalize]: capitalize,
+        [acronymStyleOptions.originalWord]: originalWord,
+        [acronymStyleOptions.lower]: allLowerWordStyle
     };
 
     return options[style];

--- a/src/quicktype-core/support/Acronyms.ts
+++ b/src/quicktype-core/support/Acronyms.ts
@@ -1,3 +1,6 @@
+import { EnumOption } from "../RendererOptions";
+import { allUpperWordStyle, firstUpperWordStyle, capitalize, originalWord } from "./Strings";
+
 export const acronyms: string[] = [
     "aaa",
     "aabb",
@@ -1095,3 +1098,33 @@ export const acronyms: string[] = [
     "zope",
     "zpl"
 ];
+
+export enum acronymStyleOptions {
+    pascal,
+    camel,
+    capitalize,
+    originalWord
+}
+
+export const acronymOption = new EnumOption(
+    "acronym-style",
+    "acronym naming convention",
+    [
+        ["originalWord", acronymStyleOptions.originalWord],
+        ["pascal", acronymStyleOptions.pascal],
+        ["camel", acronymStyleOptions.camel],
+        ["capitalize", acronymStyleOptions.capitalize]
+    ],
+    "pascal"
+);
+
+export function acronymStyle(style: acronymStyleOptions): (s: string) => string {
+    const options: { [key: string]: (s: string) => string } = {
+        [acronymStyleOptions.pascal]: allUpperWordStyle,
+        [acronymStyleOptions.camel]: firstUpperWordStyle,
+        [acronymStyleOptions.capitalize]: capitalize,
+        [acronymStyleOptions.originalWord]: originalWord
+    };
+
+    return options[style];
+}

--- a/src/quicktype-core/support/Acronyms.ts
+++ b/src/quicktype-core/support/Acronyms.ts
@@ -1099,36 +1099,37 @@ export const acronyms: string[] = [
     "zpl"
 ];
 
-export enum acronymStyleOptions {
-    pascal = "pascal",
-    camel = "camel",
-    capitalize = "capitalize",
-    originalWord = "originalWord",
-    lower = "lowerCase"
+export enum AcronymStyleOptions {
+    Pascal = "pascal",
+    Camel = "camel",
+    Capitalize = "capitalize",
+    Original = "original",
+    Lower = "lowerCase"
 }
 
-export const acronymOption = function(defaultOption: acronymStyleOptions) {
+export const acronymOption = function(defaultOption: AcronymStyleOptions) {
     return new EnumOption(
         "acronym-style",
         "acronym naming convention",
         [
-            [acronymStyleOptions.originalWord, acronymStyleOptions.originalWord],
-            [acronymStyleOptions.pascal, acronymStyleOptions.pascal],
-            [acronymStyleOptions.camel, acronymStyleOptions.camel],
-            [acronymStyleOptions.capitalize, acronymStyleOptions.capitalize],
-            [acronymStyleOptions.lower, acronymStyleOptions.lower]
+            [AcronymStyleOptions.Original, AcronymStyleOptions.Original],
+            [AcronymStyleOptions.Pascal, AcronymStyleOptions.Pascal],
+            [AcronymStyleOptions.Camel, AcronymStyleOptions.Camel],
+            [AcronymStyleOptions.Capitalize, AcronymStyleOptions.Capitalize],
+            [AcronymStyleOptions.Lower, AcronymStyleOptions.Lower]
         ],
-        defaultOption
+        defaultOption,
+        "secondary"
     );
 };
 
-export function acronymStyle(style: acronymStyleOptions): (s: string) => string {
+export function acronymStyle(style: AcronymStyleOptions): (s: string) => string {
     const options: { [key: string]: (s: string) => string } = {
-        [acronymStyleOptions.pascal]: allUpperWordStyle,
-        [acronymStyleOptions.camel]: firstUpperWordStyle,
-        [acronymStyleOptions.capitalize]: capitalize,
-        [acronymStyleOptions.originalWord]: originalWord,
-        [acronymStyleOptions.lower]: allLowerWordStyle
+        [AcronymStyleOptions.Pascal]: allUpperWordStyle,
+        [AcronymStyleOptions.Camel]: firstUpperWordStyle,
+        [AcronymStyleOptions.Capitalize]: capitalize,
+        [AcronymStyleOptions.Original]: originalWord,
+        [AcronymStyleOptions.Lower]: allLowerWordStyle
     };
 
     return options[style];

--- a/src/quicktype-core/support/Acronyms.ts
+++ b/src/quicktype-core/support/Acronyms.ts
@@ -1099,32 +1099,32 @@ export const acronyms: string[] = [
     "zpl"
 ];
 
-export enum acronymStyleOptions {
-    pascal,
-    camel,
-    capitalize,
-    originalWord
+export enum AcronymStyleOptions {
+    Pascal,
+    Camel,
+    Capitalize,
+    OriginalWord
 }
 
 export const acronymOption = new EnumOption(
     "acronym-style",
     "acronym naming convention",
     [
-        ["original", acronymStyleOptions.originalWord],
-        ["pascal", acronymStyleOptions.pascal],
-        ["camel", acronymStyleOptions.camel],
-        ["capitalize", acronymStyleOptions.capitalize]
+        ["original", AcronymStyleOptions.OriginalWord],
+        ["pascal", AcronymStyleOptions.Pascal],
+        ["camel", AcronymStyleOptions.Camel],
+        ["capitalize", AcronymStyleOptions.Capitalize]
     ],
     "pascal",
     "secondary"
 );
 
-export function acronymStyle(style: acronymStyleOptions): (s: string) => string {
+export function acronymStyle(style: AcronymStyleOptions): (s: string) => string {
     const options: { [key: string]: (s: string) => string } = {
-        [acronymStyleOptions.pascal]: allUpperWordStyle,
-        [acronymStyleOptions.camel]: firstUpperWordStyle,
-        [acronymStyleOptions.capitalize]: capitalize,
-        [acronymStyleOptions.originalWord]: originalWord
+        [AcronymStyleOptions.Pascal]: allUpperWordStyle,
+        [AcronymStyleOptions.Camel]: firstUpperWordStyle,
+        [AcronymStyleOptions.Capitalize]: capitalize,
+        [AcronymStyleOptions.OriginalWord]: originalWord
     };
 
     return options[style];

--- a/src/quicktype-core/support/Strings.ts
+++ b/src/quicktype-core/support/Strings.ts
@@ -12,24 +12,6 @@ export type NamingStyle =
 
 const unicode = require("unicode-properties");
 
-export enum acronymStyleOptions {
-    pascal,
-    camel,
-    capitalize,
-    originalWord
-}
-
-export function acronymStyle(style: acronymStyleOptions): (s: string) => string {
-    const options: { [key: string]: (s: string) => string } = {
-        [acronymStyleOptions.pascal]: allUpperWordStyle,
-        [acronymStyleOptions.camel]: firstUpperWordStyle,
-        [acronymStyleOptions.capitalize]: capitalize,
-        [acronymStyleOptions.originalWord]: originalWord
-    };
-
-    return options[style];
-}
-
 function computeAsciiMap(
     mapper: (codePoint: number) => string
 ): { charStringMap: string[]; charNoEscapeMap: number[] } {

--- a/src/quicktype-core/support/Strings.ts
+++ b/src/quicktype-core/support/Strings.ts
@@ -12,6 +12,24 @@ export type NamingStyle =
 
 const unicode = require("unicode-properties");
 
+export enum acronymStyleOptions {
+    pascal,
+    camel,
+    capitalize,
+    originalWord
+}
+
+export function acronymStyle(style: acronymStyleOptions): (s: string) => string {
+    const options: { [key: string]: (s: string) => string } = {
+        [acronymStyleOptions.pascal]: allUpperWordStyle,
+        [acronymStyleOptions.camel]: firstUpperWordStyle,
+        [acronymStyleOptions.capitalize]: capitalize,
+        [acronymStyleOptions.originalWord]: originalWord
+    };
+
+    return options[style];
+}
+
 function computeAsciiMap(
     mapper: (codePoint: number) => string
 ): { charStringMap: string[]; charNoEscapeMap: number[] } {
@@ -445,6 +463,10 @@ export function firstUpperWordStyle(s: string): string {
 
 export function allUpperWordStyle(s: string): string {
     return s.toUpperCase();
+}
+
+export function originalWord(s: string): string {
+    return s;
 }
 
 export function allLowerWordStyle(s: string): string {


### PR DESCRIPTION
Solution for the comment around acronyms consistently relating to https://stackoverflow.com/questions/8277355/naming-convention-for-upper-case-abbreviations

Added a new CLIoption called "acronym-style" which supports originalWord, pascal, camel and capitalize as the styling for an acronym. I've added a fallback so by default we stay with the current wordstyle. 
It's has been implemented on both swift and Java to resolve the current fixme in the JavaRender 

**Example**
--acronym-style originalWord