### PR TITLE
fix(Golang): fix enums generation

### DIFF
--- a/packages/quicktype-core/src/language/Golang.ts
+++ b/packages/quicktype-core/src/language/Golang.ts
@@ -292,12 +292,16 @@ export class GoRenderer extends ConvenienceRenderer {
         this.emitPackageDefinitons(false);
         this.emitDescription(this.descriptionForType(e));
         this.emitLine("type ", enumName, " string");
+        this.ensureBlankLine();
         this.emitLine("const (");
-        this.indent(() =>
-            this.forEachEnumCase(e, "none", (name, jsonName) => {
-                this.emitLine(name, " ", enumName, ' = "', stringEscape(jsonName), '"');
-            })
-        );
+        let columns: Sourcelike[][] = [];
+        this.forEachEnumCase(e, "none", (name, jsonName) => {
+            columns.push([
+                [name, " "],
+                [enumName, ' = "', stringEscape(jsonName), '"']
+            ]);
+        });
+        this.indent(() => this.emitTable(columns));
         this.emitLine(")");
         this.endFile();
     }


### PR DESCRIPTION
This PR fix golang enums generation requested in issue #1205 
Fix is only enum values type positioning (whitespaces change only).

## Before
```go
package schema

type Gender string
const (
	Female Gender = "female"
	Male Gender = "male"
)
```

## After
```go
package schema

type Gender string

const (
	Female Gender = "female"
	Male   Gender = "male"
)
```