### PR TITLE
fix: add is-url as dependency to quicktype-core

### DIFF
--- a/build/quicktype-core/package-lock.json
+++ b/build/quicktype-core/package-lock.json
@@ -1,9 +1,50 @@
 {
     "name": "quicktype-core",
-    "version": "5.0.53",
+    "version": "6.0.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
+        "@babel/code-frame": {
+            "version": "7.10.3",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.3.tgz",
+            "integrity": "sha512-fDx9eNW0qz0WkUeqL6tXEXzVlPh6Y5aCDEZesl0xBGA8ndRukX91Uk44ZqnkECp01NAZUdCAl+aiQNGi0k88Eg==",
+            "dev": true,
+            "requires": {
+                "@babel/highlight": "^7.10.3"
+            }
+        },
+        "@babel/helper-validator-identifier": {
+            "version": "7.10.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.3.tgz",
+            "integrity": "sha512-bU8JvtlYpJSBPuj1VUmKpFGaDZuLxASky3LhaKj3bmpSTY6VWooSM8msk+Z0CZoErFye2tlABF6yDkT3FOPAXw==",
+            "dev": true
+        },
+        "@babel/highlight": {
+            "version": "7.10.3",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.3.tgz",
+            "integrity": "sha512-Ih9B/u7AtgEnySE2L2F0Xm0GaM729XqqLfHkalTsbjXGyqmf/6M0Cu0WpvqueUlW+xk88BHw9Nkpj49naU+vWw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-validator-identifier": "^7.10.3",
+                "chalk": "^2.0.0",
+                "js-tokens": "^4.0.0"
+            }
+        },
+        "@mark.probst/unicode-properties": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@mark.probst/unicode-properties/-/unicode-properties-1.1.0.tgz",
+            "integrity": "sha512-7AQsO0hMmpqDledV7AhBuSYqYPFsKP9PaltMecX9nlnsyFxqtsqUg9/pvB2L/jxvskrDrNkdKYz2KTbQznCtng==",
+            "requires": {
+                "brfs": "^1.4.0",
+                "unicode-trie": "^0.3.0"
+            }
+        },
+        "@types/browser-or-node": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@types/browser-or-node/-/browser-or-node-1.2.0.tgz",
+            "integrity": "sha512-hLn4jvpZ804yQDu71YW7qNQDm045XmODoEOZohkH4jWb23AaPodhVM5qztG+XM54Oqw8X1dA4A7z49iNFGbrxA==",
+            "dev": true
+        },
         "@types/js-base64": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/@types/js-base64/-/js-base64-2.3.1.tgz",
@@ -28,27 +69,38 @@
             "integrity": "sha512-WR/XtQMjTx4phclpWhfuoFURYPOwiBZD89gCCTG6RETzE70AZPAGGJ0h/t+a/E27MCVf1s2Z+wvH1pVTyckIcA==",
             "dev": true
         },
+        "@types/readable-stream": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.0.tgz",
+            "integrity": "sha512-c0+lRjSeBakp3YJaP4BixI+sWWO5JFsG3wKAlUNl2olBB5sbXY8rgRbFbBwLkuuX3xSxNqpCZzeROJzMlsCdig==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
+            }
+        },
         "@types/urijs": {
-            "version": "1.19.3",
-            "resolved": "https://registry.npmjs.org/@types/urijs/-/urijs-1.19.3.tgz",
-            "integrity": "sha512-L5tP2dEIV+OMVEVRhf8PCFMNMyO5ZBodrXpEqnGczky60lcv8l5Kl9Yi4J1yxhSVfHUe+Pr2nXJfDM+rUYNs3w=="
-        },
-        "acorn": {
-            "version": "5.5.3",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
-            "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ=="
-        },
-        "ansi-regex": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+            "version": "1.19.9",
+            "resolved": "https://registry.npmjs.org/@types/urijs/-/urijs-1.19.9.tgz",
+            "integrity": "sha512-/tiJyrc0GPcsReHzgC0SXwOmoPjLqYe01W7dLYB0yasQXMbcRee+ZIk+g8MIQhoBS8fPoBQO3Y93+aeBrI93Ug==",
             "dev": true
