### PR TITLE
Option to ignore unknown properties during runtime typecheck

### DIFF
--- a/src/quicktype-core/language/JavaScript.ts
+++ b/src/quicktype-core/language/JavaScript.ts
@@ -387,7 +387,7 @@ function transform(val${anyAnnotation}, typ${anyAnnotation}, getProps${anyAnnota
                 ? ""
                 : `
         Object.getOwnPropertyNames(val).forEach(key => {
-            if (!Object.prototype.hasOwnProperty.call(props, key) && !ignoreUnknownProperties) {
+            if (!Object.prototype.hasOwnProperty.call(props, key)) {
                 result[key] = transform(val[key], additional, getProps);
             }
         });`

--- a/src/quicktype-core/language/JavaScript.ts
+++ b/src/quicktype-core/language/JavaScript.ts
@@ -382,16 +382,16 @@ function transform(val${anyAnnotation}, typ${anyAnnotation}, getProps${anyAnnota
             const prop = props[key];
             const v = Object.prototype.hasOwnProperty.call(val, key) ? val[key] : undefined;
             result[prop.key] = transform(v, prop.typ, getProps);
-        });${
-            this._jsOptions.runtimeTypecheckIgnoreUnknownProperties
-                ? ""
-                : `
+        });
         Object.getOwnPropertyNames(val).forEach(key => {
             if (!Object.prototype.hasOwnProperty.call(props, key)) {
-                result[key] = transform(val[key], additional, getProps);
+                result[key] = ${
+                    this._jsOptions.runtimeTypecheckIgnoreUnknownProperties
+                        ? `val[key]`
+                        : `transform(val[key], additional, getProps)`
+                };
             }
-        });`
-        }
+        });
         return result;
     }
 

--- a/src/quicktype-core/language/JavaScript.ts
+++ b/src/quicktype-core/language/JavaScript.ts
@@ -333,8 +333,6 @@ function jsToJSONProps(typ${anyAnnotation})${anyAnnotation} {
     return typ.jsToJSON;
 }
 
-var ignoreUnknownProperties = ${this._jsOptions.runtimeTypecheckIgnoreUnknownProperties};
-
 function transform(val${anyAnnotation}, typ${anyAnnotation}, getProps${anyAnnotation})${anyAnnotation} {
     function transformPrimitive(typ${stringAnnotation}, val${anyAnnotation})${anyAnnotation} {
         if (typeof typ === typeof val) return val;
@@ -384,12 +382,16 @@ function transform(val${anyAnnotation}, typ${anyAnnotation}, getProps${anyAnnota
             const prop = props[key];
             const v = Object.prototype.hasOwnProperty.call(val, key) ? val[key] : undefined;
             result[prop.key] = transform(v, prop.typ, getProps);
-        });
+        });${
+            this._jsOptions.runtimeTypecheckIgnoreUnknownProperties
+                ? ""
+                : `
         Object.getOwnPropertyNames(val).forEach(key => {
             if (!Object.prototype.hasOwnProperty.call(props, key) && !ignoreUnknownProperties) {
                 result[key] = transform(val[key], additional, getProps);
             }
-        });
+        });`
+        }
         return result;
     }
 

