### PR TITLE
feat: export MultiFileRenderResult

### DIFF
--- a/src/quicktype-core/index.ts
+++ b/src/quicktype-core/index.ts
@@ -20,7 +20,7 @@ export { JSONSchemaInput, JSONSchemaSourceData } from "./input/JSONSchemaInput";
 export { Ref, JSONSchemaType, JSONSchemaAttributes } from "./input/JSONSchemaInput";
 export { RenderContext } from "./Renderer";
 export { Option, OptionDefinition, getOptionValues } from "./RendererOptions";
-export { TargetLanguage } from "./TargetLanguage";
+export { TargetLanguage, MultiFileRenderResult } from "./TargetLanguage";
 export { all as defaultTargetLanguages, languageNamed } from "./language/All";
 export { MultiWord, Sourcelike, SerializedRenderResult, Annotation, modifySource, singleWord, parenIfNeeded } from "./Source";
 export { Name, funPrefixNamer, Namer } from "./Naming";


### PR DESCRIPTION
Exports `MultiFileRenderResult` in top level. Otherwise I have to do this to get the TS interface:

```ts
import {MultiFileRenderResult} from '../node_modules/quicktype-core/dist/TargetLanguage'
```

Related: https://github.com/googleapis/google-cloudevents/issues/83