### PR TITLE
Update Kotlin (kotlinx) usage API sample code

### DIFF
--- a/src/quicktype-core/language/Kotlin.ts
+++ b/src/quicktype-core/language/Kotlin.ts
@@ -1041,7 +1041,7 @@ export class KotlinXRenderer extends KotlinRenderer {
         this.emitLine("// To parse the JSON, install kotlin's serialization plugin and do:");
         this.emitLine("//");
         const table: Sourcelike[][] = [];
-        table.push(["// val ", "json", " = Json(JsonConfiguration.Stable)"]);
+        table.push(["// val ", "json", " = Json { allowStructuredMapKeys = true }"]);
         this.forEachTopLevel("none", (_, name) => {
             table.push(["// val ", modifySource(camelCase, name), ` = json.parse(${this.sourcelikeToString(name)}.serializer(), jsonString)`]);
         });


### PR DESCRIPTION
The old code is now deprecated and it is an error to use it.

![Screen Shot 2021-05-13 at 09 25 20](https://user-images.githubusercontent.com/33294549/118099555-4d363d80-b3cd-11eb-9ced-35e4b1f4e5e0.png)
