### PR TITLE
Python improvements

### DIFF
--- a/src/quicktype-core/language/Python.ts
+++ b/src/quicktype-core/language/Python.ts
@@ -1243,7 +1243,7 @@ export class JSONPythonRenderer extends PythonRenderer {
             this.emitLine("import dateutil.parser");
         }
 
-        if (!this._typeVars.size && !this._haveEnumTypeVar) return;
+        if (this._typeVars.size === 0 && !this._haveEnumTypeVar) return;
 
         this.ensureBlankLine(2);
         this._typeVars.forEach(name => {


### PR DESCRIPTION
Made a bunch of changes to the Python renderer. Replaces #1251 

- Add some more reserved words to the forbidden list (possibly breaking for people who have used them)
- Make all classes come off `object`
- Removed a lot of `Any`
- Removed all `assert` since they [might not do anything at runtime](https://stackoverflow.com/a/5143044/950099). I'm not sure if that was intended, but since this is for parsing user input I figured it was desired to always throw exceptions on bad data instead of continuing and failing elsewhere
