### PR TITLE
Added option to disable python snake case transformation

### DIFF
--- a/src/quicktype-core/language/Python.ts
+++ b/src/quicktype-core/language/Python.ts
@@ -121,7 +121,7 @@ export const pythonOptions = {
 
 export class PythonTargetLanguage extends TargetLanguage {
     protected getOptions(): Option<any>[] {
-        return [pythonOptions.features, pythonOptions.justTypes];
+        return [pythonOptions.features, pythonOptions.justTypes, pythonOptions.nicePropertyNames];
     }
 
     get stringTypeMapping(): StringTypeMapping {

--- a/src/quicktype-core/language/Python.ts
+++ b/src/quicktype-core/language/Python.ts
@@ -115,7 +115,8 @@ export const pythonOptions = {
         ],
         "3.6"
     ),
-    justTypes: new BooleanOption("just-types", "Classes only", false)
+    justTypes: new BooleanOption("just-types", "Classes only", false),
+    nicePropertyNames: new BooleanOption("nice-property-names", "Transform property names to be pythonic", false),
 };
 
 export class PythonTargetLanguage extends TargetLanguage {
@@ -257,7 +258,11 @@ export class PythonRenderer extends ConvenienceRenderer {
     }
 
     protected namerForObjectProperty(): Namer {
-        return funPrefixNamer("property", s => snakeNameStyle(this.pyOptions.features.version, s, false));
+        if (this.pyOptions.nicePropertyNames) {
+            return funPrefixNamer("property", s => snakeNameStyle(this.pyOptions.features.version, s, false));
+        } else {
+            return funPrefixNamer("properties", s => s);
+        }
     }
 
     protected makeUnionMemberNamer(): null {

--- a/src/quicktype-core/language/Python.ts
+++ b/src/quicktype-core/language/Python.ts
@@ -116,7 +116,7 @@ export const pythonOptions = {
         "3.6"
     ),
     justTypes: new BooleanOption("just-types", "Classes only", false),
-    nicePropertyNames: new BooleanOption("nice-property-names", "Transform property names to be pythonic", false),
+    nicePropertyNames: new BooleanOption("nice-property-names", "Transform property names to be Pythonic", true),
 };
 
 export class PythonTargetLanguage extends TargetLanguage {


### PR DESCRIPTION
now `camelCase` doesn't get transformed to `snake_case` when `--no-nice-property-names`
closes #1280 