### PR TITLE
fix: GraphQL Introspection Query

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -775,7 +775,7 @@ export async function makeQuicktypeOptions(
             if (options.graphqlIntrospect !== undefined) {
                 schemaString = await introspectServer(
                     options.graphqlIntrospect,
-                    withDefault(options.httpMethod, "GET"),
+                    withDefault(options.httpMethod, "POST"),
                     withDefault<string[]>(options.httpHeader, [])
                 );
                 if (options.graphqlSchema !== undefined) {


### PR DESCRIPTION
Out-of-the-box, schema introspection wasn't working with my GraphQL server as the default HTTP method was GET, but the request was using a body with the serialized content. This doesn't align with the recommended serving (in its various forms) of a graphql api over HTTP as per: https://graphql.org/learn/serving-over-http/

I was tempted to just make this `"POST"` and not wrap in `withDefault`, but I guess some people's graphql APIs might work on a GET with a body... albeit strange.