### PR TITLE
Fix rename of method in string text.

### DIFF
--- a/src/quicktype-core/ConvenienceRenderer.ts
+++ b/src/quicktype-core/ConvenienceRenderer.ts
@@ -595,7 +595,7 @@ export abstract class ConvenienceRenderer extends Renderer {
     }
 
     protected isImplicitCycleBreaker(_t: Type): boolean {
-        return panic("A renderer that invokes isCycleBreakerType must implement canBeCycleBreakerType");
+        return panic("A renderer that invokes isCycleBreakerType must implement isImplicitCycleBreaker");
     }
 
     protected canBreakCycles(_t: Type): boolean {


### PR DESCRIPTION
In 59cd3db87, a method was renamed, but not in this string text.