### PR TITLE
Fix type error in TypeScript output

### DIFF
--- a/src/quicktype-core/language/JavaScript.ts
+++ b/src/quicktype-core/language/JavaScript.ts
@@ -447,7 +447,7 @@ function transform(val${anyAnnotation}, typ${anyAnnotation}, getProps${anyAnnota
         return invalidValue(typ, val, key, parent);
     }
     if (typ === false) return invalidValue(typ, val, key, parent);
-    let ref = undefined;
+    let ref${anyAnnotation} = undefined;
     while (typeof typ === "object" && typ.ref !== undefined) {
         ref = typ.ref;
         typ = typeMap[typ.ref];


### PR DESCRIPTION
TypeScript with `noImplicitAny` enabled will error and fail to compile on the `let ref` statement because its type cannot be inferred. By explicitly declaring `let ref: any` the error goes away.

The error TypeScript outputs, for the curious:

> Variable 'ref' implicitly has type 'any' in some locations where its type cannot be determined. ts(7034)

Probably for another PR, but the `ref` variable is used before it is declared, which is technically not valid because referencing a `let` binding before it has been initialized throws in JavaScript. A `var` binding would be okay as it becomes hoisted to the top of the scope with an `undefined` value. But perhaps the better fix would be to move the statement up.

<img width="656" alt="Screenshot 2023-01-10 at 21 20 36" src="https://user-images.githubusercontent.com/158591/211654555-756e5579-8376-434b-837e-b18f1beec557.png">
