### PR TITLE
Fixing the required keyword syntax

### DIFF
--- a/src/quicktype-core/language/Dart.ts
+++ b/src/quicktype-core/language/Dart.ts
@@ -496,7 +496,7 @@ export class DartRenderer extends ConvenienceRenderer {
                 this.emitLine(className, "({");
                 this.indent(() => {
                     this.forEachClassProperty(c, "none", (name, _, _p) => {
-                        this.emitLine(this._options.requiredProperties ? "@required " : "", "this.", name, ",");
+                        this.emitLine(this._options.requiredProperties ? "required " : "", "this.", name, ",");
                     });
                 });
                 this.emitLine("});");


### PR DESCRIPTION
Just removed the `@required` annotation for the correct `required` keyword