### PR TITLE
Add `noExtraProps` to typescript-input generator

### DIFF
--- a/src/quicktype-typescript-input/index.ts
+++ b/src/quicktype-typescript-input/index.ts
@@ -6,7 +6,8 @@ import { defined, JSONSchemaSourceData, messageError } from "../quicktype-core";
 const settings: PartialArgs = {
     required: true,
     titles: true,
-    topRef: true
+    topRef: true,
+    noExtraProps: true
 };
 
 const compilerOptions: ts.CompilerOptions = {


### PR DESCRIPTION
## The problem

Generating types from TypeScript and back into TypeScript does not behave as expected (this is admittedly a strange thing to do)

## Context

[`typescript-json-schema`](https://www.npmjs.com/package/@mark.probst/typescript-json-schema) has a setting called `noExtraProps`. 

Without it (as the code currently is in `master`), you will see the following behaviour:

```ts
// foo.ts
export type Foo = {
    bar: string
}
```

- `quicktype foo.ts -o out.ts`

```ts
// out.ts
export interface Foo {
    bar: string;
    [property: string]: any;
}
```

This makes sense to me in that it is technically correct, typescript interfaces/types are not _exact_ and you can provide additional properties. However this does not seem to necessarily be useful or wanted behaviour.

## Potential Fix

By adding `noExtraProps: true` to the `settings` in `quicktype-typescript-input/index.ts` the result turns into this:


With it (as in this PR) you get:
```ts
// out.ts
export interface Foo = {
    bar: string
}
```

Which matches the input (which is what I'd expect).

However, I appreciate this may have impact on other language generations and serialization stability (especially if languages error on unknown properties). So I suspect this PR should not be merged as is, and instead needs some modification to make this configurable through the CLI, or some other thoughts to be given to this. As it stands, I think Typescript inputs are pretty unpleasant to work with at the moment if they always allow additional properties.