--- a/src/quicktype-core/language/JavaScript.ts
+++ b/src/quicktype-core/language/JavaScript.ts
@@ -36,7 +36,13 @@ import { isES3IdentifierPart, isES3IdentifierStart } from "./JavaScriptUnicodeMa
 export const javaScriptOptions = {
     acronymStyle: acronymOption(AcronymStyleOptions.Pascal),
     runtimeTypecheck: new BooleanOption("runtime-typecheck", "Verify JSON.parse results at runtime", true),
-    converters: convertersOption()
+    runtimeTypecheckIgnoreUnknownProperties: new BooleanOption(
+        "runtime-typecheck-ignore-unknown-properties",
+        "Ignore unknown properties when verifying at runtime",
+        false,
+        "secondary"
+    ),
+    converters: convertersOption(),
 };
 
 export type JavaScriptTypeAnnotations = {
@@ -59,7 +65,12 @@ export class JavaScriptTargetLanguage extends TargetLanguage {
     }
 
     protected getOptions(): Option<any>[] {
-        return [javaScriptOptions.runtimeTypecheck, javaScriptOptions.acronymStyle, javaScriptOptions.converters];
+        return [
+            javaScriptOptions.runtimeTypecheck,
+            javaScriptOptions.runtimeTypecheckIgnoreUnknownProperties,
+            javaScriptOptions.acronymStyle,
+            javaScriptOptions.converters,
+        ];
     }
 
     get stringTypeMapping(): StringTypeMapping {
@@ -322,6 +333,8 @@ function jsToJSONProps(typ${anyAnnotation})${anyAnnotation} {
     return typ.jsToJSON;
 }
 
+var ignoreUnknownProperties = ${this._jsOptions.runtimeTypecheckIgnoreUnknownProperties};
+
 function transform(val${anyAnnotation}, typ${anyAnnotation}, getProps${anyAnnotation})${anyAnnotation} {
     function transformPrimitive(typ${stringAnnotation}, val${anyAnnotation})${anyAnnotation} {
         if (typeof typ === typeof val) return val;
@@ -373,7 +386,7 @@ function transform(val${anyAnnotation}, typ${anyAnnotation}, getProps${anyAnnota
             result[prop.key] = transform(v, prop.typ, getProps);
         });
         Object.getOwnPropertyNames(val).forEach(key => {
-            if (!Object.prototype.hasOwnProperty.call(props, key)) {
+            if (!Object.prototype.hasOwnProperty.call(props, key) && !ignoreUnknownProperties) {
                 result[key] = transform(val[key], additional, getProps);
             }
         });

--- a/src/quicktype-core/language/TypeScriptFlow.ts
+++ b/src/quicktype-core/language/TypeScriptFlow.ts
@@ -39,6 +39,7 @@ export abstract class TypeScriptFlowBaseTargetLanguage extends JavaScriptTargetL
             tsFlowOptions.nicePropertyNames,
             tsFlowOptions.declareUnions,
             tsFlowOptions.runtimeTypecheck,
+            tsFlowOptions.runtimeTypecheckIgnoreUnknownProperties,
             tsFlowOptions.acronymStyle,
             tsFlowOptions.converters
         ];

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -120,8 +120,8 @@ export const JavaLanguageWithLombok: Language = {
   skipMiscJSON: false,
   skipSchema: ["keyword-unions.schema"], // generates classes with names that are case-insensitively equal
   rendererOptions: {},
-  quickTestRendererOptions: [{ "array-type": "list", "lombok": "true" }],
-  sourceFiles: ["src/language/Java.ts"]
+  quickTestRendererOptions: [{ "array-type": "list", lombok: "true" }],
+  sourceFiles: ["src/language/Java.ts"],
 };
 
 export const PythonLanguage: Language = {
@@ -617,6 +617,7 @@ export const TypeScriptLanguage: Language = {
   rendererOptions: { "explicit-unions": "yes" },
   quickTestRendererOptions: [
     { "runtime-typecheck": "false" },
+    { "runtime-typecheck-ignore-unknown-properties": "true" },
     { "nice-property-names": "true" },
     { "declare-unions": "true" },
     { "acronym-style": "pascal" },
@@ -644,7 +645,11 @@ export const JavaScriptLanguage: Language = {
   skipMiscJSON: false,
   skipSchema: ["keyword-unions.schema"], // can't handle "constructor" property
   rendererOptions: {},
-  quickTestRendererOptions: [{ "runtime-typecheck": "false" }, { converters: "top-level" }],
+  quickTestRendererOptions: [
+    { "runtime-typecheck": "false" },
+    { "runtime-typecheck-ignore-unknown-properties": "true" },
+    { converters: "top-level" },
+  ],
   sourceFiles: ["src/language/JavaScript.ts"],
 };
 
@@ -671,7 +676,11 @@ export const JavaScriptPropTypesLanguage: Language = {
   skipSchema: [],
   skipMiscJSON: false,
   rendererOptions: {},
-  quickTestRendererOptions: [{ "runtime-typecheck": "false" }, { converters: "top-level" }],
+  quickTestRendererOptions: [
+    { "runtime-typecheck": "false" },
+    { "runtime-typecheck-ignore-unknown-properties": "true" },
+    { converters: "top-level" },
+  ],
   sourceFiles: ["src/Language/JavaScriptPropTypes.ts"],
 };
 
@@ -697,6 +706,7 @@ export const FlowLanguage: Language = {
   rendererOptions: { "explicit-unions": "yes" },
   quickTestRendererOptions: [
     { "runtime-typecheck": "false" },
+    { "runtime-typecheck-ignore-unknown-properties": "true" },
     { "nice-property-names": "true" },
     { "declare-unions": "true" },
   ],


### PR DESCRIPTION
By default, JavaScript, Flow, and TypeScript will throw an error if an unexpected property is found during runtime typecheck.