### PR TITLE
description is not a keyword in Swift

### DIFF
--- a/src/quicktype-core/language/Swift.ts
+++ b/src/quicktype-core/language/Swift.ts
@@ -207,7 +207,6 @@ const keywords = [
     "continue",
     "default",
     "defer",
-    "description",
     "do",
     "else",
     "fallthrough",


### PR DESCRIPTION
Fixes #1998