+        },
+        "@types/yaml": {
+            "version": "1.9.7",
+            "resolved": "https://registry.npmjs.org/@types/yaml/-/yaml-1.9.7.tgz",
+            "integrity": "sha512-8WMXRDD1D+wCohjfslHDgICd2JtMATZU8CkhH8LVJqcJs6dyYj5TGptzP8wApbmEullGBSsCEzzap73DQ1HJaA==",
+            "dev": true,
+            "requires": {
+                "yaml": "*"
+            }
         },
         "ansi-styles": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-            "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-            "dev": true
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "dev": true,
+            "requires": {
+                "color-convert": "^1.9.0"
+            }
         },
         "argparse": {
             "version": "1.0.10",
@@ -56,33 +108,7 @@
             "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
             "dev": true,
             "requires": {
-                "sprintf-js": "1.0.3"
-            }
-        },
-        "babel-code-frame": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-            "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-            "dev": true,
-            "requires": {
-                "chalk": "1.1.3",
-                "esutils": "2.0.2",
-                "js-tokens": "3.0.2"
-            },
-            "dependencies": {
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
-                    }
-                }
+                "sprintf-js": "~1.0.2"
             }
         },
         "balanced-match": {
@@ -97,7 +123,7 @@
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "dev": true,
             "requires": {
-                "balanced-match": "1.0.0",
+                "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
             }
         },
@@ -106,11 +132,16 @@
             "resolved": "https://registry.npmjs.org/brfs/-/brfs-1.6.1.tgz",
             "integrity": "sha512-OfZpABRQQf+Xsmju8XE9bDjs+uU4vLREGolP7bDgcpsI17QREyZ4Bl+2KLxxx1kCgA0fAIhKQBaBYh+PEcCqYQ==",
             "requires": {
-                "quote-stream": "1.0.2",
-                "resolve": "1.7.1",
-                "static-module": "2.2.5",
-                "through2": "2.0.3"
+                "quote-stream": "^1.0.1",
+                "resolve": "^1.1.5",
+                "static-module": "^2.2.0",
+                "through2": "^2.0.0"
             }
+        },
+        "browser-or-node": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/browser-or-node/-/browser-or-node-1.2.1.tgz",
+            "integrity": "sha512-sVIA0cysIED0nbmNOm7sZzKfgN1rpFmrqvLZaFWspaBAftfQcezlC81G6j6U2RJf4Lh66zFxrCeOsvkUXIcPWg=="
         },
         "buffer-equal": {
             "version": "0.0.1",
@@ -118,9 +149,9 @@
             "integrity": "sha1-kbx0sR6kBbyRa8aqkI+q+ltKrEs="
         },
         "buffer-from": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
-            "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA=="
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+            "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
         },
         "builtin-modules": {
             "version": "1.1.1",
@@ -129,34 +160,14 @@
             "dev": true
         },
         "chalk": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-            "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
             "dev": true,
             "requires": {
-                "ansi-styles": "3.2.1",
-                "escape-string-regexp": "1.0.5",
-                "supports-color": "5.4.0"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "3.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-                    "dev": true,
-                    "requires": {
-                        "color-convert": "1.9.1"
-                    }
-                },
-                "supports-color": {
-                    "version": "5.4.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "3.0.0"
-                    }
-                }
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
             }
         },
         "collection-utils": {
@@ -165,9 +176,9 @@
             "integrity": "sha512-LA2YTIlR7biSpXkKYwwuzGjwL5rjWEZVOSnvdUc7gObvWe4WkjxOpfrdhoP7Hs09YWDVfg0Mal9BpAqLfVEzQg=="
         },
         "color-convert": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-            "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
             "dev": true,
             "requires": {
                 "color-name": "1.1.3"
@@ -180,9 +191,9 @@
             "dev": true
         },
         "commander": {
-            "version": "2.15.1",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-            "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+            "version": "2.20.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
             "dev": true
         },
         "concat-map": {
@@ -196,16 +207,19 @@
             "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
             "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
             "requires": {
-                "buffer-from": "1.0.0",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6",
-                "typedarray": "0.0.6"
+                "buffer-from": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.2.2",
+                "typedarray": "^0.0.6"
             }
         },
         "convert-source-map": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-            "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+            "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+            "requires": {
+                "safe-buffer": "~5.1.1"
+            }
         },
         "core-util-is": {
             "version": "1.0.2",
@@ -218,9 +232,9 @@
             "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
         },
         "diff": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-            "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+            "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
             "dev": true
         },
         "duplexer2": {
@@ -228,7 +242,15 @@
             "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
             "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
             "requires": {
-                "readable-stream": "2.3.6"
+                "readable-stream": "^2.0.2"
+            }
+        },
+        "encoding": {
+            "version": "0.1.12",
+            "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+            "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+            "requires": {
+                "iconv-lite": "~0.4.13"
             }
         },
         "escape-string-regexp": {
@@ -242,11 +264,11 @@
             "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
             "integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
             "requires": {
-                "esprima": "3.1.3",
-                "estraverse": "4.2.0",
-                "esutils": "2.0.2",
-                "optionator": "0.8.2",
-                "source-map": "0.6.1"
+                "esprima": "^3.1.3",
+                "estraverse": "^4.2.0",
+                "esutils": "^2.0.2",
+                "optionator": "^0.8.1",
+                "source-map": "~0.6.1"
             }
         },
         "esprima": {
@@ -255,9 +277,9 @@
             "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
         },
         "estraverse": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-            "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+            "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
         },
         "esutils": {
             "version": "2.0.2",
@@ -265,20 +287,25 @@
             "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
         },
         "falafel": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/falafel/-/falafel-2.1.0.tgz",
