### PR TITLE
setting nil value for scalar keys should not raise an exception in obj-c

### DIFF
--- a/src/quicktype-core/language/Objective-C.ts
+++ b/src/quicktype-core/language/Objective-C.ts
@@ -744,9 +744,9 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
                 this.emitLine("if (resolved) [super setValue:value forKey:resolved];");
             });
 
-            // setNilForKey: is automatically invoked by the NSObject setValue:forKey: when it is passed nil for a scalar (a.k.a. non-nullable) object
-            // The approach below sets the scalar to 0 in this case, and therefore assumes an initializer with incomplete data shouldn't be grounds for an exception.
-            // Put another way, if the initializer didn't have a key at all, there wouldn't be an exception raised, so sending nil for soemthing probably shouldn't cause one.
+            // setNilValueForKey: is automatically invoked by the NSObject setValue:forKey: when it is passed nil for a scalar (a.k.a. non-nullable) object
+            // The approach below sets the scalar to 0 in this case, and therefore assumes an initializer with incomplete data shouldn't be grounds for raising an exception.
+            // Put another way, if the initializer didn't have a key at all, there wouldn't be an exception raised, so sending nil for something probably shouldn't cause one.
             this.ensureBlankLine();
             this.emitMethod("- (void)setNilValueForKey:(NSString *)key", () => {
                 this.emitLine("id resolved = ", className, ".properties[key];");

--- a/src/quicktype-core/language/Objective-C.ts
+++ b/src/quicktype-core/language/Objective-C.ts
@@ -748,7 +748,7 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
             // The approach below sets the scalar to 0 in this case, and therefore assumes an initializer with incomplete data shouldn't be grounds for an exception.
             // Put another way, if the initializer didn't have a key at all, there wouldn't be an exception raised, so sending nil for soemthing probably shouldn't cause one.
             this.ensureBlankLine();
-            this.emitMethod("- (void)setNilForKey:(NSString *)key", () => {
+            this.emitMethod("- (void)setNilValueForKey:(NSString *)key", () => {
                 this.emitLine("id resolved = ", className, ".properties[key];");
                 this.emitLine("if (resolved) [super setValue:@(0) forKey:resolved];");
             });

--- a/src/quicktype-core/language/Objective-C.ts
+++ b/src/quicktype-core/language/Objective-C.ts
@@ -744,6 +744,15 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
                 this.emitLine("if (resolved) [super setValue:value forKey:resolved];");
             });
 
+            // setNilForKey: is automatically invoked by the NSObject setValue:forKey: when it is passed nil for a scalar (a.k.a. non-nullable) object
+            // The approach below sets the scalar to 0 in this case, and therefore assumes an initializer with incomplete data shouldn't be grounds for an exception.
+            // Put another way, if the initializer didn't have a key at all, there wouldn't be an exception raised, so sending nil for soemthing probably shouldn't cause one.
+            this.ensureBlankLine();
+            this.emitMethod("- (void)setNilForKey:(NSString *)key", () => {
+                this.emitLine("id resolved = ", className, ".properties[key];");
+                this.emitLine("if (resolved) [super setValue:@(0) forKey:resolved];");
+            });
+
             this.ensureBlankLine();
             this.emitMethod("- (NSDictionary *)JSONDictionary", () => {
                 if (!hasIrregularProperties && !hasUnsafeProperties) {


### PR DESCRIPTION
Quicktype object initialization dictionaries may eventually receive null values in places where the user intended to send a scalar value. This change makes that non-fatal in objective-c.

At parse-time, unexpected null values for scalar types will raise exceptions and effectively throw out entire object graphs due to the default behavior of NSObject. Specifically, passing in null (NSNull) values for a scalar key in setValue:forKey: in objective-c triggers the default implementation of setNilValueForKey:, which raises an exception. This lives on a primary initialization path for Quicktype objects. Meanwhile, if the key/value were simply not included, no exception would be thrown even though that is semantically pretty close to passing in null.

The change does the following:

1. Overrides setNilValueForKey: to explicitly handle this case.
2. An exception will not be thrown.
3. The value is then explicitly set to 0.

Setting the value to 0 here matches general objective-c behavior of having un-set scalars be 0. Technically we could no-op this and the value would still be zero at init, but we want to correctly handle a case where the parent is mutated after creation. Another option here would be to simply not alter the value, but putting in 0 *feels* more right to me. Would be happy to change the behavior to a no-op as the outcome for most use cases is the same.