### PR TITLE
Generate correct optionality of Enums  in swift from graphql

### DIFF
--- a/src/quicktype-graphql-input/index.ts
+++ b/src/quicktype-graphql-input/index.ts
@@ -232,6 +232,7 @@ class GQLQuery {
                     name = fieldNode.name.value;
                     fieldName = null;
                 }
+                optional = true;
                 result = builder.getEnumType(makeNames(name, fieldName, containingTypeName), new Set(values));
                 break;
             case TypeKind.INPUT_OBJECT:


### PR DESCRIPTION
Nullable enums are always made NON_NULLABLE in generated code. This PR fixes that.

Solves:
#1528