-            "integrity": "sha1-lrsXdh2rqU9G0AFzizzt86Z/4Gw=",
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/falafel/-/falafel-2.2.4.tgz",
+            "integrity": "sha512-0HXjo8XASWRmsS0X1EkhwEMZaD3Qvp7FfURwjLKjG1ghfRm/MGZl2r4cWUTv41KdNghTw4OUMmVtdGQp3+H+uQ==",
             "requires": {
-                "acorn": "5.5.3",
-                "foreach": "2.0.5",
-                "isarray": "0.0.1",
-                "object-keys": "1.0.11"
+                "acorn": "^7.1.1",
+                "foreach": "^2.0.5",
+                "isarray": "^2.0.1",
+                "object-keys": "^1.0.6"
             },
             "dependencies": {
+                "acorn": {
+                    "version": "7.3.1",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.3.1.tgz",
+                    "integrity": "sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA=="
+                },
                 "isarray": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+                    "version": "2.0.5",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+                    "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
                 }
             }
         },
@@ -304,34 +331,25 @@
             "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
         },
         "glob": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-            "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+            "version": "7.1.6",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+            "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
             "dev": true,
             "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
             }
         },
         "has": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
-            "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
             "requires": {
-                "function-bind": "1.1.1"
-            }
-        },
-        "has-ansi": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-            "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-            "dev": true,
-            "requires": {
-                "ansi-regex": "2.1.1"
+                "function-bind": "^1.1.1"
             }
         },
         "has-flag": {
@@ -340,14 +358,22 @@
             "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
             "dev": true
         },
+        "iconv-lite": {
+            "version": "0.4.24",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+            "requires": {
+                "safer-buffer": ">= 2.1.2 < 3"
+            }
+        },
         "inflight": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "dev": true,
             "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
+                "once": "^1.3.0",
+                "wrappy": "1"
             }
         },
         "inherits": {
@@ -355,10 +381,29 @@
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
             "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
+        "is-stream": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+        },
+        "is-url": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+            "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww=="
+        },
         "isarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
             "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "isomorphic-fetch": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+            "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+            "requires": {
+                "node-fetch": "^1.0.1",
+                "whatwg-fetch": ">=0.10.0"
+            }
         },
         "js-base64": {
             "version": "2.4.5",
@@ -366,25 +411,25 @@
             "integrity": "sha512-aUnNwqMOXw3yvErjMPSQu6qIIzUmT1e5KcU1OZxRDU1g/am6mzBvcrmLAYwzmB59BHPrh5/tKaiF4OPhqRWESQ=="
         },
         "js-tokens": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-            "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
             "dev": true
         },
         "js-yaml": {
-            "version": "3.11.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
-            "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
+            "version": "3.14.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
+            "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
             "dev": true,
             "requires": {
-                "argparse": "1.0.10",
-                "esprima": "4.0.0"
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
             },
             "dependencies": {
                 "esprima": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-                    "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+                    "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
                     "dev": true
                 }
             }
