### PR TITLE
Fixed @types/urijs for quicktype-core

### DIFF
--- a/build/quicktype-core/package-lock.json
+++ b/build/quicktype-core/package-lock.json
@@ -29,7 +29,9 @@
             "dev": true
         },
         "@types/urijs": {
-            "version": "github:quicktype/types-urijs#a23603a04e31e883a92244bff8515e3d841a8b98"
+            "version": "1.19.3",
+            "resolved": "https://registry.npmjs.org/@types/urijs/-/urijs-1.19.3.tgz",
+            "integrity": "sha512-L5tP2dEIV+OMVEVRhf8PCFMNMyO5ZBodrXpEqnGczky60lcv8l5Kl9Yi4J1yxhSVfHUe+Pr2nXJfDM+rUYNs3w=="
         },
         "acorn": {
             "version": "5.5.3",

--- a/build/quicktype-core/package.in.json
+++ b/build/quicktype-core/package.in.json
@@ -13,7 +13,7 @@
         "tslint": "tslint --project ."
     },
     "dependencies": {
-        "@types/urijs": "github:quicktype/types-urijs",
+        "@types/urijs": "^1.19.1",
         "collection-utils": "^1.0.1",
         "js-base64": "^2.4.3",
         "pako": "^1.0.6",


### PR DESCRIPTION
Last time I updated the `@types/urijs`, I forgot to update the dependency for the `quicktype-core` build.