### PR TITLE
Added option to remove boost dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,12 @@ RUN apt-get install dotnet-sdk-2.0.0 --assume-yes
 
 # Install Boost for C++
 RUN apt-get install libboost-all-dev --assume-yes
+RUN apt-get update && apt-get install software-properties-common python-software-properties --assume-yes
+RUN add-apt-repository ppa:jonathonf/gcc-7.1
+RUN apt-get update
+RUN apt-get install g++-7 --assume-yes
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 60 --slave /usr/bin/g++ g++ /usr/bin/g++-7
+RUN update-alternatives --config gcc
 
 # Install Rust
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
@@ -51,7 +57,6 @@ RUN /bin/bash -c "source /root/.sdkman/bin/sdkman-init.sh && sdk install kotlin"
 ENV PATH="/root/.sdkman/candidates/kotlin/current/bin:${PATH}"
 
 # Python
-RUN apt-get install software-properties-common python-software-properties --assume-yes
 RUN add-apt-repository ppa:jonathonf/python-3.6
 RUN apt-get update
 RUN apt-get install python3.6 --assume-yes

--- a/src/quicktype-core/language/CPlusPlus.ts
+++ b/src/quicktype-core/language/CPlusPlus.ts
@@ -106,7 +106,7 @@ export const cPlusPlusOptions = {
         pascalUpperAcronymsValue,
         camelUpperAcronymsValue
     ]),
-    boost: new BooleanOption("boost", "Do not require a dependency on boost (Requires C++17)", false)
+    boost: new BooleanOption("boost", "Do not require a dependency on boost (Requires C++17)", true)
 };
 
 export class CPlusPlusTargetLanguage extends TargetLanguage {

--- a/src/quicktype-core/language/CPlusPlus.ts
+++ b/src/quicktype-core/language/CPlusPlus.ts
@@ -458,6 +458,7 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
     private _optionalType: string;
     private _nulloptType: string;
     private _variantType: string;
+    private _variantIndexMethodName: string;
 
     protected readonly typeNamingStyle: NamingStyle;
     protected readonly enumeratorNamingStyle: NamingStyle;
@@ -496,10 +497,12 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
             this._optionalType = "boost::optional";
             this._nulloptType = "boost::none";
             this._variantType = "boost::variant";
+            this._variantIndexMethodName = "which";
         } else {
             this._optionalType = "std::optional";
             this._nulloptType = "std::nullopt";
             this._variantType = "std::variant";
+            this._variantIndexMethodName = "index";
         }
 
         this.setupGlobalNames();
@@ -1473,7 +1476,7 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
         this.emitBlock(
             ["inline void to_json(json & j, ", this.withConst(variantType), " & x)"],
             false, () => {
-            this.emitBlock("switch (x.which())", false, () => {
+            this.emitBlock(["switch (x.", this._variantIndexMethodName, "())"], false, () => {
                 let i = 0;
                 for (const t of nonNulls) {
                     this.emitLine("case ", i.toString(), ":");

--- a/src/quicktype-core/language/CPlusPlus.ts
+++ b/src/quicktype-core/language/CPlusPlus.ts
@@ -106,7 +106,7 @@ export const cPlusPlusOptions = {
         pascalUpperAcronymsValue,
         camelUpperAcronymsValue
     ]),
-    boost: new BooleanOption("boost", "Do not require a dependency on boost (Requires C++17)", true)
+    boost: new BooleanOption("boost", "Require a dependency on boost. Without boost, C++17 is required", true)
 };
 
 export class CPlusPlusTargetLanguage extends TargetLanguage {

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -328,7 +328,7 @@ export const CPlusPlusLanguage: Language = {
   base: "test/fixtures/cplusplus",
   setupCommand:
     "curl -o json.hpp https://raw.githubusercontent.com/nlohmann/json/87df1d6708915ffbfa26a051ad7562ecc22e5579/src/json.hpp",
-  compileCommand: "g++ -O0 -o quicktype -std=c++14 main.cpp",
+  compileCommand: "g++ -O0 -o quicktype -std=c++17 main.cpp",
   runCommand(sample: string) {
     return `./quicktype "${sample}"`;
   },
@@ -367,7 +367,8 @@ export const CPlusPlusLanguage: Language = {
     { "source-style": "multi-source" },
     { "code-format": "with-struct" },
     { "wstring": "use-wstring" },
-    { "const-style": "east-const" }
+    { "const-style": "east-const" },
+    { "boost": "no-boost"}
   ],
   sourceFiles: ["src/language/CPlusPlus.ts"]
 };


### PR DESCRIPTION
Implements #1128

Added option to CLI for C++ to not depend on boost and instead depend on C++17

Tested on a large JSON schema data set (OCA OCPP 1.6 Json Schema).

Let me know if there are any issues!

