### PR TITLE
toDouble() no longer valid, use double.parse('123') instead

### DIFF
--- a/src/quicktype-core/language/Dart.ts
+++ b/src/quicktype-core/language/Dart.ts
@@ -413,7 +413,7 @@ export class DartRenderer extends ConvenienceRenderer {
             _nullType => dynamic, // FIXME: check null
             _boolType => dynamic,
             _integerType => dynamic,
-            _doubleType => ["parse.double(", dynamic, ")"],
+            _doubleType => ["double.parse(", dynamic, ")"],
             _stringType => dynamic,
             arrayType =>
                 this.mapList(this.dartType(arrayType.items), dynamic, this.fromDynamicExpression(arrayType.items, "x")),


### PR DESCRIPTION
Hi,

compiling dart code that was generated from a json, containing double values, does not work anymore, when fooBar.toDouble() is used. Instead double.parse(fooBar) should be used.

See: https://dartpad.dev/?id=57f6b4a8bd06b184c60e20fc1f2dcfcd&null_safety=true