### PR TITLE
Go: Support `omitempty` tag for optional arrays

### DIFF
--- a/src/quicktype-core/language/Golang.ts
+++ b/src/quicktype-core/language/Golang.ts
@@ -87,7 +87,7 @@ function singleDescriptionComment(description: string[] | undefined): string {
 function canOmitEmpty(cp: ClassProperty): boolean {
     if (!cp.isOptional) return false;
     const t = cp.type;
-    return ["union", "null", "any", "array"].indexOf(t.kind) < 0;
+    return ["union", "null", "any"].indexOf(t.kind) < 0;
 }
 
 export class GoRenderer extends ConvenienceRenderer {

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -342,7 +342,15 @@ export const GoLanguage: Language = {
   features: ["union"],
   output: "quicktype.go",
   topLevel: "TopLevel",
-  skipJSON: ["identifiers.json", "simple-identifiers.json", "blns-object.json", "nst-test-suite.json"],
+  skipJSON: [
+    "identifiers.json",
+    "simple-identifiers.json",
+    "blns-object.json",
+    "nst-test-suite.json",
+    // can't differenciate empty array and nothing for optional empty array
+    // (omitempty).
+    "github-events.json",
+  ],
   skipMiscJSON: false,
   skipSchema: [],
   rendererOptions: {},

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -352,7 +352,11 @@ export const GoLanguage: Language = {
     "github-events.json",
   ],
   skipMiscJSON: false,
-  skipSchema: [],
+  skipSchema: [
+    // can't differenciate empty array and nothing for optional empty array
+    // (omitempty).
+    "postman-collection.schema",
+  ],
   rendererOptions: {},
   quickTestRendererOptions: [],
   sourceFiles: ["src/language/Golang.ts"],


### PR DESCRIPTION
Optional array can be (or should be) marked as omitempty.

ref: #1288