### PR TITLE
feat(Go): Add support for custom tags generation

### DIFF
--- a/packages/quicktype-core/src/RendererOptions.ts
+++ b/packages/quicktype-core/src/RendererOptions.ts
@@ -142,6 +142,26 @@ export class StringOption extends Option<string> {
     }
 }
 
+export class StringsOption extends Option<string[]> {
+    constructor(
+        name: string,
+        description: string,
+        typeLabel: string,
+        defaultValue: string[],
+        kind: OptionKind = "primary"
+    ) {
+        const definition = {
+            name,
+            kind,
+            type: String,
+            description,
+            typeLabel,
+            defaultValue
+        };
+        super(definition);
+    }
+}
+
 export class EnumOption<T> extends Option<T> {
     private readonly _values: { [name: string]: T };
 

--- a/packages/quicktype-core/src/RendererOptions.ts
+++ b/packages/quicktype-core/src/RendererOptions.ts
@@ -142,26 +142,6 @@ export class StringOption extends Option<string> {
     }
 }
 
-export class StringsOption extends Option<string[]> {
-    constructor(
-        name: string,
-        description: string,
-        typeLabel: string,
-        defaultValue: string[],
-        kind: OptionKind = "primary"
-    ) {
-        const definition = {
-            name,
-            kind,
-            type: String,
-            description,
-            typeLabel,
-            defaultValue
-        };
-        super(definition);
-    }
-}
-
 export class EnumOption<T> extends Option<T> {
     private readonly _values: { [name: string]: T };
 

--- a/packages/quicktype-core/src/language/Golang.ts
+++ b/packages/quicktype-core/src/language/Golang.ts
@@ -13,7 +13,7 @@ import {
     camelCase
 } from "../support/Strings";
 import { assert, defined } from "../support/Support";
-import { StringOption, BooleanOption, StringsOption, Option, OptionValues, getOptionValues } from "../RendererOptions";
+import { StringOption, BooleanOption, Option, OptionValues, getOptionValues } from "../RendererOptions";
 import { Sourcelike, maybeAnnotated, modifySource } from "../Source";
 import { anyTypeIssueAnnotation, nullTypeIssueAnnotation } from "../Annotation";
 import { TargetLanguage } from "../TargetLanguage";
@@ -25,7 +25,7 @@ export const goOptions = {
     justTypesAndPackage: new BooleanOption("just-types-and-package", "Plain types with package only", false),
     packageName: new StringOption("package", "Generated package name", "NAME", "main"),
     multiFileOutput: new BooleanOption("multi-file-output", "Renders each top-level object in its own Go file", false),
-    fieldTags: new StringsOption("field-tags", "list of tags which should be generated for fields", "TAGS", ["json"])
+    fieldTags: new StringOption("field-tags", "list of tags which should be generated for fields", "TAGS", "json")
 };
 
 export class GoTargetLanguage extends TargetLanguage {
@@ -267,7 +267,7 @@ export class GoRenderer extends ConvenienceRenderer {
             const omitEmpty = canOmitEmpty(p) ? ",omitempty" : [];
 
             docStrings.forEach(doc => columns.push([doc]));
-            const tags = this._options.fieldTags.map(tag => tag + ':"' + stringEscape(jsonName)+ omitEmpty+ '"').join(", ")
+            const tags = this._options.fieldTags.split(",").map(tag => tag + ':"' + stringEscape(jsonName)+ omitEmpty+ '"').join(", ")
             columns.push([
                 [name, " "],
                 [goType, " "],

--- a/packages/quicktype-core/src/language/Golang.ts
+++ b/packages/quicktype-core/src/language/Golang.ts
@@ -267,7 +267,7 @@ export class GoRenderer extends ConvenienceRenderer {
             const omitEmpty = canOmitEmpty(p) ? ",omitempty" : [];
 
             docStrings.forEach(doc => columns.push([doc]));
-            const tags = this._options.fieldTags.split(",").map(tag => tag + ':"' + stringEscape(jsonName)+ omitEmpty+ '"').join(", ")
+            const tags = this._options.fieldTags.split(",").map(tag => tag + ':"' + stringEscape(jsonName)+ omitEmpty+ '"').join(" ")
             columns.push([
                 [name, " "],
                 [goType, " "],

--- a/packages/quicktype-core/src/language/Golang.ts
+++ b/packages/quicktype-core/src/language/Golang.ts
@@ -271,7 +271,7 @@ export class GoRenderer extends ConvenienceRenderer {
             columns.push([
                 [name, " "],
                 [goType, " "],
-                [tags]
+                ["`", tags, "`"]
             ]);
         });
         this.emitDescription(this.descriptionForType(c));

--- a/packages/quicktype-core/src/language/Golang.ts
+++ b/packages/quicktype-core/src/language/Golang.ts
@@ -34,7 +34,13 @@ export class GoTargetLanguage extends TargetLanguage {
     }
 
     protected getOptions(): Option<any>[] {
-        return [goOptions.justTypes, goOptions.packageName, goOptions.multiFileOutput, goOptions.justTypesAndPackage, goOptions.fieldTags];
+        return [
+            goOptions.justTypes,
+            goOptions.packageName,
+            goOptions.multiFileOutput,
+            goOptions.justTypesAndPackage,
+            goOptions.fieldTags
+        ];
     }
 
     get supportsUnionsWithBothNumberTypes(): boolean {
@@ -267,7 +273,10 @@ export class GoRenderer extends ConvenienceRenderer {
             const omitEmpty = canOmitEmpty(p) ? ",omitempty" : [];
 
             docStrings.forEach(doc => columns.push([doc]));
-            const tags = this._options.fieldTags.split(",").map(tag => tag + ':"' + stringEscape(jsonName)+ omitEmpty+ '"').join(" ")
+            const tags = this._options.fieldTags
+                .split(",")
+                .map(tag => tag + ':"' + stringEscape(jsonName) + omitEmpty + '"')
+                .join(" ");
             columns.push([
                 [name, " "],
                 [goType, " "],

--- a/packages/quicktype-core/src/language/Golang.ts
+++ b/packages/quicktype-core/src/language/Golang.ts
@@ -267,7 +267,7 @@ export class GoRenderer extends ConvenienceRenderer {
             const omitEmpty = canOmitEmpty(p) ? ",omitempty" : [];
 
             docStrings.forEach(doc => columns.push([doc]));
-            const tags = this._options.fieldTags.map(tag => tag + ':"' + stringEscape(jsonName)+ omitEmpty+ '"').join(" ,")
+            const tags = this._options.fieldTags.map(tag => tag + ':"' + stringEscape(jsonName)+ omitEmpty+ '"').join(", ")
             columns.push([
                 [name, " "],
                 [goType, " "],


### PR DESCRIPTION
This PR add support for generation field tags requested in issue #2204 

example 
```bash
quicktype -l go -s schema --just-types-and-package --multi-file-output --field-tags='json,bson' -t Example --src input.json -o output.go
```

example output
```golang
package main

type Example struct {
	Field1 string `json:"field1" bson:"field1"`
	Field2  int   `json:"field2" bson:"field2"`          
}

```