### PR TITLE
Report missing CLI option values

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -581,6 +581,13 @@ function parseOptions(definitions: OptionDefinition[], argv: string[], partial: 
         assert(!partial, "Partial option parsing should not have failed");
         return messageError("DriverCLIOptionParsingFailed", { message: e.message });
     }
+    for (const k of Object.keys(opts)) {
+        if (opts[k] === null) {
+            return messageError("DriverCLIOptionParsingFailed", {
+                message: `Missing value for command line option "${k}"`
+            });
+        }
+    }
 
     const options: { rendererOptions: RendererOptions; [key: string]: any } = { rendererOptions: {} };
     for (const o of definitions) {


### PR DESCRIPTION
For example, passing `--debug` without an argument
will result in `.debug === null`, which we didn't catch.