### PR TITLE
Allow custom protocol declaration in Swift

### DIFF
--- a/src/quicktype-core/language/Swift.ts
+++ b/src/quicktype-core/language/Swift.ts
@@ -490,7 +490,7 @@ export class SwiftRenderer extends ConvenienceRenderer {
         this.emitLine("typealias ", name, " = ", this.swiftType(t, true));
     }
 
-    private getProtocolString(): Sourcelike {
+    protected getProtocolsArray(_t: Type): string[] {
         const protocols: string[] = [];
         if (!this._options.justTypes) {
             protocols.push("Codable");
@@ -503,7 +503,11 @@ export class SwiftRenderer extends ConvenienceRenderer {
         if (this._options.protocol.equatable) {
             protocols.push("Equatable");
         }
+        return protocols;
+    }
 
+    private getProtocolString(_t: Type): Sourcelike {
+        const protocols = this.getProtocolsArray(_t);
         return protocols.length > 0 ? ": " + protocols.join(", ") : "";
     }
 
@@ -547,7 +551,7 @@ export class SwiftRenderer extends ConvenienceRenderer {
 
         const isClass = this._options.useClasses || this.isCycleBreakerType(c);
         const structOrClass = isClass ? "class" : "struct";
-        this.emitBlockWithAccess([structOrClass, " ", className, this.getProtocolString()], () => {
+        this.emitBlockWithAccess([structOrClass, " ", className, this.getProtocolString(c)], () => {
             if (this._options.dense) {
                 let lastProperty: ClassProperty | undefined = undefined;
                 let lastNames: Name[] = [];
@@ -790,7 +794,7 @@ encoder.dateEncodingStrategy = .formatted(formatter)`);
 
         const indirect = this.isCycleBreakerType(u) ? "indirect " : "";
         const [maybeNull, nonNulls] = removeNullFromUnion(u, sortBy);
-        this.emitBlockWithAccess([indirect, "enum ", unionName, this.getProtocolString()], () => {
+        this.emitBlockWithAccess([indirect, "enum ", unionName, this.getProtocolString(u)], () => {
             this.forEachUnionMember(u, nonNulls, "none", null, (name, t) => {
                 this.emitLine("case ", name, "(", this.swiftType(t), ")");
             });


### PR DESCRIPTION
## Summary

This PR aims to allow `quicktype-core` users to add custom protocol conformance to generated swift code.

## Implementation Details

- I've added the `getProtocolsArray` method which takes care of assembling an array with all protocol declarations. This new method is marked as `protected` so consumers can override it.

- The `getProtocolString` method keeps being private and now only takes care of turning `getProtocolsArray` output into some swift valid string.

- Additionally I'm passing the `type` of the "class/union" being analyzed to allow for conditional customization.

## Usage

```typescript
class CustomRenderer extends SwiftRenderer {
    protected getProtocolsArray(t: Type): String[] {
        const protocols = super.getProtocolsArray(t);
        protocols.push("CustomProtocol");
        return protocols;
    }
}
```