### PR TITLE
Increasing tooManyNamesThreshold to 1000 from 20.

### DIFF
--- a/src/quicktype-core/attributes/TypeNames.ts
+++ b/src/quicktype-core/attributes/TypeNames.ts
@@ -78,7 +78,7 @@ function combineNames(names: ReadonlySet<string>): string {
     return first;
 }
 
-export const tooManyNamesThreshold = 20;
+export const tooManyNamesThreshold = 1000;
 
 export abstract class TypeNames {
     static makeWithDistance(


### PR DESCRIPTION
As referenced in #1331, the tooManyNamesThreshold is set too low for real business cases and needs to be increased. 

This looks like it was set to 20 by @schani during some testing and was never set back to a reasonable value. 

This has the impact of people misreporting this behavior as a defect and is an embarrassment of this otherwise fantastic project. 