### PR TITLE
fix instantiateMapper readerFor and writerFor class when type is a list

### DIFF
--- a/src/quicktype-core/language/Java.ts
+++ b/src/quicktype-core/language/Java.ts
@@ -706,7 +706,7 @@ export class JavaRenderer extends ConvenienceRenderer {
     protected javaTypeWithoutGenerics(reference: boolean, t: Type): Sourcelike {
         if (t instanceof ArrayType) {
             if (this._options.useList) {
-                return ["List<", this.javaTypeWithoutGenerics(true, t.items), ">"];
+                return ["List"];
             } else {
                 return [this.javaTypeWithoutGenerics(false, t.items), "[]"];
             }

--- a/src/quicktype-core/language/Java.ts
+++ b/src/quicktype-core/language/Java.ts
@@ -1368,6 +1368,7 @@ export class JacksonRenderer extends JavaRenderer {
                         const renderedForClass = this.javaTypeWithoutGenerics(false, topLevelType);
                         this.emitLine("ObjectMapper mapper = new ObjectMapper();");
                         this.emitLine("mapper.findAndRegisterModules();");
+                        this.emitLine("mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);");
                         this.emitLine("mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);");
                         this.emitOffsetDateTimeConverterModule();
                         this.emitLine(readerName, " = mapper.readerFor(", renderedForClass, ".class);");


### PR DESCRIPTION
When json schema contains array of object and the option array-type=list is used for java
The generated Converter class contains compilation errors into instantiateMapper 
```
    reader = mapper.readerFor(List<MyClass>.class);
    writer = mapper.writerFor(List<MyClass>.class);
```
instead of

```
    reader = mapper.readerFor(List.class);
    writer = mapper.writerFor(List.class);
```    