### PR TITLE
Adds ExplicitCodingkey option to SwiftOptions

### DIFF
--- a/src/quicktype-core/language/Swift.ts
+++ b/src/quicktype-core/language/Swift.ts
@@ -47,6 +47,7 @@ const MAX_SAMELINE_PROPERTIES = 4;
 export const swiftOptions = {
     justTypes: new BooleanOption("just-types", "Plain types only", false),
     convenienceInitializers: new BooleanOption("initializers", "Generate initializers and mutators", true),
+    explicitCodingKeys: new BooleanOption("coding-keys", "Explicit CodingKey values in Codable types", true),
     urlSession: new BooleanOption("url-session", "URLSession task extensions", false),
     alamofire: new BooleanOption("alamofire", "Alamofire extensions", false),
     namedTypePrefix: new StringOption("type-prefix", "Prefix for type names", "PREFIX", "", "secondary"),
@@ -116,6 +117,7 @@ export class SwiftTargetLanguage extends TargetLanguage {
             swiftOptions.useClasses,
             swiftOptions.dense,
             swiftOptions.convenienceInitializers,
+            swiftOptions.explicitCodingKeys,
             swiftOptions.accessLevel,
             swiftOptions.urlSession,
             swiftOptions.alamofire,
@@ -639,7 +641,7 @@ export class SwiftRenderer extends ConvenienceRenderer {
                     this.emitBlock("enum CodingKeys: String, CodingKey", () => {
                         for (const group of groups) {
                             const { name, label } = group[0];
-                            if (label !== undefined) {
+                            if (this._options.explicitCodingKeys && label !== undefined) {
                                 this.emitLine("case ", name, ' = "', label, '"');
                             } else {
                                 const names = arrayIntercalate<Sourcelike>(", ", group.map(p => p.name));


### PR DESCRIPTION
# Summary

When generating swift code without the `--just-types` option from the schema:
```json
"recipe.visit":{
  "$id":"#/events/recipe.visit",
  "type":"object",
  "description":"When a user successfully views / visits a recipe.",
  "properties":{
    "event":{
      "type":"string",
      "const":"recipe.visit"
    },
    "event_time":{
      "type":"string"
    },
  },
  "required":[
    "event",
    "event_time"
  ]
}
```
The output looks like this:
```swift
public struct RecipeVisit: Codable {
    public let event: String
    public let eventTime: String

    enum CodingKeys: String, CodingKey {
        case event = "event"
        case eventTime = "event_time"
    }
}
```

Most of the time this is correct and works fine in swift expect when we specify the `KeyDecodingStrategy.convertFromSnakeCase` in swift's `JSONDecoder` class, which converts the incoming json to `camelCase` and then swift can't match the camel-cassed json to the generated snake-cased `CodingKeys` enum.

This PR aims to solve ☝️by providing the user a way to opt-out from explicit `CodingKeys` values.

# Usage

By running `quicktype` with the `--no-coding-keys` option
```
quicktype -s schema "schema.json" -o out.swift  --no-coding-keys
```

The swift generated code will look like
```swift
public struct RecipeVisit: Codable {
    public let event: String
    public let eventTime: String

    enum CodingKeys: String, CodingKey {
        case event
        case eventTime
    }
}
```

Which will work fine with the `KeyDecodingStrategy.convertFromSnakeCase` swift's `JSONDecoder` option