### PR TITLE
TypeScript renderer: Option to render uninons insted of enums

### DIFF
--- a/src/quicktype-core/language/TypeScriptFlow.ts
+++ b/src/quicktype-core/language/TypeScriptFlow.ts
@@ -20,7 +20,8 @@ import { isES3IdentifierStart } from "./JavaScriptUnicodeMaps";
 export const tsFlowOptions = Object.assign({}, javaScriptOptions, {
     justTypes: new BooleanOption("just-types", "Interfaces only", false),
     nicePropertyNames: new BooleanOption("nice-property-names", "Transform property names to be JavaScripty", false),
-    declareUnions: new BooleanOption("explicit-unions", "Explicitly name unions", false)
+    declareUnions: new BooleanOption("explicit-unions", "Explicitly name unions", false),
+    preferUnions: new BooleanOption("prefer-unions", "Use union type instead of enum", false)
 });
 
 const tsFlowTypeAnnotations = {
@@ -42,7 +43,8 @@ export abstract class TypeScriptFlowBaseTargetLanguage extends JavaScriptTargetL
             tsFlowOptions.runtimeTypecheckIgnoreUnknownProperties,
             tsFlowOptions.acronymStyle,
             tsFlowOptions.converters,
-            tsFlowOptions.rawType
+            tsFlowOptions.rawType,
+            tsFlowOptions.preferUnions
         ];
     }
 
@@ -274,11 +276,24 @@ export class TypeScriptRenderer extends TypeScriptFlowBaseRenderer {
 
     protected emitEnum(e: EnumType, enumName: Name): void {
         this.emitDescription(this.descriptionForType(e));
-        this.emitBlock(["export enum ", enumName, " "], "", () => {
-            this.forEachEnumCase(e, "none", (name, jsonName) => {
-                this.emitLine(name, ` = "${utf16StringEscape(jsonName)}",`);
+
+        if (this._tsFlowOptions.preferUnions) {
+            let items = "";
+            e.cases.forEach((item) => {
+                if (items === "") {
+                    items += `"${utf16StringEscape(item)}"`;
+                    return;
+                }
+                items += ` | "${utf16StringEscape(item)}"`;
             });
-        });
+            this.emitLine("export type ", enumName, " = ", items, ";");
+        } else {
+            this.emitBlock(["export enum ", enumName, " "], "", () => {
+                this.forEachEnumCase(e, "none", (name, jsonName) => {
+                    this.emitLine(name, ` = "${utf16StringEscape(jsonName)}",`);
+                });
+            });
+        }
     }
 
     protected emitClassBlock(c: ClassType, className: Name): void {

--- a/src/quicktype-core/language/TypeScriptFlow.ts
+++ b/src/quicktype-core/language/TypeScriptFlow.ts
@@ -89,12 +89,15 @@ function quotePropertyName(original: string): string {
 }
 
 export abstract class TypeScriptFlowBaseRenderer extends JavaScriptRenderer {
+    protected _tsFlowOptions: OptionValues<typeof tsFlowOptions>;
+
     constructor(
         targetLanguage: TargetLanguage,
         renderContext: RenderContext,
-        protected readonly _tsFlowOptions: OptionValues<typeof tsFlowOptions>
+        _tsFlowOptions: OptionValues<typeof tsFlowOptions>
     ) {
         super(targetLanguage, renderContext, _tsFlowOptions);
+        this._tsFlowOptions = _tsFlowOptions;
     }
 
     protected namerForObjectProperty(): Namer {


### PR DESCRIPTION
This PR adds an extra option to the render options of the TypeScript language (called `prefer-unions`).
When the option is enabled some easier to use union types are generated instead of enums.

When the option is disabled we get still get the old result:
```typescript
enum Language {
    En: 'en',
    De: 'de'
}
```

But when the option is enabled we get this instead:
```typescript
type Language = 'en' | 'de';
```

P. S.: I'm open to any suggestions about code improvements. 😉 