### PR TITLE
Add the ability to generate Swift code with Objective-C compatibility

### DIFF
--- a/src/quicktype-core/Renderer.ts
+++ b/src/quicktype-core/Renderer.ts
@@ -138,6 +138,10 @@ export abstract class Renderer {
         this._emitContext.preventBlankLine();
     }
 
+    emitItem(item: Sourcelike): void {
+        this._emitContext.emitItem(item);
+    }
+
     emitLine(...lineParts: Sourcelike[]): void {
         if (lineParts.length === 1) {
             this._emitContext.emitItem(lineParts[0]);

--- a/src/quicktype-core/language/Swift.ts
+++ b/src/quicktype-core/language/Swift.ts
@@ -496,7 +496,7 @@ export class SwiftRenderer extends ConvenienceRenderer {
         this.emitLine("typealias ", name, " = ", this.swiftType(t, true));
     }
 
-    protected getProtocolsArray(_t: Type, isClass: Boolean): string[] {
+    protected getProtocolsArray(_t: Type, isClass: boolean): string[] {
         const protocols: string[] = [];
 
         // [Michael Fey (@MrRooni), 2019-4-24] Technically NSObject isn't a "protocol" in this instance, but this felt like the best place to slot in this superclass declaration.
@@ -518,7 +518,7 @@ export class SwiftRenderer extends ConvenienceRenderer {
         return protocols;
     }
 
-    private getProtocolString(_t: Type, isClass: Boolean): Sourcelike {
+    private getProtocolString(_t: Type, isClass: boolean): Sourcelike {
         const protocols = this.getProtocolsArray(_t, isClass);
         return protocols.length > 0 ? ": " + protocols.join(", ") : "";
     }

--- a/src/quicktype-core/language/Swift.ts
+++ b/src/quicktype-core/language/Swift.ts
@@ -808,7 +808,7 @@ encoder.dateEncodingStrategy = .formatted(formatter)`);
 
         const indirect = this.isCycleBreakerType(u) ? "indirect " : "";
         const [maybeNull, nonNulls] = removeNullFromUnion(u, sortBy);
-        this.emitBlockWithAccess([indirect, "enum ", unionName, this.getProtocolString()], () => {
+        this.emitBlockWithAccess([indirect, "enum ", unionName, this.getProtocolString(false)], () => {
             this.forEachUnionMember(u, nonNulls, "none", null, (name, t) => {
                 this.emitLine("case ", name, "(", this.swiftType(t), ")");
             });


### PR DESCRIPTION
## Reason to Be

From the issue:
> For a project in transition from Objective-C to Swift, there are scenarios where the generated model classes (which preferably are in Swift) have to be used by new code in legacy files (which are in Objective-C). Unless the class is appended with @objcMembers and inheriting NSObject, I believe the generated class will be unavailable for use by the Objective-C side.

Resolves https://github.com/quicktype/quicktype/issues/1148

## Thought Process

There are two main components to using Swift code in Objective-C:

1. Swift classes must inherit from NSObject.
2. Swift classes must expose classes, properties, and functions to Objective-C via `@objcMembers` or `@objc` 

While `@objcMembers` is only available in Swift 5 or greater, it was the simpler option to implement and ultimately the one I chose to use.

## How To Test

When generating Swift code you can declare `--objective-c-support` to enable this feature. It defaults to "false":

```bash
quicktype --struct-or-class class --objective-c-support -s schema schema.json -o src/ios/models.swift
```

Right now `--objective-c-support` is dependent on `--struct-or-class` being set to `class`, however there is no error reporting if you declare `--objective-c-support` without ` --struct-or-class class`. I'd be open to suggestions on how to handle this issue.

## Possible Impacts

None?