### PR TITLE
Fix KSerializer not bound for enum in kotlinx.serialization

### DIFF
--- a/src/quicktype-core/language/Kotlin.ts
+++ b/src/quicktype-core/language/Kotlin.ts
@@ -1080,7 +1080,7 @@ export class KotlinXRenderer extends KotlinRenderer {
     protected emitEnumDefinition(e: EnumType, enumName: Name): void {
         this.emitDescription(this.descriptionForType(e));
 
-        this.emitLine(["@Serializable"]);
+        this.emitLine(["@Serializable(with = ", enumName, ".Companion::class)"]);
         this.emitBlock(["enum class ", enumName, "(val value: String)"], () => {
             let count = e.cases.size;
             this.forEachEnumCase(e, "none", (name, json) => {
@@ -1089,7 +1089,7 @@ export class KotlinXRenderer extends KotlinRenderer {
             this.ensureBlankLine();
             this.emitBlock(["companion object : KSerializer<", enumName, ">"], () => {
                 this.emitBlock("override val descriptor: SerialDescriptor get()", () => {
-                   this.emitLine("return PrimitiveSerialDescriptor(\"", this._kotlinOptions.packageName, ".", enumName, "\", PrimitiveKind.STRING)");
+                    this.emitLine("return PrimitiveSerialDescriptor(\"", this._kotlinOptions.packageName, ".", enumName, "\", PrimitiveKind.STRING)");
                 });
 
                 this.emitBlock(["override fun deserialize(decoder: Decoder): ", enumName, " = when (val value = decoder.decodeString())"], () => {


### PR DESCRIPTION
According to the doc for [Kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization/blob/master/docs/serializers.md#custom-serializers), for any custom serializers, we need to annotate with `with`. 

## Test

- Tested with `script/quicktype --lang kotlin --framework kotlinx --src-lang schema https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json`
- The generated data bindings will be available at: https://github.com/detekt/sarif4k