### PR TITLE
Quicktype C++ output now throws instances of std::runtime_error instead of const char*

### DIFF
--- a/packages/quicktype-core/src/language/CPlusPlus.ts
+++ b/packages/quicktype-core/src/language/CPlusPlus.ts
@@ -1845,7 +1845,7 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
                         onFirst = false;
                     });
                     // this.emitLine('else throw "Input JSON does not conform to schema";');
-                    this.emitLine('default: throw std::runtime_error("Input JSON does not conform to schema!");');
+                    this.emitLine('else { throw std::runtime_error("Input JSON does not conform to schema!"); }');
                 }
             }
         );

--- a/packages/quicktype-core/src/language/CPlusPlus.ts
+++ b/packages/quicktype-core/src/language/CPlusPlus.ts
@@ -1709,7 +1709,8 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
                     });
                     onFirst = false;
                 }
-                this.emitLine('else throw "Could not deserialize";');
+                // this.emitLine('else throw "Could not deserialize";');
+                this.emitLine('else throw std::runtime_error("Could not deserialise!");');
             }
         );
         this.ensureBlankLine();
@@ -1758,7 +1759,8 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
                         });
                         i++;
                     }
-                    this.emitLine('default: throw "Input JSON does not conform to schema";');
+                    // this.emitLine('default: throw "Input JSON does not conform to schema";');
+                    this.emitLine('default: throw std::runtime_error("Input JSON does not conform to schema!");');
                 });
             }
         );
@@ -1842,7 +1844,8 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
                         );
                         onFirst = false;
                     });
-                    this.emitLine('else throw "Input JSON does not conform to schema";');
+                    // this.emitLine('else throw "Input JSON does not conform to schema";');
+                    this.emitLine('default: throw std::runtime_error("Input JSON does not conform to schema!");');
                 }
             }
         );
@@ -1870,7 +1873,8 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
                             "; break;"
                         );
                     });
-                    this.emitLine('default: throw "This should not happen";');
+                    // this.emitLine('default: throw "This should not happen";');
+                    this.emitLine('default: throw std::runtime_error("This should not happen");')
                 });
             }
         );


### PR DESCRIPTION
As mentioned in my issue #2166, the current implementation of Quicktype's C++ code generator throws `const char*` as an exception type, instead of standard exception classes.

While technically legal, this is generally considered bad practice.

Instead, it is better to use well-known exception types instead of `const char*`.

# Things to note

 - This **will** break existing `catch` expressions in production code!
 - This uses the standard std::runtime_error class for throwing the exception