### PR TITLE
optional field unset not in the json with null

### DIFF
--- a/src/quicktype-core/language/CPlusPlus.ts
+++ b/src/quicktype-core/language/CPlusPlus.ts
@@ -837,6 +837,14 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
 
     protected cppType(t: Type, ctx: TypeContext, withIssues: boolean, forceNarrowString: boolean, isOptional: boolean): Sourcelike {
         const inJsonNamespace = ctx.inJsonNamespace;
+        if (isOptional && t instanceof UnionType) { // avoid have optionalType<optionalType<Type>>
+            for (const tChild of t.getChildren()) {
+                if (tChild.isNullable) {
+                    isOptional = false;
+                    break;
+                }
+            }
+        }
         let typeSource = matchType<Sourcelike>(
             t,
             _anyType =>

--- a/src/quicktype-core/language/CPlusPlus.ts
+++ b/src/quicktype-core/language/CPlusPlus.ts
@@ -1375,15 +1375,14 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
                         this._stringType.wrapEncodingChange([ourQualifier], cppType, toType, ["x.", getter]),
                         ";"
                 ];
-                if (t instanceof UnionType && removeNullFromUnion(t, true)[0]) {
+                if (t instanceof UnionType && removeNullFromUnion(t, true)[0] !== null) {
                     this.emitBlock(
                         ["if (", this._stringType.wrapEncodingChange([ourQualifier], cppType, toType, ["x.", getter]),")"],
                         false,
                         () => {
                             this.emitLine(assignment);
                     });
-                }
-                else {
+                } else {
                     this.emitLine(assignment);
                 }
             });

--- a/src/quicktype-core/language/CPlusPlus.ts
+++ b/src/quicktype-core/language/CPlusPlus.ts
@@ -136,6 +136,10 @@ export class CPlusPlusTargetLanguage extends TargetLanguage {
         return true;
     }
 
+    get supportsOptionalClassProperties(): boolean {
+        return true;
+    }
+
     protected makeRenderer(
         renderContext: RenderContext,
         untypedOptionValues: { [name: string]: any }
@@ -1375,7 +1379,7 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
                         this._stringType.wrapEncodingChange([ourQualifier], cppType, toType, ["x.", getter]),
                         ";"
                 ];
-                if (t instanceof UnionType && removeNullFromUnion(t, true)[0] !== null) {
+                if (p.isOptional) {
                     this.emitBlock(
                         ["if (", this._stringType.wrapEncodingChange([ourQualifier], cppType, toType, ["x.", getter]),")"],
                         false,

--- a/src/quicktype-core/language/CPlusPlus.ts
+++ b/src/quicktype-core/language/CPlusPlus.ts
@@ -1363,18 +1363,29 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
                 } else {
                     getter = [name];
                 }
-                this.emitLine(
-                    "j[",
-                    this._stringType.wrapEncodingChange(
-                        [ourQualifier],
-                        this._stringType.getType(),
-                        this.NarrowString.getType(),
-                        this._stringType.createStringLiteral([stringEscape(json)])
-                    ),
-                    "] = ",
-                    this._stringType.wrapEncodingChange([ourQualifier], cppType, toType, ["x.", getter]),
-                    ";"
-                );
+                let assignment: Sourcelike[] = [
+                        "j[",
+                        this._stringType.wrapEncodingChange(
+                            [ourQualifier],
+                            this._stringType.getType(),
+                            this.NarrowString.getType(),
+                            this._stringType.createStringLiteral([stringEscape(json)])
+                        ),
+                        "] = ",
+                        this._stringType.wrapEncodingChange([ourQualifier], cppType, toType, ["x.", getter]),
+                        ";"
+                ];
+                if (t instanceof UnionType && removeNullFromUnion(t, true)[0]) {
+                    this.emitBlock(
+                        ["if (", this._stringType.wrapEncodingChange([ourQualifier], cppType, toType, ["x.", getter]),")"],
+                        false,
+                        () => {
+                            this.emitLine(assignment);
+                    });
+                }
+                else {
+                    this.emitLine(assignment);
+                }
             });
         });
     }


### PR DESCRIPTION
Close: #1563 

## Previous output

```cpp
    inline void to_json(json & j, const quicktype::Test & x) {
        j = json::object();
        j["optionalField"] = x.optional_field;
        j["requiredField"] = x.required_field;
    }
```

## New output

```cpp
    inline void to_json(json & j, const quicktype::Test & x) {
        j = json::object();
        if (x.get_optional_field()) {
            j["optionalField"] = x.get_optional_field();
        }
        j["requiredField"] = x.get_required_field();
    }
```