### PR TITLE
Swift: Add option sendable

### DIFF
--- a/packages/quicktype-core/src/language/Swift.ts
+++ b/packages/quicktype-core/src/language/Swift.ts
@@ -75,6 +75,7 @@ export const swiftOptions = {
     ),
     optionalEnums: new BooleanOption("optional-enums", "If no matching case is found enum value is set to null", false),
     swift5Support: new BooleanOption("swift-5-support", "Renders output in a Swift 5 compatible mode", false),
+    sendable: new BooleanOption("sendable", "Mark generated models as Sendable", false),
     multiFileOutput: new BooleanOption(
         "multi-file-output",
         "Renders each top-level object in its own Swift file",
@@ -149,6 +150,7 @@ export class SwiftTargetLanguage extends TargetLanguage {
             swiftOptions.acronymStyle,
             swiftOptions.objcSupport,
             swiftOptions.optionalEnums,
+            swiftOptions.sendable,
             swiftOptions.swift5Support,
             swiftOptions.multiFileOutput,
             swiftOptions.mutableProperties
@@ -169,7 +171,7 @@ export class SwiftTargetLanguage extends TargetLanguage {
         return true;
     }
 
-    protected makeRenderer(renderContext: RenderContext, untypedOptionValues: { [name: string]: any }): SwiftRenderer {
+    protected makeRenderer(renderContext: RenderContext, untypedOptionValues: { [name: string]: any; }): SwiftRenderer {
         return new SwiftRenderer(this, renderContext, getOptionValues(swiftOptions, untypedOptionValues));
     }
 
@@ -559,6 +561,11 @@ export class SwiftRenderer extends ConvenienceRenderer {
         if (this._options.protocol.equatable) {
             protocols.push("Equatable");
         }
+
+        if (this._options.sendable && !this._options.mutableProperties) {
+            protocols.push("Sendable");
+        }
+
         return protocols;
     }
 
@@ -568,7 +575,7 @@ export class SwiftRenderer extends ConvenienceRenderer {
     }
 
     private getEnumPropertyGroups(c: ClassType) {
-        type PropertyGroup = { name: Name; label?: string }[];
+        type PropertyGroup = { name: Name; label?: string; }[];
 
         let groups: PropertyGroup[] = [];
         let group: PropertyGroup = [];

--- a/packages/quicktype-core/src/language/Swift.ts
+++ b/packages/quicktype-core/src/language/Swift.ts
@@ -542,12 +542,19 @@ export class SwiftRenderer extends ConvenienceRenderer {
         this.emitLine(this.accessLevel, "typealias ", name, " = ", this.swiftType(t, true));
     }
 
-    protected getProtocolsArray(_t: Type, isClass: boolean): string[] {
+    protected getProtocolsArray(kind: "struct" | "class" | "enum"): string[] {
         const protocols: string[] = [];
 
         // [Michael Fey (@MrRooni), 2019-4-24] Technically NSObject isn't a "protocol" in this instance, but this felt like the best place to slot in this superclass declaration.
+        const isClass = kind === "class";
+        const isEnum = kind === "enum";
+
         if (isClass && this._options.objcSupport) {
             protocols.push("NSObject");
+        }
+
+        if (isEnum) {
+            protocols.push("String");
         }
 
         if (!this._options.justTypes) {
@@ -562,15 +569,15 @@ export class SwiftRenderer extends ConvenienceRenderer {
             protocols.push("Equatable");
         }
 
-        if (this._options.sendable && !this._options.mutableProperties) {
+        if (this._options.sendable && !this._options.mutableProperties && !this._options.objcSupport) {
             protocols.push("Sendable");
         }
 
         return protocols;
     }
 
-    private getProtocolString(_t: Type, isClass: boolean): Sourcelike {
-        const protocols = this.getProtocolsArray(_t, isClass);
+    private getProtocolString(kind: "struct" | "class" | "enum"): Sourcelike {
+        const protocols = this.getProtocolsArray(kind);
         return protocols.length > 0 ? ": " + protocols.join(", ") : "";
     }
 
@@ -666,7 +673,7 @@ export class SwiftRenderer extends ConvenienceRenderer {
             this.emitItem(this.objcMembersDeclaration);
         }
 
-        this.emitBlockWithAccess([structOrClass, " ", className, this.getProtocolString(c, isClass)], () => {
+        this.emitBlockWithAccess([structOrClass, " ", className, this.getProtocolString(structOrClass)], () => {
             if (this._options.dense) {
                 let lastProperty: ClassProperty | undefined = undefined;
                 let lastNames: Name[] = [];
@@ -913,22 +920,7 @@ encoder.dateEncodingStrategy = .formatted(formatter)`);
         this.ensureBlankLine();
 
         this.emitDescription(this.descriptionForType(e));
-
-        const protocols: string[] = [];
-        if (!this._options.justTypes) {
-            protocols.push("String"); // Not a protocol
-            protocols.push("Codable");
-        }
-
-        if (this._options.protocol.hashable) {
-            protocols.push("Hashable");
-        }
-
-        if (this._options.protocol.equatable) {
-            protocols.push("Equatable");
-        }
-
-        const protocolString = protocols.length > 0 ? ": " + protocols.join(", ") : "";
+        const protocolString = this.getProtocolString("enum");
 
         if (this._options.justTypes) {
             this.emitBlockWithAccess(["enum ", enumName, protocolString], () => {
@@ -970,7 +962,7 @@ encoder.dateEncodingStrategy = .formatted(formatter)`);
 
         const indirect = this.isCycleBreakerType(u) ? "indirect " : "";
         const [maybeNull, nonNulls] = removeNullFromUnion(u, sortBy);
-        this.emitBlockWithAccess([indirect, "enum ", unionName, this.getProtocolString(u, false)], () => {
+        this.emitBlockWithAccess([indirect, "enum ", unionName, this.getProtocolString("enum")], () => {
             this.forEachUnionMember(u, nonNulls, "none", null, (name, t) => {
                 this.emitLine("case ", name, "(", this.swiftType(t), ")");
             });

--- a/test/fixtures/swift/quicktype.swift
+++ b/test/fixtures/swift/quicktype.swift
@@ -2,7 +2,7 @@
 // To parse the JSON, add this file to your project and do:
 //
 //   guard let topLevel = try TopLevel(json) else { ... }
-
+// Hej
 import Foundation
 
 class TopLevel: Codable {


### PR DESCRIPTION
Generate structs with `Sendable` conformance for upcoming concurrency in Swift.