### PR TITLE
GQL: Make nullable scalars optional

### DIFF
--- a/src/quicktype-graphql-input/index.ts
+++ b/src/quicktype-graphql-input/index.ts
@@ -192,11 +192,12 @@ class GQLQuery {
         fieldType: GQLType,
         containingTypeName: string
     ): TypeRef => {
-        const optional = hasOptionalDirectives(fieldNode.directives);
+        let optional = hasOptionalDirectives(fieldNode.directives);
         let result: TypeRef;
         switch (fieldType.kind) {
             case TypeKind.SCALAR:
                 result = makeScalar(builder, fieldType);
+                optional = true;
                 break;
             case TypeKind.OBJECT:
             case TypeKind.INTERFACE:


### PR DESCRIPTION
Nullable scalars are always made NON_NULLABLE in generated code. This PR fixes that.

Solves:
https://github.com/quicktype/quicktype/issues/1074
https://github.com/quicktype/quicktype/issues/1296