### PR TITLE
[Swift] Add more dictionary support

### DIFF
--- a/src/quicktype-core/language/Swift.ts
+++ b/src/quicktype-core/language/Swift.ts
@@ -867,12 +867,12 @@ encoder.dateEncodingStrategy = .formatted(formatter)`);
             this.ensureBlankLine();
 
             this.emitBlock([convenience, "init(dictionary: [AnyHashable:Any]) throws"], () => {
-                this.emitMultiline(`    guard JSONSerialization.isValidJSONObject(dictionary) else {
-                    throw NSError(domain: "JSONDecoding", code: 0, userInfo: nil)
-                }
+                this.emitMultiline(`guard JSONSerialization.isValidJSONObject(dictionary) else {
+throw NSError(domain: "JSONDecoding", code: 0, userInfo: nil)
+}
 
-        let data = try JSONSerialization.data(withJSONObject: dictionary, options: [])
-            try self.init(data: data)`);
+let data = try JSONSerialization.data(withJSONObject: dictionary, options: [])
+try self.init(data: data)`);
             });
 
             this.ensureBlankLine();
@@ -881,14 +881,14 @@ encoder.dateEncodingStrategy = .formatted(formatter)`);
 
             this.ensureBlankLine();
 
-            this.emitMultiline(`    func dictionaryRepresentation() throws -> [AnyHashable:Any] {
-        let data = try self.jsonData()
-        guard let dictionaryRep = try JSONSerialization.jsonObject(with: data, options: []) as? [AnyHashable:Any] else {
-            throw NSError(domain: "JSONEncoding", code: 0, userInfo: nil)
-        }
+            this.emitMultiline(`func dictionaryRepresentation() throws -> [AnyHashable:Any] {
+    let data = try self.jsonData()
+    guard let dictionaryRep = try JSONSerialization.jsonObject(with: data, options: []) as? [AnyHashable:Any] else {
+        throw NSError(domain: "JSONEncoding", code: 0, userInfo: nil)
+    }
 
-        return dictionaryRep
-    }`);
+    return dictionaryRep
+}`);
 
             // Convenience serializers
             this.ensureBlankLine();

--- a/src/quicktype-core/language/Swift.ts
+++ b/src/quicktype-core/language/Swift.ts
@@ -865,7 +865,30 @@ encoder.dateEncodingStrategy = .formatted(formatter)`);
             });
 
             this.ensureBlankLine();
+
+            this.emitBlock([convenience, "init(dictionary: [AnyHashable:Any]) throws"], () => {
+                this.emitMultiline(`    guard JSONSerialization.isValidJSONObject(dictionary) else {
+                    throw NSError(domain: "JSONDecoding", code: 0, userInfo: nil)
+                }
+
+        let data = try JSONSerialization.data(withJSONObject: dictionary, options: [])
+            try self.init(data: data)`);
+            });
+
+            this.ensureBlankLine();
+
             this.emitConvenienceMutator(c, className);
+
+            this.ensureBlankLine();
+
+            this.emitMultiline(`    func dictionaryRepresentation() throws -> [AnyHashable:Any] {
+        let data = try self.jsonData()
+        guard let dictionaryRep = try JSONSerialization.jsonObject(with: data, options: []) as? [AnyHashable:Any] else {
+            throw NSError(domain: "JSONEncoding", code: 0, userInfo: nil)
+        }
+
+        return dictionaryRep
+    }`);
 
             // Convenience serializers
             this.ensureBlankLine();


### PR DESCRIPTION
## Reason to Be

At 1Password we have run into a few instances where we have generic dictionary objects that we want to initialize into strongly typed objects. This PR adds the ability to do that. It also allows us to dump a strongly typed object out to a dictionary. 

## CHANGELOG Entry

> [IMPROVED] Swift classes can now be initialized using a generic dictionary (`[AnyHashable:Any]`).
> [IMPROVED] You can now get a dictionary representation of a Swift class.

## Thought Process

This one was pretty straightforward. The code to do this is the same for every class, so I just added a new initializer and function.

## How To Test

Testing manually should be as simple as:
```
quicktype . -l Swift -s schema -o .
```

## Possible Impacts

None.