### PR TITLE
test: remove duplicated entry in 76ae1.json

### DIFF
--- a/test/inputs/json/misc/76ae1.json
+++ b/test/inputs/json/misc/76ae1.json
@@ -1662,10 +1662,6 @@
                     "description": "Short description of the category that the lead falls under",
                     "type": "string"
                 },
-                "topic": {
-                    "description": "Short description of the category that the lead falls under",
-                    "type": "string"
-                },
                 "url": {
                     "description": "URL that pertains to the bid.",
                     "type": "string"


### PR DESCRIPTION
As discussed at https://github.com/quicktype/quicktype/issues/2197, this PR remove a duplicated entry in a test file, that makes the json file invalid.