### PR TITLE
Added possibility to specify order in JSON-Schema #336

### DIFF
--- a/src/quicktype-core/input/JSONSchemaInput.ts
+++ b/src/quicktype-core/input/JSONSchemaInput.ts
@@ -634,10 +634,11 @@ async function addTypesInSchema(
         attributes: TypeAttributes,
         properties: StringMap,
         requiredArray: string[],
-        additionalProperties: any
+        additionalProperties: any,
+        sortKey: (k: string) => number | string = (k: string) => k.toLowerCase()
     ): Promise<TypeRef> {
         const required = new Set(requiredArray);
-        const propertiesMap = mapSortBy(mapFromObject(properties), (_, k) => k.toLowerCase());
+        const propertiesMap = mapSortBy(mapFromObject(properties), (_, k) => sortKey(k));
         const props = await mapMapSync(propertiesMap, async (propSchema, propName) => {
             const propLoc = loc.push("properties", propName);
             const t = await toType(
@@ -846,8 +847,15 @@ async function addTypesInSchema(
                 inferredAttributes,
                 combineProducedAttributes(({ forObject }) => forObject)
             );
+            const order = schema.propertyOrder ? schema.propertyOrder : [];
+            const orderKey = (propertyName: string) => {
+                // use the index of the order array
+                const index = order.indexOf(propertyName);
+                // if no index then use the property name
+                return index !== -1 ? index : propertyName.toLowerCase();
+            };
 
-            return await makeObject(loc, objectAttributes, properties, required, additionalProperties);
+            return await makeObject(loc, objectAttributes, properties, required, additionalProperties, orderKey);
         }
 
         async function makeTypesFromCases(cases: any, kind: string): Promise<TypeRef[]> {

--- a/src/quicktype-core/input/JSONSchemaInput.ts
+++ b/src/quicktype-core/input/JSONSchemaInput.ts
@@ -847,7 +847,7 @@ async function addTypesInSchema(
                 inferredAttributes,
                 combineProducedAttributes(({ forObject }) => forObject)
             );
-            const order = schema.propertyOrder ? schema.propertyOrder : [];
+            const order = schema.quicktypePropertyOrder ? schema.quicktypePropertyOrder : [];
             const orderKey = (propertyName: string) => {
                 // use the index of the order array
                 const index = order.indexOf(propertyName);


### PR DESCRIPTION
It is an alternative approach trying to resolve the ordering issue for object properties of JSON-Schemas.  Solution is to provide a propertyOrder string array on the object type. This array will be used to determine the order of properties for resulting language bindings. Example JSON:

```JSON
{
  "description": "Example for ordering properties",
  "type": "object",
  "properties": {
    "z_prop": {
      "type": "string"
    },
    "b_prop": {
      "type": "string"
    },
    "a_prop": {
      "type": "string"
    }
  },
  "propertyOrder": ["z_prop", "b_prop", "c_prop"]
}
``` 
Resulting typescript:
```typescript

export interface ExampleTest {
    z_prop?: string;
    b_prop?: string;
    a_prop?: string;
}

``` 

I would also like to add some tests but I need some support on that topic.
Perhaps we could first discuss if this is a valid approach for fixing the issue without re-writing the json parsing.

