### PR TITLE
[WIP] Python - Getting rid of lambdas

### DIFF
--- a/src/quicktype-core/language/Python.ts
+++ b/src/quicktype-core/language/Python.ts
@@ -505,9 +505,13 @@ export type ConverterFunction =
     | "str"
     | "to-enum"
     | "list"
+    | "list-of"
     | "to-class"
+    | "to-class-of"
     | "dict"
+    | "dict-of"
     | "union"
+    | "union-of"
     | "from-datetime"
     | "from-stringified-bool"
     | "is-type";
@@ -709,6 +713,35 @@ export class JSONPythonRenderer extends PythonRenderer {
         );
     }
 
+    protected emitListOfConverter(): void {
+        const tvar = this.typeVar();
+        this.emitBlock(
+            [
+                "def from_list_of(f",
+                this.typeHint(": ", this.withTyping("Callable"), "[[", this.withTyping("Any"), "], ", tvar, "]"),
+                ")",
+                this.typeHint(" -> ", this.withTyping("Callable"), "[[", this.withTyping("Any"), "], ", this.withTyping("List"), "[", tvar, "]", "]"),
+                ":"
+            ],
+            () => {
+                this.emitBlock(
+                    [
+                        "def _from_list(",
+                        this.typingDecl("x", "Any"),
+                        ")",
+                        this.typeHint(" -> ", this.withTyping("List"), "[", tvar, "]"),
+                        ":"
+                    ],
+                    () => {
+                        this.emitLine("assert isinstance(x, list)");
+                        this.emitLine("return [f(y) for y in x]");
+                    }
+                );
+                this.emitLine("return _from_list");
+            }
+        );
+    }
+
     protected emitToClassConverter(): void {
         const tvar = this.typeVar();
         this.emitBlock(
@@ -724,6 +757,35 @@ export class JSONPythonRenderer extends PythonRenderer {
             () => {
                 this.emitLine("assert isinstance(x, c)");
                 this.emitLine("return ", this.cast(this.withTyping("Any"), "x"), ".to_dict()");
+            }
+        );
+    }
+
+    protected emitToClassOfConverter(): void {
+        const tvar = this.typeVar();
+        this.emitBlock(
+            [
+                "def to_class_of(c",
+                this.typeHint(": ", this.withTyping("Type"), "[", tvar, "]"),
+                ")",
+                this.typeHint(" -> ", this.withTyping("Callable"), "[[", this.withTyping("Any"), "], dict]"),
+                ":"
+            ],
+            () => {
+                this.emitBlock(
+                    [
+                        "def _to_class(",
+                        this.typingDecl("x", "Any"),
+                        ")",
+                        this.typeHint(" -> dict"),
+                        ":"
+                    ],
+                    () => {
+                        this.emitLine("assert isinstance(x, c)");
+                        this.emitLine("return ", this.cast(this.withTyping("Any"), "x"), ".to_dict()");
+                    }
+                );
+                this.emitLine("return _to_class");
             }
         );
     }
@@ -747,6 +809,34 @@ export class JSONPythonRenderer extends PythonRenderer {
         );
     }
 
+    protected emitDictOfConverter(): void {
+        const tvar = this.typeVar();
+        this.emitBlock(
+            [
+                "def from_dict_of(f",
+                this.typeHint(": ", this.withTyping("Callable"), "[[", this.withTyping("Any"), "], ", tvar, "]"),
+                ")",
+                this.typeHint(" -> ", this.withTyping("Callable"), "[[", this.withTyping("Any"), "], ", this.withTyping("Dict"), "[str, ", tvar, "]", "]"),
+                ":"
+            ],
+            () => {
+                this.emitBlock(
+                    [
+                        "def _from_dict(",
+                        this.typingDecl("x", "Any"),
+                        ")",
+                        this.typeHint(" -> ", this.withTyping("Dict"), "[str, ", tvar, "]"),
+                        ":"
+                    ],
+                    () => {
+                        this.emitLine("assert isinstance(x, dict)");
+                        this.emitLine("return { k: f(v) for (k, v) in x.items() }");
+                    }
+                );
+                this.emitLine("return _from_dict");
+            }
+        );
+    }
     // This is not easily idiomatically typeable in Python.  See
     // https://stackoverflow.com/questions/51066468/computed-types-in-mypy/51084497
     protected emitUnionConverter(): void {
@@ -757,6 +847,18 @@ export class JSONPythonRenderer extends PythonRenderer {
         except:
             pass
     assert False`);
+    }
+
+    protected emitUnionOfConverter(): void {
+        this.emitMultiline(`def from_union_of(fs):
+    def _from_union(x):
+        for f in fs:
+            try:
+                return f(x)
+            except:
+                pass
+        assert False
+    return _from_union`);
     }
 
     protected emitFromDatetimeConverter(): void {
@@ -823,12 +925,20 @@ export class JSONPythonRenderer extends PythonRenderer {
                 return this.emitToEnumConverter();
             case "list":
                 return this.emitListConverter();
+            case "list-of":
+                return this.emitListOfConverter();
             case "to-class":
                 return this.emitToClassConverter();
+            case "to-class-of":
+                return this.emitToClassOfConverter();
             case "dict":
                 return this.emitDictConverter();
+            case "dict-of":
+                return this.emitDictOfConverter();
             case "union":
                 return this.emitUnionConverter();
+            case "union-of":
+                return this.emitUnionOfConverter();
             case "from-datetime":
                 return this.emitFromDatetimeConverter();
             case "from-stringified-bool":


### PR DESCRIPTION
As suggested in https://github.com/quicktype/quicktype/issues/1102, Python conversion expressions can be simplified by defining curried functions instead of lambdas.

When fully implemented, this would simplify both the generated code and also the generator code.

    foo = from_union([lambda x: from_list(from_str, x), from_none], obj.get("foo"))  #before
    foo = from_union_of([from_list_of(from_str), from_none])(obj.get("foo"))         #after

    result["bar"] = from_union([lambda x: to_class(Bar, x), from_none], self.bar)    #before
    result["bar"] = from_union_of([to_class_of(Bar), from_none])(self.bar)           #after

This results in fully functioning converter functions where the value is only passed in the end.

I created the modified conversion functions, but my head hurts while I try to wrap it around the `serializer`/`deserializer` functions (https://github.com/quicktype/quicktype/blob/master/src/quicktype-core/language/Python.ts#L990). I feel like the change I propose is more compatible with older versions of Python generator (e.g. https://github.com/quicktype/quicktype/commit/89423cb15a26aa43819bba60824928e88c29fc1c#diff-9678b475f763b3fd561e5fb2f238e25e) when there was no complicated recursive value passing. We could do it similarly to how the only `serializerFn` function worked.

@schani If you know the easiest way to do this, I'd like a bit of your help.

P.S. This [WIP] PR *adds* the new variants of list/dict/class/union converters, but the final goal is to replace the existing ones.