### PR TITLE
feat: export cPlusPlusOptions

### DIFF
--- a/src/quicktype-core/index.ts
+++ b/src/quicktype-core/index.ts
@@ -74,7 +74,7 @@ export { removeNullFromUnion, matchType, nullableFromUnion } from "./TypeUtils";
 export { ConvenienceRenderer } from "./ConvenienceRenderer";
 export { uriTypeAttributeKind } from "./attributes/URIAttributes";
 
-export { CPlusPlusTargetLanguage, CPlusPlusRenderer } from "./language/CPlusPlus";
+export { CPlusPlusTargetLanguage, CPlusPlusRenderer, cPlusPlusOptions } from "./language/CPlusPlus";
 export {
     CSharpTargetLanguage,
     cSharpOptions,


### PR DESCRIPTION
This PR exports `cPlusPlusOptoins` so that a custom renderer can be made, using this [blog post](http://blog.quicktype.io/customizing-quicktype/) as a guide. This allows us to support https://github.com/quicktype/quicktype/issues/1505.