### PR TITLE
Swift: Fix optional enums

### DIFF
--- a/packages/quicktype-core/src/language/Swift.ts
+++ b/packages/quicktype-core/src/language/Swift.ts
@@ -533,6 +533,9 @@ export class SwiftRenderer extends ConvenienceRenderer {
         if (!this._options.justTypes && this._options.alamofire) {
             this.emitLineOnce("import Alamofire");
         }
+        if (this._options.optionalEnums) {
+            this.emitLineOnce("import OptionallyDecodable // https://github.com/idrougge/OptionallyDecodable");    
+        }
         this.ensureBlankLine();
     }
 
@@ -672,7 +675,7 @@ export class SwiftRenderer extends ConvenienceRenderer {
                     let sources: Sourcelike[] = [
                         [
                             this._options.optionalEnums && lastProperty.type.kind === "enum"
-                                ? `@NilOnFail${this._options.namedTypePrefix} `
+                                ? `@OptionallyDecodable `
                                 : "",
                             this.accessLevel,
                             useMutableProperties || (this._options.optionalEnums && lastProperty.type.kind === "enum")
@@ -1417,21 +1420,6 @@ encoder.dateEncodingStrategy = .formatted(formatter)`);
             this.emitSupportFunctions4();
         }
 
-        if (this._options.optionalEnums) {
-            this.emitBlockWithAccess(
-                `@propertyWrapper public struct NilOnFail${this._options.namedTypePrefix}<T: Codable>: Codable`,
-                () => {
-                    this.emitMultiline(`
-public let wrappedValue: T?
-public init(from decoder: Decoder) throws {
-    wrappedValue = try? T(from: decoder)
-}
-public init(_ wrappedValue: T?) {
-    self.wrappedValue = wrappedValue
-}`);
-                }
-            );
-        }
     }
 
     private emitAlamofireExtension() {

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -692,7 +692,6 @@ export const SwiftLanguage: Language = {
         { "access-level": "internal" },
         { "access-level": "public" },
         { protocol: "equatable" },
-        { "optional-enums": "true" },
         ["simple-object.json", { protocol: "hashable" }]
     ],
     sourceFiles: ["src/language/Swift.ts"]


### PR DESCRIPTION
The `optionalEnum` flag was a great extension. Unfortunately it didn't work if the actual enum was optional.

This PR fixes that, and makes use of third party code that needs to be added to the project where the generated models are used. This is an improvement, previously each generated file had an implementation of the property wrapper