### PR TITLE
Fix RendererOptions type

### DIFF
--- a/packages/quicktype-core/src/Run.ts
+++ b/packages/quicktype-core/src/Run.ts
@@ -31,7 +31,7 @@ export function getTargetLanguage(nameOrInstance: string | TargetLanguage): Targ
     return messageError("DriverUnknownOutputLanguage", { lang: nameOrInstance });
 }
 
-export type RendererOptions = { [name: string]: string };
+export type RendererOptions = { [name: string]: string | boolean };
 
 export interface InferenceFlag {
     description: string;


### PR DESCRIPTION
There are many boolean language options that cause type checking errors:

![image](https://user-images.githubusercontent.com/5836790/234454813-4f768ec4-71e7-4554-8f5d-2f3e8caf69e5.png)

So I add `boolean` type to value.