### PR TITLE
fix hanging docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN apt-get -y install dotnet-sdk-2.0.0 --assume-yes
 # Install Boost for C++
 RUN apt-get -y install libboost-all-dev --assume-yes
 RUN apt-get -y update && apt-get -y install software-properties-common python-software-properties --assume-yes
-RUN add-apt-repository ppa:jonathonf/gcc
+RUN add-apt-repository ppa:jonathonf/gcc -y
 RUN apt-get -y update
 RUN apt-get -y install g++-7 --assume-yes
 RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 60 --slave /usr/bin/g++ g++ /usr/bin/g++-7
@@ -62,7 +62,7 @@ RUN /bin/bash -c "source /root/.sdkman/bin/sdkman-init.sh && sdk install kotlin"
 ENV PATH="/root/.sdkman/candidates/kotlin/current/bin:${PATH}"
 
 # Python
-RUN add-apt-repository ppa:deadsnakes/ppa
+RUN add-apt-repository ppa:deadsnakes/ppa -y
 RUN apt-get -y update
 RUN apt-get -y install python3.6 --assume-yes
 RUN curl https://bootstrap.pypa.io/get-pip.py | python3.6


### PR DESCRIPTION
A prompt for donations came up when adding the repository. This
fix should ensure that the command does not hang.

Before:
```sh
$ podman build -t quicktype .
# ...
STEP 20: RUN add-apt-repository ppa:jonathonf/gcc
 Collected backports of GCC

---

Donate to GNU: https://my.fsf.org/civicrm/contribute/transact?reset=1&id=57
Donate to Debian: https://www.debian.org/donations
Donate to this PPA: https://ko-fi.com/jonathonf
 More info: https://launchpad.net/~jonathonf/+archive/ubuntu/gcc
Press [ENTER] to continue or ctrl-c to cancel adding it
```

After:
```sh
$ podman build -t quicktype .
# ...
STEP 20: RUN add-apt-repository ppa:jonathonf/gcc -y
gpg: keyring `/tmp/tmpdoy6vzki/secring.gpg' created
gpg: keyring `/tmp/tmpdoy6vzki/pubring.gpg' created
gpg: requesting key F06FC659 from hkp server keyserver.ubuntu.com
gpg: /tmp/tmpdoy6vzki/trustdb.gpg: trustdb created
gpg: key F06FC659: public key "Launchpad PPA for J Fernyhough" imported
gpg: Total number processed: 1
gpg:               imported: 1  (RSA: 1)
OK
--> 726d77dcfbd
# ...
```