### PR TITLE
build(deps): Fix use of undeclared dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
             "dependencies": {
                 "@glideapps/ts-necessities": "^2.1.2",
                 "chalk": "^4.1.2",
+                "collection-utils": "^1.0.1",
                 "command-line-args": "^5.2.1",
                 "command-line-usage": "^7.0.1",
                 "cross-fetch": "^3.1.5",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "dependencies": {
         "@glideapps/ts-necessities": "^2.1.2",
         "chalk": "^4.1.2",
+        "collection-utils": "^1.0.1",
         "command-line-args": "^5.2.1",
         "command-line-usage": "^7.0.1",
         "cross-fetch": "^3.1.5",


### PR DESCRIPTION
`quicktype` package does not have dependency of `collection-utils`, but it uses the package in `index.ts` through implicit dependency of `quicktype-core`. This causes installation failure on Yarn Berry (v2 or later).

This pull request fixes the use of undeclared dependency by adding the `collection-utils` dep explicitly.