### PR TITLE
Remove YAML.parse from JSON parsing

### DIFF
--- a/build/quicktype-core/package.in.json
+++ b/build/quicktype-core/package.in.json
@@ -23,8 +23,7 @@
         "pluralize": "^7.0.0",
         "readable-stream": "2.3.0",
         "urijs": "^1.19.1",
-        "wordwrap": "^1.0.0",
-        "yaml": "^1.5.0"
+        "wordwrap": "^1.0.0"
     },
     "devDependencies": {
         "@types/urijs": "^1.19.8",
@@ -32,7 +31,6 @@
         "@types/node": "8.10.10",
         "@types/pako": "^1.0.0",
         "@types/pluralize": "0.0.28",
-        "@types/yaml": "^1.0.2",
         "typescript": "~3.2.1",
         "tslint": "^5.11.0",
         "@types/readable-stream": "2.3.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,8 +31,7 @@
         "typescript": "~3.2.1",
         "urijs": "^1.19.11",
         "uuid": "^3.2.1",
-        "wordwrap": "^1.0.0",
-        "yaml": "^1.5.0"
+        "wordwrap": "^1.0.0"
       },
       "bin": {
         "quicktype": "dist/cli/index.js"
@@ -51,7 +50,6 @@
         "@types/semver": "^5.5.0",
         "@types/shelljs": "^0.7.8",
         "@types/urijs": "^1.19.8",
-        "@types/yaml": "^1.0.2",
         "ajv": "^5.5.2",
         "deep-equal": "^1.0.1",
         "exit": "^0.1.2",
@@ -85,19 +83,6 @@
         "esutils": "^2.0.2",
         "js-tokens": "^3.0.0"
       }
-    },
-    "node_modules/@babel/runtime": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.5.tgz",
-      "integrity": "sha512-TuI4qpWZP6lGOGIuGWtp9sPluqYICmbk8T/1vpSysqJxRPkudh/ofFWyqdcMsDf2s7KvDL4/YHgKyvcS3g9CJQ==",
-      "dependencies": {
-        "regenerator-runtime": "^0.13.2"
-      }
-    },
-    "node_modules/@babel/runtime/node_modules/regenerator-runtime": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
-      "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -501,12 +486,6 @@
       "version": "1.19.8",
       "resolved": "https://registry.npmjs.org/@types/urijs/-/urijs-1.19.8.tgz",
       "integrity": "sha512-SVQd2Qq0oL+b8VtJbQyv0cMIdU7fbRDcg2JIpcBvv+GUayJ3c5Ll1K+iivZl6ifcI6NbYcwjqDjljDFSiSGOeA==",
-      "dev": true
-    },
-    "node_modules/@types/yaml": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@types/yaml/-/yaml-1.0.2.tgz",
-      "integrity": "sha512-rS1VJFjyGKNHk8H97COnPIK+oeLnc0J9G0ES63o/Ky+WlJCeaFGiGCTGhV/GEVKua7ZWIV1JIDopYUwrfvTo7A==",
       "dev": true
     },
     "node_modules/abab": {
@@ -7377,17 +7356,6 @@
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
     },
-    "node_modules/yaml": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.6.0.tgz",
-      "integrity": "sha512-iZfse3lwrJRoSlfs/9KQ9iIXxs9++RvBFVzAqbbBiFT+giYtyanevreF9r61ZTbGMgWQBxAua3FzJiniiJXWWw==",
-      "dependencies": {
-        "@babel/runtime": "^7.4.5"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/yargs": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
@@ -7472,21 +7440,6 @@
         "chalk": "^2.0.0",
         "esutils": "^2.0.2",
         "js-tokens": "^3.0.0"
-      }
-    },
-    "@babel/runtime": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.5.tgz",
-      "integrity": "sha512-TuI4qpWZP6lGOGIuGWtp9sPluqYICmbk8T/1vpSysqJxRPkudh/ofFWyqdcMsDf2s7KvDL4/YHgKyvcS3g9CJQ==",
-      "requires": {
-        "regenerator-runtime": "^0.13.2"
-      },
-      "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.13.2",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
-          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
-        }
       }
     },
     "@cspotcode/source-map-support": {
@@ -7839,12 +7792,6 @@
       "version": "1.19.8",
       "resolved": "https://registry.npmjs.org/@types/urijs/-/urijs-1.19.8.tgz",
       "integrity": "sha512-SVQd2Qq0oL+b8VtJbQyv0cMIdU7fbRDcg2JIpcBvv+GUayJ3c5Ll1K+iivZl6ifcI6NbYcwjqDjljDFSiSGOeA==",
-      "dev": true
-    },
-    "@types/yaml": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@types/yaml/-/yaml-1.0.2.tgz",
-      "integrity": "sha512-rS1VJFjyGKNHk8H97COnPIK+oeLnc0J9G0ES63o/Ky+WlJCeaFGiGCTGhV/GEVKua7ZWIV1JIDopYUwrfvTo7A==",
       "dev": true
     },
     "abab": {
@@ -13510,14 +13457,6 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
-    },
-    "yaml": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.6.0.tgz",
-      "integrity": "sha512-iZfse3lwrJRoSlfs/9KQ9iIXxs9++RvBFVzAqbbBiFT+giYtyanevreF9r61ZTbGMgWQBxAua3FzJiniiJXWWw==",
-      "requires": {
-        "@babel/runtime": "^7.4.5"
-      }
     },
     "yargs": {
       "version": "11.1.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "urijs": "^1.19.11",
     "uuid": "^3.2.1",
     "wordwrap": "^1.0.0",
-    "yaml": "^1.5.0",
     "readable-stream": "2.3.0",
     "isomorphic-fetch": "^3.0.0",
     "browser-or-node": "^1.2.1"
@@ -50,7 +49,6 @@
     "@types/node": "8.10.10",
     "@types/shelljs": "^0.7.8",
     "@types/semver": "^5.5.0",
-    "@types/yaml": "^1.0.2",
     "ajv": "^5.5.2",
     "deep-equal": "^1.0.1",
     "exit": "^0.1.2",

--- a/src/quicktype-core/support/Support.ts
+++ b/src/quicktype-core/support/Support.ts
@@ -1,7 +1,6 @@
 import { Base64 } from "js-base64";
 import * as pako from "pako";
 import { messageError } from "../Messages";
-import * as YAML from "yaml";
 
 export type StringMap = { [name: string]: any };
 
@@ -111,7 +110,7 @@ export function parseJSON(text: string, description: string, address: string = "
         if (text.charCodeAt(0) === 0xfeff) {
             text = text.slice(1);
         }
-        return YAML.parse(text);
+        return JSON.parse(text);
     } catch (e) {
         let message: string;
 


### PR DESCRIPTION
For some reason, `YAML.parse` was being used instead of `JSON.parse`. Changing it seems to have no effect and we have security warnings about `YAML`.

@schani any idea why we were using `YAML`?