### PR TITLE
WIP: feature/go-methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@matiasanaya/quicktype-go-methods",
-    "version": "17.0.1",
+    "version": "17.0.2",
     "license": "Apache-2.0",
     "main": "dist/cli/index.js",
     "types": "dist/cli/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@matiasanaya/quicktype-go-methods",
-    "version": "16.0.0",
+    "version": "17.0.1",
     "license": "Apache-2.0",
     "main": "dist/cli/index.js",
     "types": "dist/cli/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-    "name": "quicktype",
-    "version": "15.0.0",
+    "name": "@matiasanaya/quicktype-go-methods",
+    "version": "16.0.0",
     "license": "Apache-2.0",
     "main": "dist/cli/index.js",
     "types": "dist/cli/index.d.ts",
-    "repository": "https://github.com/quicktype/quicktype",
+    "repository": "https://github.com/matiasanaya/quicktype",
     "scripts": {
         "pub": "script/publish.sh",
         "prepare": "npm run build",

--- a/src/quicktype-core/language/Golang.ts
+++ b/src/quicktype-core/language/Golang.ts
@@ -348,6 +348,12 @@ export class GoRenderer extends ConvenienceRenderer {
                 } else if (!this.isPrimitive(p.type) && !goType.toString().startsWith("*")) {
                     this.emitLine("original := g.Source__", name);
                     this.emitLine("return &original");
+                } else if (!this.isPrimitive(p.type)) {
+                    this.emitLine("original := g.Source__", name);
+                    this.emitLine("if original == nil {");
+                    this.emitLine("  return nil");
+                    this.emitLine("}");
+                    this.emitLine("return original");
                 } else {
                     this.emitLine("return g.Source__", name);
                 }

--- a/src/quicktype-core/language/Golang.ts
+++ b/src/quicktype-core/language/Golang.ts
@@ -256,13 +256,25 @@ export class GoRenderer extends ConvenienceRenderer {
     private emitClass(c: ClassType, className: Name): void {
         this.startFile(className);
         this.emitPackageDefinitons(false);
+
         let columns: Sourcelike[][] = [];
         this.forEachClassProperty(c, "none", (name, jsonName, p) => {
             const goType = this.propertyGoType(p);
             const comment = singleDescriptionComment(this.descriptionForClassProperty(c, jsonName));
             const omitEmpty = canOmitEmpty(p) ? ",omitempty" : [];
-            columns.push([[name, " "], [goType, " "], ['`json:"', stringEscape(jsonName), omitEmpty, '"`'], comment]);
+            columns.push([
+                ["Source__", name, " "],
+                [goType, " "],
+                ['`json:"', stringEscape(jsonName), omitEmpty, '"`'],
+                comment
+            ]);
+
+            this.emitFunc(["(g *", className, ") ", name, "() ", goType], () => {
+                this.emitLine("return g.Source__", name);
+            });
+            this.ensureBlankLine();
         });
+
         this.emitDescription(this.descriptionForType(c));
         this.emitStruct(className, columns);
         this.endFile();


### PR DESCRIPTION
I'm building a server that interacts with shopify through their GraphQL API. I unmarshal shopify's response with `quicktype` generated code.

I have at least five different queries that return an `Order` and would like to be able to reuse my code, so the best I could come up with was to put an `interface`.

`quicktype` by default generates structs with fields but no methods, so I went about hacking the methods onto the generation step.

This implementation is no more than a POC but I'd love to see this as an optional feature eventually.

Would you consider merging a proper implementation of this behaviour?

Is there a better way to solve for this?

cheers!