### PR TITLE
Remove typo in template text for Swift file

### DIFF
--- a/src/quicktype-core/language/Swift.ts
+++ b/src/quicktype-core/language/Swift.ts
@@ -458,7 +458,7 @@ export class SwiftRenderer extends ConvenienceRenderer {
                     "//   let ",
                     modifySource(camelCase, topLevelName),
                     " = ",
-                    "try? newJSONDecoder().decode(",
+                    "try? JSONDecoder().decode(",
                     topLevelName,
                     ".self, from: jsonData)"
                 );


### PR DESCRIPTION
Looks like an artifact from a different language was used in the template. Swift doesn't use `new`

`try? newJSONDecoder()` becomes `try? JSONDecoder()`