@@ -394,8 +439,8 @@
             "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
             "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
             "requires": {
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2"
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2"
             }
         },
         "magic-string": {
@@ -403,7 +448,7 @@
             "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
             "integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
             "requires": {
-                "vlq": "0.2.3"
+                "vlq": "^0.2.2"
             }
         },
         "merge-source-map": {
@@ -411,7 +456,7 @@
             "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.0.4.tgz",
             "integrity": "sha1-pd5GU42uhNQRTMXqArR3KmNGcB8=",
             "requires": {
-                "source-map": "0.5.7"
+                "source-map": "^0.5.6"
             },
             "dependencies": {
                 "source-map": {
@@ -427,13 +472,31 @@
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
             "dev": true,
             "requires": {
-                "brace-expansion": "1.1.11"
+                "brace-expansion": "^1.1.7"
             }
         },
         "minimist": {
-            "version": "1.2.0",
-            "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-            "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+        },
+        "mkdirp": {
+            "version": "0.5.5",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+            "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+            "dev": true,
+            "requires": {
+                "minimist": "^1.2.5"
+            }
+        },
+        "node-fetch": {
+            "version": "1.7.3",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+            "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+            "requires": {
+                "encoding": "^0.1.11",
+                "is-stream": "^1.0.1"
+            }
         },
         "object-inspect": {
             "version": "1.4.1",
@@ -441,9 +504,9 @@
             "integrity": "sha512-wqdhLpfCUbEsoEwl3FXwGyv8ief1k/1aUdIPCqVnupM6e8l63BEJdiF/0swtn04/8p05tG/T0FrpTlfwvljOdw=="
         },
         "object-keys": {
-            "version": "1.0.11",
-            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-            "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
         },
         "once": {
             "version": "1.4.0",
@@ -451,20 +514,20 @@
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "dev": true,
             "requires": {
-                "wrappy": "1.0.2"
+                "wrappy": "1"
             }
         },
         "optionator": {
-            "version": "0.8.2",
-            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-            "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+            "version": "0.8.3",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+            "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
             "requires": {
-                "deep-is": "0.1.3",
-                "fast-levenshtein": "2.0.6",
-                "levn": "0.3.0",
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2",
-                "wordwrap": "1.0.0"
+                "deep-is": "~0.1.3",
+                "fast-levenshtein": "~2.0.6",
+                "levn": "~0.3.0",
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2",
+                "word-wrap": "~1.2.3"
             }
         },
         "pako": {
@@ -494,9 +557,9 @@
             "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
         },
         "process-nextick-args": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-            "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
         },
         "quote-stream": {
             "version": "1.0.2",
@@ -504,22 +567,37 @@
             "integrity": "sha1-hJY/jJwmuULhU/7rU6rnRlK34LI=",
             "requires": {
                 "buffer-equal": "0.0.1",
-                "minimist": "1.2.0",
-                "through2": "2.0.3"
+                "minimist": "^1.1.3",
+                "through2": "^2.0.0"
             }
         },
         "readable-stream": {
-            "version": "2.3.6",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-            "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.0.tgz",
+            "integrity": "sha512-c7KMXGd4b48nN3OJ1U9qOsn6pXNzf6kLd3kdZCkg2sxAcoiufInqF0XckwEnlrcwuaYwonlNK8GQUIOC/WC7sg==",
             "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "2.0.0",
-                "safe-buffer": "5.1.2",
-                "string_decoder": "1.1.1",
-                "util-deprecate": "1.0.2"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~1.0.6",
+                "safe-buffer": "~5.1.0",
+                "string_decoder": "~1.0.0",
+                "util-deprecate": "~1.0.1"
+            },
+            "dependencies": {
+                "process-nextick-args": {
+                    "version": "1.0.7",
+                    "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                    "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+                },
+                "string_decoder": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+                    "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+                    "requires": {
+                        "safe-buffer": "~5.1.0"
+                    }
+                }
             }
         },
         "resolve": {
@@ -527,7 +605,7 @@
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
             "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
             "requires": {
-                "path-parse": "1.0.5"
+                "path-parse": "^1.0.5"
             }
         },
         "safe-buffer": {
@@ -535,10 +613,15 @@
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         },
+        "safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+        },
         "semver": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-            "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
             "dev": true
         },
         "shallow-copy": {
@@ -559,11 +642,30 @@
             "dev": true
         },
         "static-eval": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.0.0.tgz",
