### PR TITLE
Cpp changes marius

### DIFF
--- a/src/quicktype-core/language/CPlusPlus.ts
+++ b/src/quicktype-core/language/CPlusPlus.ts
@@ -1609,7 +1609,7 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
         this.emitLine("template <typename T>");
         this.emitBlock(["struct adl_serializer<", optionalType, "<T>>"], true, () => {
             
-            this.emitBlock(["static void to_json(json & j, ", this.withConst(optionalType), "<T> & opt)"], false, () => {
+            this.emitBlock(["static void to_json(json & j, ", this.withConst([optionalType, "<T>"]), " & opt)"], false, () => {
                 this.emitLine("if (!opt) j = nullptr; else j = *opt;");
             });
 

--- a/src/quicktype-core/language/CPlusPlus.ts
+++ b/src/quicktype-core/language/CPlusPlus.ts
@@ -1017,8 +1017,7 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
                 } else {
                     if(this._options.constStyle) {
                         this.emitLine("const ", rendered, " & ", getterName, "() const { return ", name, "; }");
-                    }
-                    else {
+                    } else {
                         this.emitLine(rendered, " const & ", getterName, "() const { return ", name, "; }");                     
                     }
                     this.emitLine(rendered, " & ", mutableGetterName, "() { return ", name, "; }");
@@ -1039,8 +1038,7 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
                                 name,
                                 " = value; }"
                             );
-                        }
-                        else {
+                        } else {
                             this.emitLine(
                                 "void ",
                                 setterName,
@@ -1068,8 +1066,7 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
                                 name,
                                 " = value; }"
                             );
-                        }
-                        else {
+                        } else {
                             this.emitLine(
                                 "void ",
                                 setterName,
@@ -1153,8 +1150,7 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
             if(this._options.constStyle) {
                 this.emitLine("void from_json(const json & j, ", ourQualifier, className, " & x);");
                 this.emitLine("void to_json(json & j, const ", ourQualifier, className, " & x);");
-            }
-            else {
+            } else {
                 this.emitLine("void from_json(json const & j, ", ourQualifier, className, " & x);");
                 this.emitLine("void to_json(json & j, ", ourQualifier, className, " const & x);");
             }
@@ -1167,8 +1163,7 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
         if(this._options.constStyle) {
             this.emitLine("void from_json(const json & j, ", ourQualifier, className, " & x);");
             this.emitLine("void to_json(json & j, const ", ourQualifier, className, " & x);");
-        }
-        else {
+        } else {
             this.emitLine("void from_json(json const & j, ", ourQualifier, className, " & x);");
             this.emitLine("void to_json(json & j, ", ourQualifier, className, " const & x);");
         }
@@ -1438,8 +1433,7 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
         if(this._options.constStyle) {
             this.emitLine("void from_json(const json & j, ", variantType, " & x);");
             this.emitLine("void to_json(json & j, const ", variantType, " & x);");
-        }
-        else {
+        } else {
             this.emitLine("void from_json(json const & j, ", variantType, " & x);");
             this.emitLine("void to_json(json & j, ", variantType, " const & x);");
         }
@@ -1559,8 +1553,7 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
         if(this._options.constStyle) {
             this.emitLine("void from_json(const json & j, ", ourQualifier, enumName, " & x);");
             this.emitLine("void to_json(json & j, const ", ourQualifier, enumName, " & x);");
-        } 
-        else {
+        } else {
             this.emitLine("void from_json(json const & j, ", ourQualifier, enumName, " & x);");
             this.emitLine("void to_json(json & j, ", ourQualifier, enumName, " const & x);");
         }
@@ -1690,8 +1683,7 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
                         `if (j.is_null()) return std::unique_ptr<T>(); else return std::unique_ptr<T>(new T(j.get<T>()));`
                     );
                 });
-            }
-            else {
+            } else {
                 this.emitBlock(["static void to_json(json & j, ", optionalType, "<T> const & opt)"], false, () => {
                     this.emitLine("if (!opt) j = nullptr; else j = *opt;");
                 });

--- a/src/quicktype-core/language/CPlusPlus.ts
+++ b/src/quicktype-core/language/CPlusPlus.ts
@@ -1423,9 +1423,9 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
     }
 
     protected emitUnionTypedefs(u: UnionType, unionName: Name): void {
-        this.emitLine("typedef ", this.variantType(u, false), " ", unionName, ";");
+        this.emitLine("using ", unionName, " = ", this.variantType(u, false), ";");
     }
