### PR TITLE
[Dart] add required/final props

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "quicktype",
-  "version": "15.0.0",
+  "version": "15.0.203",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "quicktype",
-    "version": "15.0.0",
+    "version": "15.0.203",
     "license": "Apache-2.0",
     "main": "dist/cli/index.js",
     "types": "dist/cli/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "quicktype",
-    "version": "15.0.203",
+    "version": "15.0.0",
     "license": "Apache-2.0",
     "main": "dist/cli/index.js",
     "types": "dist/cli/index.d.ts",


### PR DESCRIPTION
Added 2 new options for Dart language.
* Required constractor parameters (adds @required annotation in the constructor) and importing ```package:meta/meta.dart```
*  Final properties. (Solving #1306)