-            "integrity": "sha512-6flshd3F1Gwm+Ksxq463LtFd1liC77N/PX1FVVc3OzL3hAmo2fwHFbuArkcfi7s9rTNsLEhcRmXGFZhlgy40uw==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.1.0.tgz",
+            "integrity": "sha512-agtxZ/kWSsCkI5E4QifRwsaPs0P0JmZV6dkLz6ILYfFYQGn+5plctanRN+IC8dJRiFkyXHrwEE3W9Wmx67uDbw==",
             "requires": {
-                "escodegen": "1.9.1"
+                "escodegen": "^1.11.1"
+            },
+            "dependencies": {
+                "escodegen": {
+                    "version": "1.14.2",
+                    "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.2.tgz",
+                    "integrity": "sha512-InuOIiKk8wwuOFg6x9BQXbzjrQhtyXh46K9bqVTPzSo2FnyMBaYGBMC6PhQy7yxxil9vIedFBweQBMK74/7o8A==",
+                    "requires": {
+                        "esprima": "^4.0.1",
+                        "estraverse": "^4.2.0",
+                        "esutils": "^2.0.2",
+                        "optionator": "^0.8.1",
+                        "source-map": "~0.6.1"
+                    }
+                },
+                "esprima": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+                    "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+                }
             }
         },
         "static-module": {
@@ -571,20 +673,36 @@
             "resolved": "https://registry.npmjs.org/static-module/-/static-module-2.2.5.tgz",
             "integrity": "sha512-D8vv82E/Kpmz3TXHKG8PPsCPg+RAX6cbCOyvjM6x04qZtQ47EtJFVwRsdov3n5d6/6ynrOY9XB4JkaZwB2xoRQ==",
             "requires": {
-                "concat-stream": "1.6.2",
-                "convert-source-map": "1.5.1",
-                "duplexer2": "0.1.4",
-                "escodegen": "1.9.1",
-                "falafel": "2.1.0",
-                "has": "1.0.1",
-                "magic-string": "0.22.5",
+                "concat-stream": "~1.6.0",
+                "convert-source-map": "^1.5.1",
+                "duplexer2": "~0.1.4",
+                "escodegen": "~1.9.0",
+                "falafel": "^2.1.0",
+                "has": "^1.0.1",
+                "magic-string": "^0.22.4",
                 "merge-source-map": "1.0.4",
-                "object-inspect": "1.4.1",
-                "quote-stream": "1.0.2",
-                "readable-stream": "2.3.6",
-                "shallow-copy": "0.0.1",
-                "static-eval": "2.0.0",
-                "through2": "2.0.3"
+                "object-inspect": "~1.4.0",
+                "quote-stream": "~1.0.2",
+                "readable-stream": "~2.3.3",
+                "shallow-copy": "~0.0.1",
+                "static-eval": "^2.0.0",
+                "through2": "~2.0.3"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "2.3.7",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                }
             }
         },
         "string_decoder": {
@@ -592,71 +710,82 @@
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
             "requires": {
-                "safe-buffer": "5.1.2"
-            }
-        },
-        "strip-ansi": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-            "dev": true,
-            "requires": {
-                "ansi-regex": "2.1.1"
+                "safe-buffer": "~5.1.0"
             }
         },
         "supports-color": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-            "dev": true
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+            "dev": true,
+            "requires": {
+                "has-flag": "^3.0.0"
+            }
         },
         "through2": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-            "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+            "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
             "requires": {
-                "readable-stream": "2.3.6",
-                "xtend": "4.0.1"
+                "readable-stream": "~2.3.6",
+                "xtend": "~4.0.1"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "2.3.7",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                }
             }
         },
         "tiny-inflate": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.2.tgz",
-            "integrity": "sha1-k9nez/yIBb1X6uQxDwt0Xptvs6c="
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+            "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="
         },
         "tslib": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.1.tgz",
-            "integrity": "sha512-avfPS28HmGLLc2o4elcc2EIq2FcH++Yo5YxpBZi9Yw93BCTGFthI4HPE4Rpep6vSYQaK8e69PelM44tPj+RaQg==",
+            "version": "1.13.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+            "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
             "dev": true
         },
         "tslint": {
-            "version": "5.10.0",
-            "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.10.0.tgz",
-            "integrity": "sha1-EeJrzLiK+gLdDZlWyuPUVAtfVMM=",
+            "version": "5.20.1",
+            "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.20.1.tgz",
+            "integrity": "sha512-EcMxhzCFt8k+/UP5r8waCf/lzmeSyVlqxqMEDQE7rWYiQky8KpIBz1JAoYXfROHrPZ1XXd43q8yQnULOLiBRQg==",
             "dev": true,
             "requires": {
-                "babel-code-frame": "6.26.0",
-                "builtin-modules": "1.1.1",
-                "chalk": "2.4.1",
-                "commander": "2.15.1",
-                "diff": "3.5.0",
-                "glob": "7.1.2",
-                "js-yaml": "3.11.0",
-                "minimatch": "3.0.4",
-                "resolve": "1.7.1",
-                "semver": "5.5.0",
-                "tslib": "1.9.1",
-                "tsutils": "2.27.1"
+                "@babel/code-frame": "^7.0.0",
+                "builtin-modules": "^1.1.1",
+                "chalk": "^2.3.0",
+                "commander": "^2.12.1",
+                "diff": "^4.0.1",
+                "glob": "^7.1.1",
+                "js-yaml": "^3.13.1",
+                "minimatch": "^3.0.4",
+                "mkdirp": "^0.5.1",
+                "resolve": "^1.3.2",
+                "semver": "^5.3.0",
+                "tslib": "^1.8.0",
+                "tsutils": "^2.29.0"
             }
         },
         "tsutils": {
-            "version": "2.27.1",
-            "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.27.1.tgz",
-            "integrity": "sha512-AE/7uzp32MmaHvNNFES85hhUDHFdFZp6OAiZcd6y4ZKKIg6orJTm8keYWBhIhrJQH3a4LzNKat7ZPXZt5aTf6w==",
+            "version": "2.29.0",
+            "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
+            "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
             "dev": true,
             "requires": {
-                "tslib": "1.9.1"
+                "tslib": "^1.8.1"
             }
         },
         "type-check": {
@@ -664,7 +793,7 @@
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
             "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
             "requires": {
-                "prelude-ls": "1.1.2"
+                "prelude-ls": "~1.1.2"
             }
         },
         "typedarray": {
@@ -673,25 +802,18 @@
             "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
         },
         "typescript": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.0.3.tgz",
