### PR TITLE
"Any" types get converted to JsonObject and JsonArray in KotlinX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ test/fixtures/objective-c/quicktype
 /.node-persist
 /.vs
 .idea
+.DS_Store

--- a/src/quicktype-core/language/Kotlin.ts
+++ b/src/quicktype-core/language/Kotlin.ts
@@ -239,7 +239,7 @@ export class KotlinRenderer extends ConvenienceRenderer {
     }
 
     // (asarazan): I've broken out the following three functions
-    // because some renderers, such as kotlinx, can cope with `any`, while most probably can't.
+    // because some renderers, such as kotlinx, can cope with `any`, while some get mad.
     protected anyType(withIssues: boolean = false, noOptional: boolean = false): Sourcelike {
         const optional = noOptional ? "" : "?";
         return maybeAnnotated(withIssues, anyTypeIssueAnnotation, ["Any", optional]);

--- a/src/quicktype-core/language/Kotlin.ts
+++ b/src/quicktype-core/language/Kotlin.ts
@@ -4,7 +4,7 @@ import { anyTypeIssueAnnotation, nullTypeIssueAnnotation } from "../Annotation";
 import { ConvenienceRenderer, ForbiddenWordsInfo } from "../ConvenienceRenderer";
 import { Name, Namer, funPrefixNamer } from "../Naming";
 import { EnumOption, Option, StringOption, OptionValues, getOptionValues } from "../RendererOptions";
-import {Sourcelike, maybeAnnotated, modifySource} from "../Source";
+import { Sourcelike, maybeAnnotated, modifySource } from "../Source";
 import {
     allLowerWordStyle,
     allUpperWordStyle,


### PR DESCRIPTION
Summary:
Kotlinx is able to handle some pretty open-ended types by just dumping them into the JsonObject and JsonArray classes. You don't get fully static types, but it at least allows you to operate on those types without having to hand-fix the code.

Details:
I had to break out various parts of KotlinRenderer's `kotlinType` function, so that subclasses can override how to handle any-like types. I've updated the renderer to map the following:
`Any` -> `JsonObject`
`List<Any>` -> `JsonArray`
`Map<*, Any>` -> `JsonObject`

Tests:
Have verified it works for reasonable inputs on my machine. Have reached out on Slack for help in navigating the fixture system to write proper tests.