### PR TITLE
updates typescript renderer to have babel 7 compliant output

### DIFF
--- a/src/quicktype-core/language/JavaScript.ts
+++ b/src/quicktype-core/language/JavaScript.ts
@@ -273,6 +273,9 @@ export class JavaScriptRenderer extends ConvenienceRenderer {
                 }
             });
         });
+    }
+
+  protected emitConvertModuleHelpers(): void { 
         if (this._jsOptions.runtimeTypecheck) {
             const {
                 any: anyAnnotation,
@@ -414,7 +417,7 @@ function r(name${stringAnnotation}) {
 `);
             this.emitTypeMap();
         }
-    }
+  }
 
     protected emitConvertModule(): void {
         this.ensureBlankLine();
@@ -478,6 +481,8 @@ function r(name${stringAnnotation}) {
         this.emitTypes();
 
         this.emitConvertModule();
+
+        this.emitConvertModuleHelpers() 
 
         this.emitModuleExports();
     }

--- a/src/quicktype-core/language/JavaScript.ts
+++ b/src/quicktype-core/language/JavaScript.ts
@@ -1,6 +1,13 @@
 import { arrayIntercalate } from "collection-utils";
 
-import { TransformedStringTypeKind,  PrimitiveStringTypeKind, Type, ClassProperty, ClassType, ObjectType } from "../Type";
+import {
+    TransformedStringTypeKind,
+    PrimitiveStringTypeKind,
+    Type,
+    ClassProperty,
+    ClassType,
+    ObjectType
+} from "../Type";
 import { matchType, directlyReachableSingleNamedType } from "../TypeUtils";
 import { acronymOption, acronymStyle, AcronymStyleOptions } from "../support/Acronyms";
 import {
@@ -49,10 +56,7 @@ export class JavaScriptTargetLanguage extends TargetLanguage {
     }
 
     protected getOptions(): Option<any>[] {
-        return [
-            javaScriptOptions.runtimeTypecheck,
-            javaScriptOptions.acronymStyle
-        ];
+        return [javaScriptOptions.runtimeTypecheck, javaScriptOptions.acronymStyle];
     }
 
     get stringTypeMapping(): StringTypeMapping {
@@ -92,10 +96,7 @@ export class JavaScriptRenderer extends ConvenienceRenderer {
         super(targetLanguage, renderContext);
     }
 
-    protected nameStyle(
-        original: string,
-        upper: boolean,
-    ): string {
+    protected nameStyle(original: string, upper: boolean): string {
         const acronyms = acronymStyle(this._jsOptions.acronymStyle);
         const words = splitIntoWords(original);
         return combineWords(
@@ -275,7 +276,7 @@ export class JavaScriptRenderer extends ConvenienceRenderer {
         });
     }
 
-  protected emitConvertModuleHelpers(): void { 
+    protected emitConvertModuleHelpers(): void {
         if (this._jsOptions.runtimeTypecheck) {
             const {
                 any: anyAnnotation,
@@ -417,7 +418,7 @@ function r(name${stringAnnotation}) {
 `);
             this.emitTypeMap();
         }
-  }
+    }
 
     protected emitConvertModule(): void {
         this.ensureBlankLine();
@@ -482,7 +483,7 @@ function r(name${stringAnnotation}) {
 
         this.emitConvertModule();
 
-        this.emitConvertModuleHelpers() 
+        this.emitConvertModuleHelpers();
 
         this.emitModuleExports();
     }

--- a/src/quicktype-core/language/TypeScriptFlow.ts
+++ b/src/quicktype-core/language/TypeScriptFlow.ts
@@ -10,7 +10,7 @@ import {
     JavaScriptTargetLanguage,
     JavaScriptRenderer,
     JavaScriptTypeAnnotations,
-    legalizeName,
+    legalizeName
 } from "./JavaScript";
 import { defined, panic } from "../support/Support";
 import { TargetLanguage } from "../TargetLanguage";

--- a/src/quicktype-core/language/TypeScriptFlow.ts
+++ b/src/quicktype-core/language/TypeScriptFlow.ts
@@ -188,12 +188,12 @@ export abstract class TypeScriptFlowBaseRenderer extends JavaScriptRenderer {
     }
 
     protected deserializerFunctionLine(t: Type, name: Name): Sourcelike {
-        return ["to", name, "(json: string): ", this.sourceFor(t).source];
+        return ["function to", name, "(json: string): ", this.sourceFor(t).source];
     }
 
     protected serializerFunctionLine(t: Type, name: Name): Sourcelike {
         const camelCaseName = modifySource(camelCase, name);
-        return ["", camelCaseName, "ToJson(value: ", this.sourceFor(t).source, "): string"];
+        return ["function ", camelCaseName, "ToJson(value: ", this.sourceFor(t).source, "): string"];
     }
 
     protected get moduleLine(): string | undefined {
@@ -228,11 +228,12 @@ export class TypeScriptRenderer extends TypeScriptFlowBaseRenderer {
     }
 
     protected deserializerFunctionLine(t: Type, name: Name): Sourcelike {
-        return ["public static ", super.deserializerFunctionLine(t, name)];
+        return ["public static to", name, "(json: string): ", this.sourceFor(t).source];
     }
 
     protected serializerFunctionLine(t: Type, name: Name): Sourcelike {
-        return ["public static ", super.serializerFunctionLine(t, name)];
+        const camelCaseName = modifySource(camelCase, name);
+        return ["public static ", camelCaseName, "ToJson(value: ", this.sourceFor(t).source, "): string"];
     }
 
     protected get moduleLine(): string | undefined {

--- a/src/quicktype-core/language/TypeScriptFlow.ts
+++ b/src/quicktype-core/language/TypeScriptFlow.ts
@@ -188,12 +188,12 @@ export abstract class TypeScriptFlowBaseRenderer extends JavaScriptRenderer {
     }
 
     protected deserializerFunctionLine(t: Type, name: Name): Sourcelike {
-        return ["function to", name, "(json: string): ", this.sourceFor(t).source];
+        return ["to", name, "(json: string): ", this.sourceFor(t).source];
     }
 
     protected serializerFunctionLine(t: Type, name: Name): Sourcelike {
         const camelCaseName = modifySource(camelCase, name);
-        return ["function ", camelCaseName, "ToJson(value: ", this.sourceFor(t).source, "): string"];
+        return ["", camelCaseName, "ToJson(value: ", this.sourceFor(t).source, "): string"];
     }
 
     protected get moduleLine(): string | undefined {
@@ -228,15 +228,15 @@ export class TypeScriptRenderer extends TypeScriptFlowBaseRenderer {
     }
 
     protected deserializerFunctionLine(t: Type, name: Name): Sourcelike {
-        return ["export ", super.deserializerFunctionLine(t, name)];
+        return ["public static ", super.deserializerFunctionLine(t, name)];
     }
 
     protected serializerFunctionLine(t: Type, name: Name): Sourcelike {
-        return ["export ", super.serializerFunctionLine(t, name)];
+        return ["public static ", super.serializerFunctionLine(t, name)];
     }
 
     protected get moduleLine(): string | undefined {
-        return "export namespace Convert";
+        return "export class Convert";
     }
 
     protected get typeAnnotations(): JavaScriptTypeAnnotations {


### PR DESCRIPTION
## Background
The current output is not Babel 7 compliant.
https://github.com/quicktype/quicktype/issues/1189

## Changes
Pull the `_jsOptions.runtimeCheck` output into a helper method. This is needed to decouple the output from the actual convert functions.

Converts the `namespace` block in the TS renderer to a class and updates the convert methods to be static methods. I think I like this better than `const` actually. It's also slightly simpler because of the commas needed when defining methods on an object literal.

Below is a screen shot of a sample output:
![image](https://user-images.githubusercontent.com/11728959/55281989-b8f5e300-52f8-11e9-89a6-9aa1720b89b3.png)




