### PR TITLE
Add acronym style option for kotlin

### DIFF
--- a/build/quicktype-core/package-lock.json
+++ b/build/quicktype-core/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "quicktype-core",
-    "version": "6.0.0",
+    "version": "6.1.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/build/quicktype-core/package.in.json
+++ b/build/quicktype-core/package.in.json
@@ -1,6 +1,6 @@
 {
     "name": "quicktype-core",
-    "version": "6.0.0",
+    "version": "6.1.0",
     "description": "The quicktype engine as a library",
     "license": "Apache-2.0",
     "main": "dist/index.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "quicktype",
-  "version": "15.0.0",
+  "version": "15.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quicktype",
-  "version": "15.0.0",
+  "version": "15.1.0",
   "license": "Apache-2.0",
   "main": "dist/cli/index.js",
   "types": "dist/cli/index.d.ts",


### PR DESCRIPTION
This change adds the acronym style to the CLI for kotlin for the just-types framework. This follows same pattern as swift acronym style option. 