### PR TITLE
Added convert JSON option for JavaScript

### DIFF
--- a/src/quicktype-core/language/JavaScript.ts
+++ b/src/quicktype-core/language/JavaScript.ts
@@ -29,7 +29,7 @@ import { Namer, Name, funPrefixNamer } from "../Naming";
 import { ConvenienceRenderer } from "../ConvenienceRenderer";
 import { TargetLanguage } from "../TargetLanguage";
 import { StringTypeMapping } from "../TypeBuilder";
-import { BooleanOption, Option, OptionValues, getOptionValues, EnumOption } from "../RendererOptions";
+import { BooleanOption, Option, OptionValues, getOptionValues, EnumOption} from "../RendererOptions";
 import { RenderContext } from "../Renderer";
 import { isES3IdentifierPart, isES3IdentifierStart } from "./JavaScriptUnicodeMaps";
 

--- a/src/quicktype-core/language/JavaScript.ts
+++ b/src/quicktype-core/language/JavaScript.ts
@@ -43,12 +43,12 @@ export const javaScriptOptions = {
         "secondary"
     ),
     converters: convertersOption(),
-    rawType: new EnumOption(
+    rawType: new EnumOption<"json" | "any">(
         "raw-type",
         "Type to raw input (json by default)",
         [
-            ["json", "json" as const],
-            ["any", "any" as const]
+            ["json", "json"],
+            ["any", "any"]
         ],
         "json",
         "secondary"

--- a/src/quicktype-core/language/JavaScript.ts
+++ b/src/quicktype-core/language/JavaScript.ts
@@ -29,7 +29,7 @@ import { Namer, Name, funPrefixNamer } from "../Naming";
 import { ConvenienceRenderer } from "../ConvenienceRenderer";
 import { TargetLanguage } from "../TargetLanguage";
 import { StringTypeMapping } from "../TypeBuilder";
-import { BooleanOption, Option, OptionValues, getOptionValues, EnumOption} from "../RendererOptions";
+import { BooleanOption, Option, OptionValues, getOptionValues, EnumOption } from "../RendererOptions";
 import { RenderContext } from "../Renderer";
 import { isES3IdentifierPart, isES3IdentifierStart } from "./JavaScriptUnicodeMaps";
 

--- a/src/quicktype-core/language/TypeScriptFlow.ts
+++ b/src/quicktype-core/language/TypeScriptFlow.ts
@@ -42,7 +42,7 @@ export abstract class TypeScriptFlowBaseTargetLanguage extends JavaScriptTargetL
             tsFlowOptions.runtimeTypecheckIgnoreUnknownProperties,
             tsFlowOptions.acronymStyle,
             tsFlowOptions.converters,
-            tsFlowOptions.convertJson
+            tsFlowOptions.rawType
         ];
     }
 
@@ -191,13 +191,13 @@ export abstract class TypeScriptFlowBaseRenderer extends JavaScriptRenderer {
     }
 
     protected deserializerFunctionLine(t: Type, name: Name): Sourcelike {
-        const jsonType = this._tsFlowOptions.convertJson ? "string" : "any";
+        const jsonType = this._tsFlowOptions.rawType === "json" ? "string" : "any";
         return ["function to", name, "(json: ", jsonType, "): ", this.sourceFor(t).source];
     }
 
     protected serializerFunctionLine(t: Type, name: Name): Sourcelike {
         const camelCaseName = modifySource(camelCase, name);
-        const returnType = this._tsFlowOptions.convertJson ? "string" : "any";
+        const returnType = this._tsFlowOptions.rawType === "json" ? "string" : "any";
         return ["function ", camelCaseName, "ToJson(value: ", this.sourceFor(t).source, "): ", returnType];
     }
 
