### PR TITLE
No more use of `var` in JavaScript

### DIFF
--- a/src/quicktype-core/language/JavaScript.ts
+++ b/src/quicktype-core/language/JavaScript.ts
@@ -306,7 +306,7 @@ export class JavaScriptRenderer extends ConvenienceRenderer {
 
 function jsonToJSProps(typ${anyAnnotation})${anyAnnotation} {
     if (typ.jsonToJS === undefined) {
-        var map${anyAnnotation} = {};
+        const map${anyAnnotation} = {};
         typ.props.forEach((p${anyAnnotation}) => map[p.json] = { key: p.js, typ: p.typ });
         typ.jsonToJS = map;
     }
@@ -315,7 +315,7 @@ function jsonToJSProps(typ${anyAnnotation})${anyAnnotation} {
 
 function jsToJSONProps(typ${anyAnnotation})${anyAnnotation} {
     if (typ.jsToJSON === undefined) {
-        var map${anyAnnotation} = {};
+        const map${anyAnnotation} = {};
         typ.props.forEach((p${anyAnnotation}) => map[p.js] = { key: p.json, typ: p.typ });
         typ.jsToJSON = map;
     }
@@ -330,9 +330,9 @@ function transform(val${anyAnnotation}, typ${anyAnnotation}, getProps${anyAnnota
 
     function transformUnion(typs${anyArrayAnnotation}, val${anyAnnotation})${anyAnnotation} {
         // val must validate against one typ in typs
-        var l = typs.length;
-        for (var i = 0; i < l; i++) {
-            var typ = typs[i];
+        const l = typs.length;
+        for (let i = 0; i < l; i++) {
+            const typ = typs[i];
             try {
                 return transform(val, typ, getProps);
             } catch (_) {}
@@ -366,7 +366,7 @@ function transform(val${anyAnnotation}, typ${anyAnnotation}, getProps${anyAnnota
         if (val === null || typeof val !== "object" || Array.isArray(val)) {
             return invalidValue("object", val);
         }
-        var result${anyAnnotation} = {};
+        const result${anyAnnotation} = {};
         Object.getOwnPropertyNames(props).forEach(key => {
             const prop = props[key];
             const v = Object.prototype.hasOwnProperty.call(val, key) ? val[key] : undefined;


### PR DESCRIPTION
The JavaScript renderer already requires `es6` (uses `const`, fat arrows), so let's use `let` and `const` to make Flow and TypeScript happier.