### PR TITLE
Fix programmatic example in README ("Calling `quicktype` from JavaScript")

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ const {
   InputData,
   jsonInputForTargetLanguage,
   JSONSchemaInput,
-  JSONSchemaStore,
+  FetchingJSONSchemaStore,
 } = require("quicktype-core");
 
 async function quicktypeJSON(targetLanguage, typeName, jsonString) {
@@ -172,7 +172,7 @@ async function quicktypeJSON(targetLanguage, typeName, jsonString) {
 }
 
 async function quicktypeJSONSchema(targetLanguage, typeName, jsonSchemaString) {
-  const schemaInput = new JSONSchemaInput(new JSONSchemaStore());
+  const schemaInput = new JSONSchemaInput(new FetchingJSONSchemaStore());
 
   // We could add multiple schemas for multiple types,
   // but here we're just making one type from JSON schema.


### PR DESCRIPTION
Current example is broken because JSONSchemaStore is an abstract class and cannot be instantiated.

Fixes #1585.