@@ -238,13 +238,13 @@ export class TypeScriptRenderer extends TypeScriptFlowBaseRenderer {
     }
 
     protected deserializerFunctionLine(t: Type, name: Name): Sourcelike {
-        const jsonType = this._tsFlowOptions.convertJson ? "string" : "any";
+        const jsonType = this._tsFlowOptions.rawType === "json" ? "string" : "any";
         return ["public static to", name, "(json: ", jsonType, "): ", this.sourceFor(t).source];
     }
 
     protected serializerFunctionLine(t: Type, name: Name): Sourcelike {
         const camelCaseName = modifySource(camelCase, name);
-        const returnType = this._tsFlowOptions.convertJson ? "string" : "any";
+        const returnType = this._tsFlowOptions.rawType === "json" ? "string" : "any";
         return ["public static ", camelCaseName, "ToJson(value: ", this.sourceFor(t).source, "): ", returnType];
     }
 

--- a/src/quicktype-core/language/TypeScriptFlow.ts
+++ b/src/quicktype-core/language/TypeScriptFlow.ts
@@ -41,7 +41,8 @@ export abstract class TypeScriptFlowBaseTargetLanguage extends JavaScriptTargetL
             tsFlowOptions.runtimeTypecheck,
             tsFlowOptions.runtimeTypecheckIgnoreUnknownProperties,
             tsFlowOptions.acronymStyle,
-            tsFlowOptions.converters
+            tsFlowOptions.converters,
+            tsFlowOptions.convertJson
         ];
     }
 
@@ -89,7 +90,7 @@ export abstract class TypeScriptFlowBaseRenderer extends JavaScriptRenderer {
     constructor(
         targetLanguage: TargetLanguage,
         renderContext: RenderContext,
-        private readonly _tsFlowOptions: OptionValues<typeof tsFlowOptions>
+        protected readonly _tsFlowOptions: OptionValues<typeof tsFlowOptions>
     ) {
         super(targetLanguage, renderContext, _tsFlowOptions);
     }
@@ -190,12 +191,14 @@ export abstract class TypeScriptFlowBaseRenderer extends JavaScriptRenderer {
     }
 
     protected deserializerFunctionLine(t: Type, name: Name): Sourcelike {
-        return ["function to", name, "(json: string): ", this.sourceFor(t).source];
+        const jsonType = this._tsFlowOptions.convertJson ? "string" : "any";
+        return ["function to", name, "(json: ", jsonType, "): ", this.sourceFor(t).source];
     }
 
     protected serializerFunctionLine(t: Type, name: Name): Sourcelike {
         const camelCaseName = modifySource(camelCase, name);
-        return ["function ", camelCaseName, "ToJson(value: ", this.sourceFor(t).source, "): string"];
+        const returnType = this._tsFlowOptions.convertJson ? "string" : "any";
+        return ["function ", camelCaseName, "ToJson(value: ", this.sourceFor(t).source, "): ", returnType];
     }
 
     protected get moduleLine(): string | undefined {
@@ -235,12 +238,14 @@ export class TypeScriptRenderer extends TypeScriptFlowBaseRenderer {
     }
 
     protected deserializerFunctionLine(t: Type, name: Name): Sourcelike {
-        return ["public static to", name, "(json: string): ", this.sourceFor(t).source];
+        const jsonType = this._tsFlowOptions.convertJson ? "string" : "any";
+        return ["public static to", name, "(json: ", jsonType, "): ", this.sourceFor(t).source];
     }
 
     protected serializerFunctionLine(t: Type, name: Name): Sourcelike {
         const camelCaseName = modifySource(camelCase, name);
-        return ["public static ", camelCaseName, "ToJson(value: ", this.sourceFor(t).source, "): string"];
+        const returnType = this._tsFlowOptions.convertJson ? "string" : "any";
+        return ["public static ", camelCaseName, "ToJson(value: ", this.sourceFor(t).source, "): ", returnType];
     }
 
     protected get moduleLine(): string | undefined {


### PR DESCRIPTION
Added option to not `JSON.parse` and `JSON.stringify` when converting to/from JSON.

## Motivation

Using [PouchDB](https://pouchdb.com) which provides document updates as a JS object but I still want to use quicktype for type generation and (de)serializing dates.