### PR TITLE
Kotlinx/1.0.0

### DIFF
--- a/src/quicktype-core/language/Kotlin.ts
+++ b/src/quicktype-core/language/Kotlin.ts
@@ -238,13 +238,12 @@ export class KotlinRenderer extends ConvenienceRenderer {
         this.emitLine(close);
     }
 
-    // (asarazan): I've broken out the following three functions
-    // because some renderers, such as kotlinx, can cope with `any`, while some get mad.
-    protected anyType(withIssues: boolean = false, noOptional: boolean = false): Sourcelike {
-        const optional = noOptional ? "" : "?";
-        return maybeAnnotated(withIssues, anyTypeIssueAnnotation, ["Any", optional]);
+    protected anySourceType(optional: string): Sourcelike {
+        return ["Any", optional];
     }
 
+    // (asarazan): I've broken out the following two functions
+    // because some renderers, such as kotlinx, can cope with `any`, while some get mad.
     protected arrayType(arrayType: ArrayType, withIssues: boolean = false, _noOptional: boolean = false): Sourcelike {
         return ["List<", this.kotlinType(arrayType.items, withIssues), ">"];
     }
@@ -257,9 +256,11 @@ export class KotlinRenderer extends ConvenienceRenderer {
         const optional = noOptional ? "" : "?";
         return matchType<Sourcelike>(
             t,
-            _anyType => this.anyType(withIssues, noOptional),
+            _anyType => {
+                return maybeAnnotated(withIssues, anyTypeIssueAnnotation, this.anySourceType(optional));
+            },
             _nullType => {
-                return maybeAnnotated(withIssues, nullTypeIssueAnnotation, ["Any", optional]);
+                return maybeAnnotated(withIssues, nullTypeIssueAnnotation, this.anySourceType(optional));
             },
             _boolType => "Boolean",
             _integerType => "Long",
@@ -999,8 +1000,8 @@ export class KotlinXRenderer extends KotlinRenderer {
         super(targetLanguage, renderContext, _kotlinOptions);
     }
 
-    protected anyType(_withIssues: boolean = false, _noOptional: boolean = false): Sourcelike {
-        return "JsonObject";
+    protected anySourceType(optional: string): Sourcelike {
+        return ["JsonObject", optional];
     }
 
     protected arrayType(arrayType: ArrayType, withIssues: boolean = false, noOptional: boolean = false): Sourcelike {

--- a/src/quicktype-core/language/Kotlin.ts
+++ b/src/quicktype-core/language/Kotlin.ts
@@ -306,7 +306,7 @@ export class KotlinRenderer extends ConvenienceRenderer {
 
     protected emitEmptyClassDefinition(c: ClassType, className: Name): void {
         this.emitDescription(this.descriptionForType(c));
-
+        this.emitClassAnnotations(c, className);
         this.emitLine("class ", className, "()");
     }
 
@@ -368,7 +368,7 @@ export class KotlinRenderer extends ConvenienceRenderer {
         this.emitLine(")");
     }
 
-    protected emitClassAnnotations(_c: ClassType, _className: Name) {
+    protected emitClassAnnotations(_c: Type, _className: Name) {
         // to be overridden
     }
 
@@ -397,6 +397,7 @@ export class KotlinRenderer extends ConvenienceRenderer {
         this.emitDescription(this.descriptionForType(u));
 
         const [maybeNull, nonNulls] = removeNullFromUnion(u, sortBy);
+        this.emitClassAnnotations(u, unionName);
         this.emitBlock(["sealed class ", unionName], () => {
             {
                 let table: Sourcelike[][] = [];
@@ -1056,7 +1057,7 @@ export class KotlinXRenderer extends KotlinRenderer {
         this.emitLine("import kotlinx.serialization.encoding.*");
     }
 
-    protected emitClassAnnotations(_c: ClassType, _className: Name) {
+    protected emitClassAnnotations(_c: Type, _className: Name) {
         this.emitLine("@Serializable");
     }
 

--- a/src/quicktype-core/language/Kotlin.ts
+++ b/src/quicktype-core/language/Kotlin.ts
@@ -1078,7 +1078,7 @@ export class KotlinXRenderer extends KotlinRenderer {
     protected emitEnumDefinition(e: EnumType, enumName: Name): void {
         this.emitDescription(this.descriptionForType(e));
 
-        this.emitLine(["@Serializable(with = ", enumName, ".Companion::class)"]);
+        this.emitLine(["@Serializable"]);
         this.emitBlock(["enum class ", enumName, "(val value: String)"], () => {
             let count = e.cases.size;
             this.forEachEnumCase(e, "none", (name, json) => {

--- a/src/quicktype-core/language/Kotlin.ts
+++ b/src/quicktype-core/language/Kotlin.ts
@@ -1051,7 +1051,8 @@ export class KotlinXRenderer extends KotlinRenderer {
 
         this.emitLine("import kotlinx.serialization.*");
         this.emitLine("import kotlinx.serialization.json.*");
-        this.emitLine("import kotlinx.serialization.internal.*");
+        this.emitLine("import kotlinx.serialization.descriptors.*");
+        this.emitLine("import kotlinx.serialization.encoding.*");
     }
 
     protected emitClassAnnotations(_c: ClassType, _className: Name) {
@@ -1086,7 +1087,7 @@ export class KotlinXRenderer extends KotlinRenderer {
             this.ensureBlankLine();
             this.emitBlock(["companion object : KSerializer<", enumName, ">"], () => {
                 this.emitBlock("override val descriptor: SerialDescriptor get()", () => {
-                   this.emitLine("return PrimitiveDescriptor(\"", this._kotlinOptions.packageName, ".", enumName, "\", PrimitiveKind.STRING)");
+                   this.emitLine("return PrimitiveSerialDescriptor(\"", this._kotlinOptions.packageName, ".", enumName, "\", PrimitiveKind.STRING)");
                 });
 
                 this.emitBlock(["override fun deserialize(decoder: Decoder): ", enumName, " = when (val value = decoder.decodeString())"], () => {


### PR DESCRIPTION
As promised, this brings the KotlinX renderer in line with the new [1.0.0 Release](https://github.com/Kotlin/kotlinx.serialization/releases/tag/v1.0.0) upstream.

Changes:
* New imports for encoding, descriptors, and json-specific logic
* PrimitiveDescriptor -> PrimitiveSerialDescriptor
* Simplify Enum Annotation

Bug Fixes:
* Upon null input, the renderer will now emit `JsonObject?` instead of `Any?`, while still preserving the user warning.
* https://github.com/quicktype/quicktype/issues/1571 Fix missing annotations on class and sealed class

Test Plan: Successfully compiles the following inputs:
* pokedex.json
* spotify-album.json
* us-senators.json
* our own internal ts schema

Known Problems:
* Does not properly annotate empty `class` declarations or `sealed class` declarations. I believe this bug existed in the prior release and is not a regression. Issue filed: https://github.com/quicktype/quicktype/issues/1571