### PR TITLE
C++: Improve compiler support

### DIFF
--- a/src/quicktype-core/language/CPlusPlus.ts
+++ b/src/quicktype-core/language/CPlusPlus.ts
@@ -1559,7 +1559,7 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
                         });
                     });
 
-                    this.emitLine("auto iter = enumValues.find(j);");
+                    this.emitLine(`auto iter = enumValues.find(j.get<${this._stringType.getType()}>());`);
                     this.emitBlock("if (iter != enumValues.end())", false, () => {
                         this.emitLine("x = iter->second;");
                     });


### PR DESCRIPTION
It seems that some compilers can't implicitly cast the json value. Explicitly doing that by calling get<T> fixes the problem.

I reproduced the issue with the latest IAR C++ compiler for ARM.