### PR TITLE
Allow custom property definition in Swift

### DIFF
--- a/src/quicktype-core/language/Swift.ts
+++ b/src/quicktype-core/language/Swift.ts
@@ -558,6 +558,10 @@ export class SwiftRenderer extends ConvenienceRenderer {
             : this._options.accessLevel + " ";
     }
 
+    protected propertyLinesDefinition(name: Name, parameter: ClassProperty): Sourcelike {
+        return [this.accessLevel, "let ", name, ": ", this.swiftPropertyType(parameter)];
+    }
+
     private renderClassDefinition(c: ClassType, className: Name): void {
         this.emitDescription(this.descriptionForType(c));
 
@@ -612,8 +616,9 @@ export class SwiftRenderer extends ConvenienceRenderer {
             } else {
                 this.forEachClassProperty(c, "none", (name, jsonName, p) => {
                     const description = this.descriptionForClassProperty(c, jsonName);
+                    const propertyLines = this.propertyLinesDefinition(name, p);
                     this.emitDescription(description);
-                    this.emitLine(this.accessLevel, "let ", name, ": ", this.swiftPropertyType(p));
+                    this.emitLine(propertyLines);
                 });
             }
 


### PR DESCRIPTION
## Summary

This PR aims to allow `quicktype-core` users to add custom class property definitions to generated swift code, giving users the ability to add features such as default values.

## Implementation Details

I've extracted the property generation logic(only for non-dense mode) that was inside the `renderClassDefinition` method to expose it in a new protected method called `propertyLinesDefinition`.

## Usage

```typescript
class CustomRenderer extends SwiftRenderer {
    protected propertyLinesDefinition(name: Name, parameter: ClassProperty): Sourcelike {
        
        // Get the code for original property definition
        const originalDefinition = super.propertyLinesDefinition(name, parameter);

        // Return a modified version if required
        return [originalDefinition, " = ",  "Some Value"];
    }
}
```