### PR TITLE
fix(Golang): fix output file names case sensitivity (unnecessary lowercasing filename characters)

### DIFF
--- a/packages/quicktype-core/src/language/Golang.ts
+++ b/packages/quicktype-core/src/language/Golang.ts
@@ -134,8 +134,7 @@ export class GoRenderer extends ConvenienceRenderer {
         }
 
         assert(this._currentFilename === undefined, "Previous file wasn't finished: " + this._currentFilename);
-        // FIXME: The filenames should actually be Sourcelikes, too
-        this._currentFilename = `${this.sourcelikeToString(basename)}.go`.toLowerCase();
+        this._currentFilename = `${this.sourcelikeToString(basename)}.go`;
         this.initializeEmitContextForFilename(this._currentFilename);
     }
 


### PR DESCRIPTION
PR fixes a bug that generates files with lowercase names instead of keeping the original naming convention.