### PR TITLE
Make Kotlin base emit functions protected so it can be overwritten

### DIFF
--- a/src/quicktype-core/language/Kotlin.ts
+++ b/src/quicktype-core/language/Kotlin.ts
@@ -310,7 +310,7 @@ export class KotlinRenderer extends ConvenienceRenderer {
         this.emitLine("class ", className, "()");
     }
 
-    private emitClassDefinition(c: ClassType, className: Name): void {
+    protected emitClassDefinition(c: ClassType, className: Name): void {
         if (c.getProperties().size === 0) {
             this.emitEmptyClassDefinition(c, className);
             return;
@@ -387,7 +387,7 @@ export class KotlinRenderer extends ConvenienceRenderer {
         });
     }
 
-    private emitUnionDefinition(u: UnionType, unionName: Name): void {
+    protected emitUnionDefinition(u: UnionType, unionName: Name): void {
         function sortBy(t: Type): string {
             const kind = t.kind;
             if (kind === "class") return kind;


### PR DESCRIPTION
It is very restricting when creating a new variant of the Kotlin target language when the main emit functions are private and can not be overwritten any more.