### PR TITLE
QuickFix for #2091 and #2097

### DIFF
--- a/src/quicktype-core/language/CSharp.ts
+++ b/src/quicktype-core/language/CSharp.ts
@@ -173,7 +173,24 @@ export const cSharpOptions = {
         ],
         "double",
         "secondary"
-    )
+    ),
+    features: new EnumOption("features", "Output features", [
+        ["complete", { namespaces: true, helpers: true, attributes: true }],
+        ["attributes-only", { namespaces: true, helpers: false, attributes: true }],
+        ["just-types-and-namespace", { namespaces: true, helpers: false, attributes: false }],
+        ["just-types", { namespaces: true, helpers: false, attributes: false }]
+    ]),
+    baseclass: new EnumOption(
+        "base-class",
+        "Base class",
+        [
+            ["EntityData", "EntityData"],
+            ["Object", undefined]
+        ],
+        "Object",
+        "secondary"
+    ),
+    checkRequired: new BooleanOption("check-required", "Fail if required properties are missing", false)
 };
 
 export class CSharpTargetLanguage extends TargetLanguage {
@@ -190,7 +207,10 @@ export class CSharpTargetLanguage extends TargetLanguage {
             cSharpOptions.useList,
             cSharpOptions.useDecimal,
             cSharpOptions.typeForAny,
-            cSharpOptions.virtual
+            cSharpOptions.virtual,
+            cSharpOptions.features,
+            cSharpOptions.baseclass,
+            cSharpOptions.checkRequired,
         ];
     }
 
@@ -659,23 +679,7 @@ export class CSharpRenderer extends ConvenienceRenderer {
 }
 
 export const newtonsoftCSharpOptions = Object.assign({}, cSharpOptions, {
-    features: new EnumOption("features", "Output features", [
-        ["complete", { namespaces: true, helpers: true, attributes: true }],
-        ["attributes-only", { namespaces: true, helpers: false, attributes: true }],
-        ["just-types-and-namespace", { namespaces: true, helpers: false, attributes: false }],
-        ["just-types", { namespaces: true, helpers: false, attributes: false }]
-    ]),
-    baseclass: new EnumOption(
-        "base-class",
-        "Base class",
-        [
-            ["EntityData", "EntityData"],
-            ["Object", undefined]
-        ],
-        "Object",
-        "secondary"
-    ),
-    checkRequired: new BooleanOption("check-required", "Fail if required properties are missing", false)
+
 });
 
 export class NewtonsoftCSharpRenderer extends CSharpRenderer {
@@ -1404,23 +1408,7 @@ export class NewtonsoftCSharpRenderer extends CSharpRenderer {
 }
 
 export const systemTextJsonCSharpOptions = Object.assign({}, cSharpOptions, {
-    features: new EnumOption("features", "Output features", [
-        ["complete", { namespaces: true, helpers: true, attributes: true }],
-        ["attributes-only", { namespaces: true, helpers: false, attributes: true }],
-        ["just-types-and-namespace", { namespaces: true, helpers: false, attributes: false }],
-        ["just-types", { namespaces: true, helpers: false, attributes: false }]
-    ]),
-    baseclass: new EnumOption(
-        "base-class",
-        "Base class",
-        [
-            ["EntityData", "EntityData"],
-            ["Object", undefined]
-        ],
-        "Object",
-        "secondary"
-    ),
-    checkRequired: new BooleanOption("check-required", "Fail if required properties are missing", false)
+
 });
 
 export class SystemTextJsonCSharpRenderer extends CSharpRenderer {


### PR DESCRIPTION
The missing options where relegated to the classes newtonsoftCSharpOptions and systemTextJsonCSharpOptions. Yet for both they are exactly the same at the moment. Therefore the quickest way to restore the missing options for me was to merge them back to the base options class cSharpOptions.

Two points to consider.

* check required is accepted for system.text.json, but the code for it is commented out, thus not functional. This was the case in the code I based this on. Probably there was some problem with it. I would like to look into that, but I am pushing this anyway for those who need it to use. It should still work as before for newtonsoft json. That renderer was not changed.
* I need to look into how to advertise renderer specific options. The option where still there, but quicktype couldn't "see" them

Fixing above requires more time. As the PR name suggest these are quickfixes, and certainly not properly tested. I consider this PR an announcement and something that the "desperate" might use.
In a little more time I hope to remove both bullet points. 

edit 1: I have done a little more reading and functionality of Check-required does not exist in NET 5 and 6 and even 7 though it has a required property doesn't offer similar functionality. I will have to think on this, but I think I should find a way to declare that option a newtonsoft framework only. Which means me understanding how to do bullet point 2.