-    
+
     protected emitUnionHeaders(u: UnionType): void {
         const nonNulls = removeNullFromUnion(u, true)[1];
         const variantType = this.cppTypeInOptional(
@@ -1629,19 +1629,19 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
 
     protected emitTopLevelTypedef(t: Type, name: Name): void {
         this.emitLine(
-            "typedef ",
+            "using ",
+            name,
+            " = ",
             this.cppType(
                 t,
                 { needsForwardIndirection: true, needsOptionalIndirection: true, inJsonNamespace: false },
                 true,
                 false
             ),
-            " ",
-            name,
             ";"
         );
     }
-    
+
     protected emitAllUnionFunctions(): void {
         this.forEachUniqueUnion(
             "interposing",

--- a/src/quicktype-core/language/CPlusPlus.ts
+++ b/src/quicktype-core/language/CPlusPlus.ts
@@ -73,7 +73,7 @@ export const cPlusPlusOptions = {
         "not-permissive",
         "secondary"
     ),
-    constStyle : new EnumOption(
+    westConst : new EnumOption(
       "const-style",
       "Put const to the left/west (const T) or right/east (T const)",
       [["west-const", true], ["east-const", false]],
@@ -120,7 +120,7 @@ export class CPlusPlusTargetLanguage extends TargetLanguage {
             cPlusPlusOptions.codeFormat,
             cPlusPlusOptions.wstring,
             cPlusPlusOptions.msbuildPermissive,
-            cPlusPlusOptions.constStyle,
+            cPlusPlusOptions.westConst,
             cPlusPlusOptions.typeSourceStyle,
             cPlusPlusOptions.includeLocation,
             cPlusPlusOptions.typeNamingStyle,
@@ -1015,14 +1015,14 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
                         this.emitLine("void ", setterName, "(", rendered, " value) { this->", name, " = value; }");
                     }
                 } else {
-                    if(this._options.constStyle) {
+                    if(this._options.westConst) {
                         this.emitLine("const ", rendered, " & ", getterName, "() const { return ", name, "; }");
                     } else {
                         this.emitLine(rendered, " const & ", getterName, "() const { return ", name, "; }");                     
                     }
                     this.emitLine(rendered, " & ", mutableGetterName, "() { return ", name, "; }");
                     if (constraints !== undefined && constraints.has(jsonName)) {
-                        if(this._options.constStyle) {
+                        if(this._options.westConst) {
                             this.emitLine(
                                 "void ",
                                 setterName,
@@ -1056,7 +1056,7 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
                             );                            
                         }
                     } else {
-                        if(this._options.constStyle) {
+                        if(this._options.westConst) {
                             this.emitLine(
                                 "void ",
                                 setterName,
@@ -1147,7 +1147,7 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
         if (t instanceof MapType && this._stringType !== this.NarrowString) {
             const ourQualifier = this.ourQualifier(true);
             
-            if(this._options.constStyle) {
+            if(this._options.westConst) {
                 this.emitLine("void from_json(const json & j, ", ourQualifier, className, " & x);");
                 this.emitLine("void to_json(json & j, const ", ourQualifier, className, " & x);");
             } else {
@@ -1160,7 +1160,7 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
     protected emitClassHeaders(className: Name): void {
         const ourQualifier = this.ourQualifier(true);
         
-        if(this._options.constStyle) {
+        if(this._options.westConst) {
             this.emitLine("void from_json(const json & j, ", ourQualifier, className, " & x);");
             this.emitLine("void to_json(json & j, const ", ourQualifier, className, " & x);");
         } else {
@@ -1177,7 +1177,7 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
             let toType: Sourcelike;
 
             this.emitBlock(
-                this._options.constStyle ?
+                this._options.westConst ?
                 ["inline void from_json(const json & j, ", ourQualifier, className, "& x)"]:
                 ["inline void from_json(json const & j, ", ourQualifier, className, "& x)"]
                 , false, () => {
@@ -1202,7 +1202,7 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
             });
 
             this.emitBlock(
-                this._options.constStyle ?
+                this._options.westConst ?
                 ["inline void to_json(json & j, const ", ourQualifier, className, " & x)"] :
                 ["inline void to_json(json & j, ", ourQualifier, className, " const & x)"]
                 , false, () => {
@@ -1234,7 +1234,7 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
         let toType: Sourcelike;
 
         this.emitBlock(
-            this._options.constStyle ? 
+            this._options.westConst ? 
             ["inline void from_json(const json & j, ", ourQualifier, className, "& x)"] : 
             ["inline void from_json(json const & j, ", ourQualifier, className, "& x)"]
             , false, () => {
@@ -1356,7 +1356,7 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
         this.ensureBlankLine();
         
         this.emitBlock(
-            this._options.constStyle ? 
+            this._options.westConst ? 
             ["inline void to_json(json & j, const ", ourQualifier, className, " & x)"] : 
             ["inline void to_json(json & j, ", ourQualifier, className, " const & x)"]
             , false, () => {
@@ -1430,7 +1430,7 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
             false
         );
         
-        if(this._options.constStyle) {
+        if(this._options.westConst) {
             this.emitLine("void from_json(const json & j, ", variantType, " & x);");
             this.emitLine("void to_json(json & j, const ", variantType, " & x);");
         } else {
@@ -1461,7 +1461,7 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
         );
 
         this.emitBlock(
-            this._options.constStyle ? 
+            this._options.westConst ? 
             ["inline void from_json(const json & j, ", variantType, " & x)"] :
             ["inline void from_json(json const & j, ", variantType, " & x)"]
             , false, () => {
@@ -1500,7 +1500,7 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
         this.ensureBlankLine();
         
         this.emitBlock(
-            this._options.constStyle ?         
+            this._options.westConst ?         
             ["inline void to_json(json & j, const ", variantType, " & x)"] : 
             ["inline void to_json(json & j, ", variantType, " const & x)"]
             , false, () => {
@@ -1550,7 +1550,7 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
     protected emitEnumHeaders(enumName: Name): void {
         const ourQualifier = this.ourQualifier(true);
         
-        if(this._options.constStyle) {
+        if(this._options.westConst) {
             this.emitLine("void from_json(const json & j, ", ourQualifier, enumName, " & x);");
             this.emitLine("void to_json(json & j, const ", ourQualifier, enumName, " & x);");
         } else {
@@ -1563,7 +1563,7 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
         const ourQualifier = this.ourQualifier(true);
 
         this.emitBlock(
-            this._options.constStyle ?
+            this._options.westConst ?
             ["inline void from_json(const json & j, ", ourQualifier, enumName, " & x)"] :
             ["inline void from_json(json const & j, ", ourQualifier, enumName, " & x)"]
             , false, () => {
@@ -1593,7 +1593,7 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
         this.ensureBlankLine();
         
         this.emitBlock(
-            this._options.constStyle ? 
+            this._options.westConst ? 
             ["inline void to_json(json & j, const ", ourQualifier, enumName, " & x)"] : 
             ["inline void to_json(json & j, ", ourQualifier, enumName, " const & x)"]
             , false, () => {
@@ -1671,7 +1671,7 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
         this.emitLine("template <typename T>");
         this.emitBlock(["struct adl_serializer<", optionalType, "<T>>"], true, () => {
             
-            if(this._options.constStyle) {
+            if(this._options.westConst) {
                 this.emitBlock(["static void to_json(json & j, const ", optionalType, "<T> & opt)"], false, () => {
                     this.emitLine("if (!opt) j = nullptr; else j = *opt;");
                 });
@@ -1812,7 +1812,7 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
 
         const checkConst = this.lookupGlobalName(GlobalNames.CheckConstraint);
         this.emitBlock(
-            this._options.constStyle ? 
+            this._options.westConst ? 
             ["void ", checkConst, "(", this._stringType.getConstType(), " name, const ", classConstraint, " & c, int64_t value)"] :
             ["void ", checkConst, "(", this._stringType.getConstType(), " name, ", classConstraint, " const & c, int64_t value)"]
             ,
@@ -1872,7 +1872,7 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
         this.ensureBlankLine();
 
         this.emitBlock(
-            this._options.constStyle ? 
+            this._options.westConst ? 
             ["void ", checkConst, "(", this._stringType.getConstType(), " name, const ", classConstraint, " & c, ", this._stringType.getConstType(), " value)"] : 
             ["void ", checkConst, "(", this._stringType.getConstType(), " name, ", classConstraint, " const & c, ", this._stringType.getConstType(), " value)"],
             false,
@@ -1972,7 +1972,7 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
 
         this.emitBlock(
         [
-            this._options.constStyle ?
+            this._options.westConst ?
             "inline json get_untyped(const json & j, const char * property)" :
             "inline json get_untyped(json const & j, char const * property)"
         ], false, () => {
@@ -1986,7 +1986,7 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
 
         this.emitBlock(
         [
-            this._options.constStyle ?
+            this._options.westConst ?
             "inline json get_untyped(const json & j, std::string property)" : 
             "inline json get_untyped(json const & j, std::string property)"
         ], false, () => {
@@ -1999,7 +1999,7 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
             this.emitLine("template <typename T>");
             
             this.emitBlock(
-                this._options.constStyle ?
+                this._options.westConst ?
                 ["inline ", optionalType, "<T> get_optional(const json & j, const char * property)"]:
                 ["inline ", optionalType, "<T> get_optional(json const & j, char const * property)"],
                 false,
@@ -2016,7 +2016,7 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
             this.emitLine("template <typename T>");
             
             this.emitBlock(
-                this._options.constStyle ?
+                this._options.westConst ?
                 ["inline ", optionalType, "<T> get_optional(const json & j, std::string property)"] : 
                 ["inline ", optionalType, "<T> get_optional(json const & j, std::string property)"],
                 false,

--- a/src/quicktype-core/language/CPlusPlus.ts
+++ b/src/quicktype-core/language/CPlusPlus.ts
@@ -1105,15 +1105,15 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
         // Maps need ecoding conversions, since they have a string in the key. Other types don't.
         if (t instanceof MapType && this._stringType !== this.NarrowString) {
             const ourQualifier = this.ourQualifier(true);
-            this.emitLine("void from_json(const json& _j, ", ourQualifier, className, "& _x);");
-            this.emitLine("void to_json(json& _j, const ", ourQualifier, className, "& _x);");
+            this.emitLine("void from_json(const json& j, ", ourQualifier, className, "& x);");
+            this.emitLine("void to_json(json& j, const ", ourQualifier, className, "& x);");
         }
     }
 
     protected emitClassHeaders(className: Name): void {
         const ourQualifier = this.ourQualifier(true);
-        this.emitLine("void from_json(const json& _j, ", ourQualifier, className, "& _x);");
-        this.emitLine("void to_json(json& _j, const ", ourQualifier, className, "& _x);");
+        this.emitLine("void from_json(const json& j, ", ourQualifier, className, "& x);");
+        this.emitLine("void to_json(json& j, const ", ourQualifier, className, "& x);");
     }
 
     protected emitTopLevelFunction(t: Type, className: Name): void {
@@ -1123,7 +1123,7 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
             let cppType: Sourcelike;
             let toType: Sourcelike;
 
-            this.emitBlock(["inline void from_json(const json& _j, ", ourQualifier, className, "& _x)"], false, () => {
+            this.emitBlock(["inline void from_json(const json& j, ", ourQualifier, className, "& x)"], false, () => {
                 cppType = this.cppType(
                     t,
                     { needsForwardIndirection: true, needsOptionalIndirection: true, inJsonNamespace: true },
@@ -1138,13 +1138,13 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
                 );
 
                 this.emitLine([
-                    "_x = ",
-                    this._stringType.wrapEncodingChange([ourQualifier], cppType, toType, ["_j.get<", cppType, ">()"]),
+                    "x = ",
+                    this._stringType.wrapEncodingChange([ourQualifier], cppType, toType, ["j.get<", cppType, ">()"]),
                     ";"
                 ]);
             });
 
-            this.emitBlock(["inline void to_json(json& _j, const ", ourQualifier, className, "& _x)"], false, () => {
+            this.emitBlock(["inline void to_json(json& j, const ", ourQualifier, className, "& x)"], false, () => {
                 cppType = this.cppType(
                     t,
                     { needsForwardIndirection: true, needsOptionalIndirection: true, inJsonNamespace: true },
@@ -1159,8 +1159,8 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
                 );
 
                 this.emitLine([
-                    "_j = ",
-                    this._stringType.wrapEncodingChange([ourQualifier], cppType, toType, "_x"),
+                    "j = ",
+                    this._stringType.wrapEncodingChange([ourQualifier], cppType, toType, "x"),
                     ";"
                 ]);
             });
@@ -1172,16 +1172,16 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
         let cppType: Sourcelike;
         let toType: Sourcelike;
 
-        this.emitBlock(["inline void from_json(const json& _j, ", ourQualifier, className, "& _x)"], false, () => {
+        this.emitBlock(["inline void from_json(const json& j, ", ourQualifier, className, "& x)"], false, () => {
             this.forEachClassProperty(c, "none", (name, json, p) => {
                 const [, , setterName] = defined(this._gettersAndSettersForPropertyName.get(name));
                 const t = p.type;
 
                 let assignment: WrappingCode;
                 if (this._options.codeFormat) {
-                    assignment = new WrappingCode(["_x.", setterName, "("], [")"]);
+                    assignment = new WrappingCode(["x.", setterName, "("], [")"]);
                 } else {
-                    assignment = new WrappingCode(["_x.", name, " = "], []);
+                    assignment = new WrappingCode(["x.", name, " = "], []);
                 }
 
                 if (t instanceof UnionType) {
@@ -1219,7 +1219,7 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
                                             ourQualifier,
                                             "get_optional<",
                                             cppType,
-                                            ">(_j, ",
+                                            ">(j, ",
                                             this._stringType.wrapEncodingChange(
                                                 [ourQualifier],
                                                 this._stringType.getType(),
@@ -1242,7 +1242,7 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
                             [],
                             [
                                 ourQualifier,
-                                "get_untyped(_j, ",
+                                "get_untyped(j, ",
                                 this._stringType.wrapEncodingChange(
                                     [ourQualifier],
                                     this._stringType.getType(),
@@ -1272,7 +1272,7 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
                     assignment.wrap(
                         [],
                         this._stringType.wrapEncodingChange([ourQualifier], cppType, toType, [
-                            "_j.at(",
+                            "j.at(",
                             this._stringType.wrapEncodingChange(
                                 [ourQualifier],
                                 this._stringType.getType(),
@@ -1289,8 +1289,8 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
             });
         });
         this.ensureBlankLine();
-        this.emitBlock(["inline void to_json(json& _j, const ", ourQualifier, className, "& _x)"], false, () => {
-            this.emitLine("_j = json::object();");
+        this.emitBlock(["inline void to_json(json& j, const ", ourQualifier, className, "& x)"], false, () => {
+            this.emitLine("j = json::object();");
             this.forEachClassProperty(c, "none", (name, json, p) => {
                 const t = p.type;
                 cppType = this.cppType(
@@ -1313,7 +1313,7 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
                     getter = [name];
                 }
                 this.emitLine(
-                    "_j[",
+                    "j[",
                     this._stringType.wrapEncodingChange(
                         [ourQualifier],
                         this._stringType.getType(),
@@ -1321,7 +1321,7 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
                         this._stringType.createStringLiteral([stringEscape(json)])
                     ),
                     "] = ",
-                    this._stringType.wrapEncodingChange([ourQualifier], cppType, toType, ["_x.", getter]),
+                    this._stringType.wrapEncodingChange([ourQualifier], cppType, toType, ["x.", getter]),
                     ";"
                 );
             });
@@ -1359,8 +1359,8 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
             false,
             false
         );
-        this.emitLine("void from_json(const json& _j, ", variantType, "& _x);");
-        this.emitLine("void to_json(json& _j, const ", variantType, "& _x);");
+        this.emitLine("void from_json(const json& j, ", variantType, "& x);");
+        this.emitLine("void to_json(json& j, const ", variantType, "& x);");
     }
 
     protected emitUnionFunctions(u: UnionType): void {
@@ -1384,12 +1384,12 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
             false
         );
 
-        this.emitBlock(["inline void from_json(const json& _j, ", variantType, "& _x)"], false, () => {
+        this.emitBlock(["inline void from_json(const json& j, ", variantType, "& x)"], false, () => {
             let onFirst = true;
             for (const [kind, func] of functionForKind) {
                 const typeForKind = iterableFind(nonNulls, t => t.kind === kind);
                 if (typeForKind === undefined) continue;
-                this.emitLine(onFirst ? "if" : "else if", " (_j.", func, "())");
+                this.emitLine(onFirst ? "if" : "else if", " (j.", func, "())");
                 this.indent(() => {
                     const cppType = this.cppType(
                         typeForKind,
@@ -1404,9 +1404,9 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
                         false
                     );
                     this.emitLine(
-                        "_x = ",
+                        "x = ",
                         this._stringType.wrapEncodingChange([ourQualifier], cppType, toType, [
-                            "_j.get<",
+                            "j.get<",
                             cppType,
                             ">()"
                         ]),
@@ -1418,8 +1418,8 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
             this.emitLine('else throw "Could not deserialize";');
         });
         this.ensureBlankLine();
-        this.emitBlock(["inline void to_json(json& _j, const ", variantType, "& _x)"], false, () => {
-            this.emitBlock("switch (_x.which())", false, () => {
+        this.emitBlock(["inline void to_json(json& j, const ", variantType, "& x)"], false, () => {
+            this.emitBlock("switch (x.which())", false, () => {
                 let i = 0;
                 for (const t of nonNulls) {
                     this.emitLine("case ", i.toString(), ":");
@@ -1445,11 +1445,11 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
                             true
                         );
                         this.emitLine(
-                            "_j = ",
+                            "j = ",
                             this._stringType.wrapEncodingChange([ourQualifier], cppType, toType, [
                                 "boost::get<",
                                 cppType,
-                                ">(_x)"
+                                ">(x)"
                             ]),
                             ";"
                         );
@@ -1464,27 +1464,27 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
 
     protected emitEnumHeaders(enumName: Name): void {
         const ourQualifier = this.ourQualifier(true);
-        this.emitLine("void from_json(const json& _j, ", ourQualifier, enumName, "& _x);");
-        this.emitLine("void to_json(json& _j, const ", ourQualifier, enumName, "& _x);");
+        this.emitLine("void from_json(const json& j, ", ourQualifier, enumName, "& x);");
+        this.emitLine("void to_json(json& j, const ", ourQualifier, enumName, "& x);");
     }
 
     protected emitEnumFunctions(e: EnumType, enumName: Name): void {
         const ourQualifier = this.ourQualifier(true);
 
-        this.emitBlock(["inline void from_json(const json& _j, ", ourQualifier, enumName, "& _x)"], false, () => {
+        this.emitBlock(["inline void from_json(const json& j, ", ourQualifier, enumName, "& x)"], false, () => {
             let onFirst = true;
             this.forEachEnumCase(e, "none", (name, jsonName) => {
                 const maybeElse = onFirst ? "" : "else ";
                 this.emitLine(
                     maybeElse,
-                    "if (_j == ",
+                    "if (j == ",
                     this._stringType.wrapEncodingChange(
                         [ourQualifier],
                         this._stringType.getType(),
                         this.NarrowString.getType(),
                         [this._stringType.createStringLiteral([stringEscape(jsonName)])]
                     ),
-                    ") _x = ",
+                    ") x = ",
                     ourQualifier,
                     enumName,
                     "::",
@@ -1496,8 +1496,8 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
             this.emitLine('else throw "Input JSON does not conform to schema";');
         });
         this.ensureBlankLine();
-        this.emitBlock(["inline void to_json(json& _j, const ", ourQualifier, enumName, "& _x)"], false, () => {
-            this.emitBlock("switch (_x)", false, () => {
+        this.emitBlock(["inline void to_json(json& j, const ", ourQualifier, enumName, "& x)"], false, () => {
+            this.emitBlock("switch (x)", false, () => {
                 this.forEachEnumCase(e, "none", (name, jsonName) => {
                     this.emitLine(
                         "case ",
@@ -1505,7 +1505,7 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
                         enumName,
                         "::",
                         name,
-                        ": _j = ",
+                        ": j = ",
                         this._stringType.wrapEncodingChange(
                             [ourQualifier],
                             this._stringType.getType(),

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -366,7 +366,8 @@ export const CPlusPlusLanguage: Language = {
     { unions: "indirection" },
     { "source-style": "multi-source" },
     { "code-format": "with-struct" },
-    { "wstring": "use-wstring" }
+    { "wstring": "use-wstring" },
+    { "const-style", "west-const" }
   ],
   sourceFiles: ["src/language/CPlusPlus.ts"]
 };

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -367,7 +367,7 @@ export const CPlusPlusLanguage: Language = {
     { "source-style": "multi-source" },
     { "code-format": "with-struct" },
     { "wstring": "use-wstring" },
-    { "const-style": "west-const" }
+    { "const-style": "east-const" }
   ],
   sourceFiles: ["src/language/CPlusPlus.ts"]
 };

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -367,7 +367,7 @@ export const CPlusPlusLanguage: Language = {
     { "source-style": "multi-source" },
     { "code-format": "with-struct" },
     { "wstring": "use-wstring" },
-    { "const-style", "west-const" }
+    { "const-style": "west-const" }
   ],
   sourceFiles: ["src/language/CPlusPlus.ts"]
 };


### PR DESCRIPTION
This pull request includes the following changes:

- do not prefix identifiers with underscore (_) as that is reserved for the implementation for names in the global namespace
- use using statements instead of typedefs (as this is now the preferred standard choice)
- introduced an option to use West const (i.e. const T) or East const (i.e. T const); the default is West const
`quicktype --const-style east-const ./sample.json -o sample.cpp` 