### PR TITLE
Removed "@" notation for required fields in dart

### DIFF
--- a/src/quicktype-core/language/Dart.ts
+++ b/src/quicktype-core/language/Dart.ts
@@ -496,7 +496,7 @@ export class DartRenderer extends ConvenienceRenderer {
                 this.emitLine(className, "({");
                 this.indent(() => {
                     this.forEachClassProperty(c, "none", (name, _, _p) => {
-                        this.emitLine(this._options.requiredProperties ? "@required " : "", "this.", name, ",");
+                        this.emitLine(this._options.requiredProperties ? "required " : "", "this.", name, ",");
                     });
                 });
                 this.emitLine("});");


### PR DESCRIPTION
# Whats inside
**Removed "@" notation for required fields in dart**

`@required` is just an annotation that allows analysers let you know that you're missing a named parameter and that's it. so you can still compile the application and possibly get an exception if this named param was not passed.

However sound null-safety was added to dart, and required is now a keyword that needs to be passed to a named parameter so that it doesn't let the compiler run if this parameter has not been passed. It makes your code more strict and safe.

https://dart.dev/null-safety/faq#how-does-required-compare-to-the-new-required-keyword

Also closes #1905 