-            "integrity": "sha512-kk80vLW9iGtjMnIv11qyxLqZm20UklzuR2tL0QAnDIygIUIemcZMxlMWudl9OOt76H3ntVzcTiddQ1/pAAJMYg==",
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.4.tgz",
+            "integrity": "sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==",
             "dev": true
-        },
-        "unicode-properties": {
-            "version": "github:quicktype/unicode-properties#d5fddfea1ef9d05c6479a979e225476063e13f52",
-            "requires": {
-                "brfs": "1.6.1",
-                "unicode-trie": "0.3.1"
-            }
         },
         "unicode-trie": {
             "version": "0.3.1",
             "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-0.3.1.tgz",
             "integrity": "sha1-1nHd3YkQGgi6w3tqUWEBBgIFIIU=",
             "requires": {
-                "pako": "0.2.9",
-                "tiny-inflate": "1.0.2"
+                "pako": "^0.2.5",
+                "tiny-inflate": "^1.0.0"
             },
             "dependencies": {
                 "pako": {
@@ -716,6 +838,16 @@
             "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
             "integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow=="
         },
+        "whatwg-fetch": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+            "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
+        },
+        "word-wrap": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+            "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
+        },
         "wordwrap": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
@@ -728,9 +860,14 @@
             "dev": true
         },
         "xtend": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-            "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+            "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+        },
+        "yaml": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
+            "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg=="
         }
     }
 }

--- a/build/quicktype-core/package.in.json
+++ b/build/quicktype-core/package.in.json
@@ -14,6 +14,7 @@
     },
     "dependencies": {
         "collection-utils": "^1.0.1",
+        "is-url": "^1.2.4",
         "js-base64": "^2.4.3",
         "pako": "^1.0.6",
         "pluralize": "^7.0.0",


### PR DESCRIPTION
quicktype-core has a direct dependency on is-url, however this is not listed as such.

```
Error: Cannot find module 'is-url'
Require stack:
- /Users/alanagius/git/angular-cli/node_modules/quicktype-core/dist/input/io/NodeIO.js
- /Users/alanagius/git/angular-cli/node_modules/quicktype-core/dist/index.js
- /Users/alanagius/git/angular-cli/tools/quicktype_runner.js
- /Users/alanagius/git/angular-cli/scripts/build-schema.ts
- /Users/alanagius/git/angular-cli/scripts/build.ts
- /Users/alanagius/git/angular-cli/bin/devkit-admin
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:980:15)
    at Function.Module._resolveFilename (/Users/alanagius/git/angular-cli/lib/bootstrap-local.js:133:29)
    at Function.Module._load (internal/modules/cjs/loader.js:862:27)
    at Module.require (internal/modules/cjs/loader.js:1042:19)
    at require (internal/modules/cjs/helpers.js:77:18)
    at Object.<anonymous> (/Users/alanagius/git/angular-cli/node_modules/quicktype-core/dist/input/io/NodeIO.js:16:15)
    at Module._compile (internal/modules/cjs/loader.js:1156:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1176:10)
    at Module.load (internal/modules/cjs/loader.js:1000:32)
    at Function.Module._load (internal/modules/cjs/loader.js:899:14)
```

Closes #1502