### PR TITLE
Update the required properties generation for Flutter 2.2+

### DIFF
--- a/src/quicktype-core/language/Dart.ts
+++ b/src/quicktype-core/language/Dart.ts
@@ -496,7 +496,7 @@ export class DartRenderer extends ConvenienceRenderer {
                 this.emitLine(className, "({");
                 this.indent(() => {
                     this.forEachClassProperty(c, "none", (name, _, _p) => {
-                        this.emitLine(this._options.requiredProperties ? "@required " : "", "this.", name, ",");
+                        this.emitLine(this._options.requiredProperties ? "required " : "", "this.", name, ",");
                     });
                 });
                 this.emitLine("});");


### PR DESCRIPTION
Since the release of Flutter 2.2, the required properties has changed its keyword from "@required" to "required".
I have remove the @ symbol in the class property generation process, in order to support higher version of Flutter.

The official release notes for Flutter 2.2 is provided at this link: https://flutter.dev/docs/development/tools/sdk/release-notes/release-notes-2.2.0

Here's a quote from the 2.2 release note.

> 79239 Remove references to @required in favor of the required keyword (cla: yes, f: material design, framework, waiting for tree to go green)