### PR TITLE
feat: add typescript-effect-schema language

### DIFF
--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -19,7 +19,7 @@ jobs:
 
             matrix:
                 fixture:
-                    - typescript,typescript-zod
+                    - typescript,typescript-zod,typescript-effect-schema
                     - javascript,schema-javascript
                     - golang,schema-golang
                     - cjson,schema-cjson
@@ -169,7 +169,7 @@ jobs:
               run: |
                   sudo apt-get update
                   sudo apt-get -y install libboost-all-dev software-properties-common g++ --assume-yes
-            
+
             - name: Install scala
               if: ${{ contains(matrix.fixture, 'scala3') }}
               uses: VirtusLab/scala-cli-setup@main

--- a/packages/quicktype-core/src/language/All.ts
+++ b/packages/quicktype-core/src/language/All.ts
@@ -26,7 +26,7 @@ import { PikeTargetLanguage } from "./Pike";
 import { HaskellTargetLanguage } from "./Haskell";
 import { TypeScriptZodTargetLanguage } from "./TypeScriptZod";
 import { PhpTargetLanguage } from "./Php";
-
+import { TypeScriptEffectSchemaTargetLanguage } from "./TypeScriptEffectSchema";
 
 export const all: TargetLanguage[] = [
     new CSharpTargetLanguage(),
@@ -53,6 +53,7 @@ export const all: TargetLanguage[] = [
     new PikeTargetLanguage(),
     new HaskellTargetLanguage(),
     new TypeScriptZodTargetLanguage(),
+    new TypeScriptEffectSchemaTargetLanguage(),
     new PhpTargetLanguage()
 ];
 

--- a/packages/quicktype-core/src/language/TypeScriptEffectSchema.ts
+++ b/packages/quicktype-core/src/language/TypeScriptEffectSchema.ts
@@ -1,0 +1,229 @@
+import { arrayIntercalate } from "collection-utils";
+import { ClassProperty, EnumType, ObjectType, Type } from "../Type";
+import { matchType } from "../TypeUtils";
+import { funPrefixNamer, Name, Namer } from "../Naming";
+import { RenderContext } from "../Renderer";
+import { BooleanOption, getOptionValues, Option, OptionValues } from "../RendererOptions";
+import { acronymStyle, AcronymStyleOptions } from "../support/Acronyms";
+import {
+    allLowerWordStyle,
+    capitalize,
+    combineWords,
+    firstUpperWordStyle,
+    isLetterOrUnderscore,
+    splitIntoWords,
+    stringEscape,
+    utf16StringEscape
+} from "../support/Strings";
+import { TargetLanguage } from "../TargetLanguage";
+import { legalizeName } from "./JavaScript";
+import { Sourcelike } from "../Source";
+import { panic } from "../support/Support";
+import { ConvenienceRenderer } from "../ConvenienceRenderer";
+
+export const typeScriptEffectSchemaOptions = {
+    justSchema: new BooleanOption("just-schema", "Schema only", false)
+};
+
+export class TypeScriptEffectSchemaTargetLanguage extends TargetLanguage {
+    protected getOptions(): Option<any>[] {
+        return [];
+    }
+
+    constructor(
+        displayName: string = "TypeScript Effect Schema",
+        names: string[] = ["typescript-effect-schema"],
+        extension: string = "ts"
+    ) {
+        super(displayName, names, extension);
+    }
+
+    protected makeRenderer(
+        renderContext: RenderContext,
+        untypedOptionValues: { [name: string]: any }
+    ): TypeScriptEffectSchemaRenderer {
+        return new TypeScriptEffectSchemaRenderer(
+            this,
+            renderContext,
+            getOptionValues(typeScriptEffectSchemaOptions, untypedOptionValues)
+        );
+    }
+}
+
+export class TypeScriptEffectSchemaRenderer extends ConvenienceRenderer {
+    constructor(
+        targetLanguage: TargetLanguage,
+        renderContext: RenderContext,
+        private readonly _options: OptionValues<typeof typeScriptEffectSchemaOptions>
+    ) {
+        super(targetLanguage, renderContext);
+    }
+
+    protected forbiddenNamesForGlobalNamespace(): string[] {
+        return ["Class", "Date", "Object", "String", "Array", "JSON", "Error"];
+    }
+
+    protected nameStyle(original: string, upper: boolean): string {
+        const acronyms = acronymStyle(AcronymStyleOptions.Camel);
+        const words = splitIntoWords(original);
+        return combineWords(
+            words,
+            legalizeName,
+            upper ? firstUpperWordStyle : allLowerWordStyle,
+            firstUpperWordStyle,
+            upper ? s => capitalize(acronyms(s)) : allLowerWordStyle,
+            acronyms,
+            "",
+            isLetterOrUnderscore
+        );
+    }
+
+    protected makeNamedTypeNamer(): Namer {
+        return funPrefixNamer("types", s => this.nameStyle(s, true));
+    }
+
+    protected makeUnionMemberNamer(): Namer {
+        return funPrefixNamer("properties", s => this.nameStyle(s, true));
+    }
+
+    protected namerForObjectProperty(): Namer {
+        return funPrefixNamer("properties", s => this.nameStyle(s, true));
+    }
+
+    protected makeEnumCaseNamer(): Namer {
+        return funPrefixNamer("enum-cases", s => this.nameStyle(s, false));
+    }
+
+    private importStatement(lhs: Sourcelike, moduleName: Sourcelike): Sourcelike {
+        return ["import ", lhs, " from ", moduleName, ";"];
+    }
+
+    protected emitImports(): void {
+        this.ensureBlankLine();
+        this.emitLine(this.importStatement("* as Schema", '"@effect/schema/Schema"'));
+    }
+
+    typeMapTypeForProperty(p: ClassProperty): Sourcelike {
+        const typeMap = this.typeMapTypeFor(p.type);
+        return p.isOptional ? ["Schema.optional(", typeMap, ")"] : typeMap;
+    }
+
+    typeMapTypeFor(t: Type, required: boolean = true): Sourcelike {
+        if (["class", "object", "enum"].indexOf(t.kind) >= 0) {
+            return ["Schema.lazy(() => ", this.nameForNamedType(t), "Schema)"];
+        }
+
+        const match = matchType<Sourcelike>(
+            t,
+            _anyType => "Schema.any",
+            _nullType => "Schema.null",
+            _boolType => "Schema.boolean",
+            _integerType => "Schema.number",
+            _doubleType => "Schema.number",
+            _stringType => "Schema.string",
+            arrayType => ["Schema.array(", this.typeMapTypeFor(arrayType.items, false), ")"],
+            _classType => panic("Should already be handled."),
+            _mapType => ["Schema.record(Schema.string, ", this.typeMapTypeFor(_mapType.values, false), ")"],
+            _enumType => panic("Should already be handled."),
+            unionType => {
+                const children = Array.from(unionType.getChildren()).map((type: Type) =>
+                    this.typeMapTypeFor(type, false)
+                );
+                return ["Schema.union(", ...arrayIntercalate(", ", children), ")"];
+            },
+            _transformedStringType => {
+                return "Schema.string";
+            }
+        );
+
+        if (required) {
+            return [match];
+        }
+
+        return match;
+    }
+
+    private emitObject(name: Name, t: ObjectType) {
+        this.ensureBlankLine();
+        this.emitLine("\nexport const ", name, "Schema = ", "Schema.struct({");
+        this.indent(() => {
+            this.forEachClassProperty(t, "none", (_, jsonName, property) => {
+                this.emitLine(`"${utf16StringEscape(jsonName)}"`, ": ", this.typeMapTypeForProperty(property), ",");
+            });
+        });
+        this.emitLine("});");
+        if (!this._options.justSchema) {
+            this.emitLine("export type ", name, " = Schema.From<typeof ", name, "Schema>;");
+        }
+    }
+
+    private emitEnum(e: EnumType, enumName: Name): void {
+        this.ensureBlankLine();
+        this.emitDescription(this.descriptionForType(e));
+        this.emitLine("\nexport const ", enumName, "Schema = ", "Schema.enums({");
+        this.indent(() =>
+            this.forEachEnumCase(e, "none", (_, jsonName) => {
+                const name = stringEscape(jsonName);
+                this.emitLine('"', name, '": "', name, '",');
+            })
+        );
+        this.emitLine("});");
+        if (!this._options.justSchema) {
+            this.emitLine("export type ", enumName, " = Schema.From<typeof ", enumName, "Schema>;");
+        }
+    }
+
+    protected emitSchemas(): void {
+        this.ensureBlankLine();
+
+        this.forEachEnum("leading-and-interposing", (u: EnumType, enumName: Name) => {
+            this.emitEnum(u, enumName);
+        });
+
+        const order: number[] = [];
+        const mapKey: Name[] = [];
+        const mapValue: Sourcelike[][] = [];
+        this.forEachObject("none", (type: ObjectType, name: Name) => {
+            mapKey.push(name);
+            mapValue.push(this.gatherSource(() => this.emitObject(name, type)));
+        });
+
+        mapKey.forEach((_, index) => {
+            // assume first
+            let ordinal = 0;
+
+            // pull out all names
+            const source = mapValue[index];
+            const names = source.filter(value => value as Name);
+
+            // must be behind all these names
+            for (let i = 0; i < names.length; i++) {
+                const depName = names[i];
+
+                // find this name's ordinal, if it has already been added
+                for (let j = 0; j < order.length; j++) {
+                    const depIndex = order[j];
+                    if (mapKey[depIndex] === depName) {
+                        // this is the index of the dependency, so make sure we come after it
+                        ordinal = Math.max(ordinal, depIndex + 1);
+                    }
+                }
+            }
+
+            // insert index
+            order.splice(ordinal, 0, index);
+        });
+
+        // now emit ordered source
+        order.forEach(i => this.emitGatheredSource(mapValue[i]));
+    }
+
+    protected emitSourceStructure(): void {
+        if (this.leadingComments !== undefined) {
+            this.emitCommentLines(this.leadingComments);
+        }
+
+        this.emitImports();
+        this.emitSchemas();
+    }
+}

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -812,6 +812,7 @@ export const allFixtures: Fixture[] = [
     new JSONFixture(languages.ObjectiveCLanguage),
     new JSONFixture(languages.TypeScriptLanguage),
     new JSONFixture(languages.TypeScriptZodLanguage),
+    new JSONFixture(languages.TypeScriptEffectSchemaLanguage),
     new JSONFixture(languages.FlowLanguage),
     new JSONFixture(languages.JavaScriptLanguage),
     new JSONFixture(languages.KotlinLanguage),

--- a/test/fixtures/typescript-effect-schema/main.ts
+++ b/test/fixtures/typescript-effect-schema/main.ts
@@ -1,0 +1,36 @@
+import * as TopLevel from "./TopLevel";
+import fs from "fs";
+import process from "process";
+import * as Schema from "@effect/schema/Schema";
+
+const sample = process.argv[2];
+const json = fs.readFileSync(sample);
+
+const value = JSON.parse(json.toString());
+let schema = TopLevel.TopLevelSchema ?? TopLevel.TopLevelElementSchema;
+if (!schema) {
+    // Sometimes key is prefixed with funPrefixes (e.g. 2df80.json)
+    Object.keys(TopLevel).some(key => {
+        if (key.endsWith("TopLevelSchema") || key.endsWith("TopLevelElementSchema")) {
+            schema = TopLevel[key];
+            return true;
+        }
+    });
+}
+
+if (!schema) {
+    throw new Error("No schema found");
+}
+
+let backToJson: string;
+if (Array.isArray(value)) {
+    const parsedValue = value.map(v => {
+        return Schema.parse(schema)(v);
+    });
+    backToJson = JSON.stringify(parsedValue, null, 2);
+} else {
+    const parsedValue = Schema.parse(schema)(value);
+    backToJson = JSON.stringify(parsedValue, null, 2);
+}
+
+console.log(backToJson);

--- a/test/fixtures/typescript-effect-schema/package-lock.json
+++ b/test/fixtures/typescript-effect-schema/package-lock.json
@@ -1,0 +1,881 @@
+{
+    "name": "typescript-effect-schema",
+    "version": "0.1.0",
+    "lockfileVersion": 2,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "typescript-effect-schema",
+            "version": "0.1.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@effect/schema": "^0.21.1"
+            },
+            "devDependencies": {
+                "tsx": "^3.12.2",
+                "typescript": "^4.3.5"
+            }
+        },
+        "node_modules/@effect/data": {
+            "version": "0.12.10",
+            "resolved": "https://registry.npmjs.org/@effect/data/-/data-0.12.10.tgz",
+            "integrity": "sha512-zIz/DgumH2LgGdr1Wc9ChET5JSG0k/G5kDc8rn4a6yIJ0v2d5rfnbRWIJO2fWmdFvc+128JyaBvYguIyz9JaAQ=="
+        },
+        "node_modules/@effect/io": {
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@effect/io/-/io-0.27.2.tgz",
+            "integrity": "sha512-J9s+v2JyGUKzxG5I6v1/X5v+I/e9dST4Afk3y6ZYBEXzU3Slo+3ZDf7XlazicS7koAoTEnvJ6zt79aM4LLkoWA==",
+            "dependencies": {
+                "@effect/data": "~0.12.6"
+            }
+        },
+        "node_modules/@effect/schema": {
+            "version": "0.21.1",
+            "resolved": "https://registry.npmjs.org/@effect/schema/-/schema-0.21.1.tgz",
+            "integrity": "sha512-ZKxrkOPFo158lw21di+cxcGc7XnvnhQ334hAlXYP4DMEAAmp4bVVuPuDSjVYLLVkg1y3bdYyVqfT7+v1ZfpJNg==",
+            "dependencies": {
+                "@effect/data": "^0.12.9",
+                "@effect/io": "^0.27.0",
+                "fast-check": "^3.10.0"
+            }
+        },
+        "node_modules/@esbuild-kit/cjs-loader": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/@esbuild-kit/cjs-loader/-/cjs-loader-2.4.1.tgz",
+            "integrity": "sha512-lhc/XLith28QdW0HpHZvZKkorWgmCNT7sVelMHDj3HFdTfdqkwEKvT+aXVQtNAmCC39VJhunDkWhONWB7335mg==",
+            "dev": true,
+            "dependencies": {
+                "@esbuild-kit/core-utils": "^3.0.0",
+                "get-tsconfig": "^4.2.0"
+            }
+        },
+        "node_modules/@esbuild-kit/core-utils": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@esbuild-kit/core-utils/-/core-utils-3.0.0.tgz",
+            "integrity": "sha512-TXmwH9EFS3DC2sI2YJWJBgHGhlteK0Xyu1VabwetMULfm3oYhbrsWV5yaSr2NTWZIgDGVLHbRf0inxbjXqAcmQ==",
+            "dev": true,
+            "dependencies": {
+                "esbuild": "~0.15.10",
+                "source-map-support": "^0.5.21"
+            }
+        },
+        "node_modules/@esbuild-kit/esm-loader": {
+            "version": "2.5.4",
+            "resolved": "https://registry.npmjs.org/@esbuild-kit/esm-loader/-/esm-loader-2.5.4.tgz",
+            "integrity": "sha512-afmtLf6uqxD5IgwCzomtqCYIgz/sjHzCWZFvfS5+FzeYxOURPUo4QcHtqJxbxWOMOogKriZanN/1bJQE/ZL93A==",
+            "dev": true,
+            "dependencies": {
+                "@esbuild-kit/core-utils": "^3.0.0",
+                "get-tsconfig": "^4.2.0"
+            }
+        },
+        "node_modules/@esbuild/android-arm": {
+            "version": "0.15.18",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.18.tgz",
+            "integrity": "sha512-5GT+kcs2WVGjVs7+boataCkO5Fg0y4kCjzkB5bAip7H4jfnOS3dA6KPiww9W1OEKTKeAcUVhdZGvgI65OXmUnw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-loong64": {
+            "version": "0.15.18",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.18.tgz",
+            "integrity": "sha512-L4jVKS82XVhw2nvzLg/19ClLWg0y27ulRwuP7lcyL6AbUWB5aPglXY3M21mauDQMDfRLs8cQmeT03r/+X3cZYQ==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/buffer-from": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+            "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+            "dev": true
+        },
+        "node_modules/esbuild": {
+            "version": "0.15.18",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.18.tgz",
+            "integrity": "sha512-x/R72SmW3sSFRm5zrrIjAhCeQSAWoni3CmHEqfQrZIQTM3lVCdehdwuIqaOtfC2slvpdlLa62GYoN8SxT23m6Q==",
+            "dev": true,
+            "hasInstallScript": true,
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "optionalDependencies": {
+                "@esbuild/android-arm": "0.15.18",
+                "@esbuild/linux-loong64": "0.15.18",
+                "esbuild-android-64": "0.15.18",
+                "esbuild-android-arm64": "0.15.18",
+                "esbuild-darwin-64": "0.15.18",
+                "esbuild-darwin-arm64": "0.15.18",
+                "esbuild-freebsd-64": "0.15.18",
+                "esbuild-freebsd-arm64": "0.15.18",
+                "esbuild-linux-32": "0.15.18",
+                "esbuild-linux-64": "0.15.18",
+                "esbuild-linux-arm": "0.15.18",
+                "esbuild-linux-arm64": "0.15.18",
+                "esbuild-linux-mips64le": "0.15.18",
+                "esbuild-linux-ppc64le": "0.15.18",
+                "esbuild-linux-riscv64": "0.15.18",
+                "esbuild-linux-s390x": "0.15.18",
+                "esbuild-netbsd-64": "0.15.18",
+                "esbuild-openbsd-64": "0.15.18",
+                "esbuild-sunos-64": "0.15.18",
+                "esbuild-windows-32": "0.15.18",
+                "esbuild-windows-64": "0.15.18",
+                "esbuild-windows-arm64": "0.15.18"
+            }
+        },
+        "node_modules/esbuild-android-64": {
+            "version": "0.15.18",
+            "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.18.tgz",
+            "integrity": "sha512-wnpt3OXRhcjfIDSZu9bnzT4/TNTDsOUvip0foZOUBG7QbSt//w3QV4FInVJxNhKc/ErhUxc5z4QjHtMi7/TbgA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-android-arm64": {
+            "version": "0.15.18",
+            "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.18.tgz",
+            "integrity": "sha512-G4xu89B8FCzav9XU8EjsXacCKSG2FT7wW9J6hOc18soEHJdtWu03L3TQDGf0geNxfLTtxENKBzMSq9LlbjS8OQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-darwin-64": {
+            "version": "0.15.18",
+            "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.18.tgz",
+            "integrity": "sha512-2WAvs95uPnVJPuYKP0Eqx+Dl/jaYseZEUUT1sjg97TJa4oBtbAKnPnl3b5M9l51/nbx7+QAEtuummJZW0sBEmg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-darwin-arm64": {
+            "version": "0.15.18",
+            "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.18.tgz",
+            "integrity": "sha512-tKPSxcTJ5OmNb1btVikATJ8NftlyNlc8BVNtyT/UAr62JFOhwHlnoPrhYWz09akBLHI9nElFVfWSTSRsrZiDUA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-freebsd-64": {
+            "version": "0.15.18",
+            "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.18.tgz",
+            "integrity": "sha512-TT3uBUxkteAjR1QbsmvSsjpKjOX6UkCstr8nMr+q7zi3NuZ1oIpa8U41Y8I8dJH2fJgdC3Dj3CXO5biLQpfdZA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-freebsd-arm64": {
+            "version": "0.15.18",
+            "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.18.tgz",
+            "integrity": "sha512-R/oVr+X3Tkh+S0+tL41wRMbdWtpWB8hEAMsOXDumSSa6qJR89U0S/PpLXrGF7Wk/JykfpWNokERUpCeHDl47wA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-linux-32": {
+            "version": "0.15.18",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.18.tgz",
+            "integrity": "sha512-lphF3HiCSYtaa9p1DtXndiQEeQDKPl9eN/XNoBf2amEghugNuqXNZA/ZovthNE2aa4EN43WroO0B85xVSjYkbg==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-linux-64": {
+            "version": "0.15.18",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.18.tgz",
+            "integrity": "sha512-hNSeP97IviD7oxLKFuii5sDPJ+QHeiFTFLoLm7NZQligur8poNOWGIgpQ7Qf8Balb69hptMZzyOBIPtY09GZYw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-linux-arm": {
+            "version": "0.15.18",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.18.tgz",
+            "integrity": "sha512-UH779gstRblS4aoS2qpMl3wjg7U0j+ygu3GjIeTonCcN79ZvpPee12Qun3vcdxX+37O5LFxz39XeW2I9bybMVA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-linux-arm64": {
+            "version": "0.15.18",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.18.tgz",
+            "integrity": "sha512-54qr8kg/6ilcxd+0V3h9rjT4qmjc0CccMVWrjOEM/pEcUzt8X62HfBSeZfT2ECpM7104mk4yfQXkosY8Quptug==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-linux-mips64le": {
+            "version": "0.15.18",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.18.tgz",
+            "integrity": "sha512-Mk6Ppwzzz3YbMl/ZZL2P0q1tnYqh/trYZ1VfNP47C31yT0K8t9s7Z077QrDA/guU60tGNp2GOwCQnp+DYv7bxQ==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-linux-ppc64le": {
+            "version": "0.15.18",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.18.tgz",
+            "integrity": "sha512-b0XkN4pL9WUulPTa/VKHx2wLCgvIAbgwABGnKMY19WhKZPT+8BxhZdqz6EgkqCLld7X5qiCY2F/bfpUUlnFZ9w==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-linux-riscv64": {
+            "version": "0.15.18",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.18.tgz",
+            "integrity": "sha512-ba2COaoF5wL6VLZWn04k+ACZjZ6NYniMSQStodFKH/Pu6RxzQqzsmjR1t9QC89VYJxBeyVPTaHuBMCejl3O/xg==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-linux-s390x": {
+            "version": "0.15.18",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.18.tgz",
+            "integrity": "sha512-VbpGuXEl5FCs1wDVp93O8UIzl3ZrglgnSQ+Hu79g7hZu6te6/YHgVJxCM2SqfIila0J3k0csfnf8VD2W7u2kzQ==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-netbsd-64": {
+            "version": "0.15.18",
+            "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.18.tgz",
+            "integrity": "sha512-98ukeCdvdX7wr1vUYQzKo4kQ0N2p27H7I11maINv73fVEXt2kyh4K4m9f35U1K43Xc2QGXlzAw0K9yoU7JUjOg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-openbsd-64": {
+            "version": "0.15.18",
+            "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.18.tgz",
+            "integrity": "sha512-yK5NCcH31Uae076AyQAXeJzt/vxIo9+omZRKj1pauhk3ITuADzuOx5N2fdHrAKPxN+zH3w96uFKlY7yIn490xQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-sunos-64": {
+            "version": "0.15.18",
+            "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.18.tgz",
+            "integrity": "sha512-On22LLFlBeLNj/YF3FT+cXcyKPEI263nflYlAhz5crxtp3yRG1Ugfr7ITyxmCmjm4vbN/dGrb/B7w7U8yJR9yw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-windows-32": {
+            "version": "0.15.18",
+            "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.18.tgz",
+            "integrity": "sha512-o+eyLu2MjVny/nt+E0uPnBxYuJHBvho8vWsC2lV61A7wwTWC3jkN2w36jtA+yv1UgYkHRihPuQsL23hsCYGcOQ==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-windows-64": {
+            "version": "0.15.18",
+            "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.18.tgz",
+            "integrity": "sha512-qinug1iTTaIIrCorAUjR0fcBk24fjzEedFYhhispP8Oc7SFvs+XeW3YpAKiKp8dRpizl4YYAhxMjlftAMJiaUw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-windows-arm64": {
+            "version": "0.15.18",
+            "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.18.tgz",
+            "integrity": "sha512-q9bsYzegpZcLziq0zgUi5KqGVtfhjxGbnksaBFYmWLxeV/S1fK4OLdq2DFYnXcLMjlZw2L0jLsk1eGoB522WXQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/fast-check": {
+            "version": "3.10.0",
+            "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.10.0.tgz",
+            "integrity": "sha512-I2FldZwnCbcY6iL+H0rp9m4D+O3PotuFu9FasWjMCzUedYHMP89/37JbSt6/n7Yq/IZmJDW0B2h30sPYdzrfzw==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/dubzzz"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fast-check"
+                }
+            ],
+            "dependencies": {
+                "pure-rand": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/fsevents": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+            "dev": true,
+            "hasInstallScript": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
+        },
+        "node_modules/get-tsconfig": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.3.0.tgz",
+            "integrity": "sha512-YCcF28IqSay3fqpIu5y3Krg/utCBHBeoflkZyHj/QcqI2nrLPC3ZegS9CmIo+hJb8K7aiGsuUl7PwWVjNG2HQQ==",
+            "dev": true,
+            "funding": {
+                "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+            }
+        },
+        "node_modules/pure-rand": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.2.tgz",
+            "integrity": "sha512-6Yg0ekpKICSjPswYOuC5sku/TSWaRYlA0qsXqJgM/d/4pLPHPuTxK7Nbf7jFKzAeedUhR8C7K9Uv63FBsSo8xQ==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/dubzzz"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fast-check"
+                }
+            ]
+        },
+        "node_modules/source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/source-map-support": {
+            "version": "0.5.21",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+            "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+            "dev": true,
+            "dependencies": {
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
+            }
+        },
+        "node_modules/tsx": {
+            "version": "3.12.2",
+            "resolved": "https://registry.npmjs.org/tsx/-/tsx-3.12.2.tgz",
+            "integrity": "sha512-ykAEkoBg30RXxeOMVeZwar+JH632dZn9EUJVyJwhfag62k6UO/dIyJEV58YuLF6e5BTdV/qmbQrpkWqjq9cUnQ==",
+            "dev": true,
+            "dependencies": {
+                "@esbuild-kit/cjs-loader": "^2.4.1",
+                "@esbuild-kit/core-utils": "^3.0.0",
+                "@esbuild-kit/esm-loader": "^2.5.4"
+            },
+            "bin": {
+                "tsx": "dist/cli.js"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.2"
+            }
+        },
+        "node_modules/typescript": {
+            "version": "4.9.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+            "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+            "dev": true,
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=4.2.0"
+            }
+        }
+    },
+    "dependencies": {
+        "@effect/data": {
+            "version": "0.12.10",
+            "resolved": "https://registry.npmjs.org/@effect/data/-/data-0.12.10.tgz",
+            "integrity": "sha512-zIz/DgumH2LgGdr1Wc9ChET5JSG0k/G5kDc8rn4a6yIJ0v2d5rfnbRWIJO2fWmdFvc+128JyaBvYguIyz9JaAQ=="
+        },
+        "@effect/io": {
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@effect/io/-/io-0.27.2.tgz",
+            "integrity": "sha512-J9s+v2JyGUKzxG5I6v1/X5v+I/e9dST4Afk3y6ZYBEXzU3Slo+3ZDf7XlazicS7koAoTEnvJ6zt79aM4LLkoWA==",
+            "requires": {
+                "@effect/data": "~0.12.6"
+            }
+        },
+        "@effect/schema": {
+            "version": "0.21.1",
+            "resolved": "https://registry.npmjs.org/@effect/schema/-/schema-0.21.1.tgz",
+            "integrity": "sha512-ZKxrkOPFo158lw21di+cxcGc7XnvnhQ334hAlXYP4DMEAAmp4bVVuPuDSjVYLLVkg1y3bdYyVqfT7+v1ZfpJNg==",
+            "requires": {
+                "@effect/data": "^0.12.9",
+                "@effect/io": "^0.27.0",
+                "fast-check": "^3.10.0"
+            }
+        },
+        "@esbuild-kit/cjs-loader": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/@esbuild-kit/cjs-loader/-/cjs-loader-2.4.1.tgz",
+            "integrity": "sha512-lhc/XLith28QdW0HpHZvZKkorWgmCNT7sVelMHDj3HFdTfdqkwEKvT+aXVQtNAmCC39VJhunDkWhONWB7335mg==",
+            "dev": true,
+            "requires": {
+                "@esbuild-kit/core-utils": "^3.0.0",
+                "get-tsconfig": "^4.2.0"
+            }
+        },
+        "@esbuild-kit/core-utils": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@esbuild-kit/core-utils/-/core-utils-3.0.0.tgz",
+            "integrity": "sha512-TXmwH9EFS3DC2sI2YJWJBgHGhlteK0Xyu1VabwetMULfm3oYhbrsWV5yaSr2NTWZIgDGVLHbRf0inxbjXqAcmQ==",
+            "dev": true,
+            "requires": {
+                "esbuild": "~0.15.10",
+                "source-map-support": "^0.5.21"
+            }
+        },
+        "@esbuild-kit/esm-loader": {
+            "version": "2.5.4",
+            "resolved": "https://registry.npmjs.org/@esbuild-kit/esm-loader/-/esm-loader-2.5.4.tgz",
+            "integrity": "sha512-afmtLf6uqxD5IgwCzomtqCYIgz/sjHzCWZFvfS5+FzeYxOURPUo4QcHtqJxbxWOMOogKriZanN/1bJQE/ZL93A==",
+            "dev": true,
+            "requires": {
+                "@esbuild-kit/core-utils": "^3.0.0",
+                "get-tsconfig": "^4.2.0"
+            }
+        },
+        "@esbuild/android-arm": {
+            "version": "0.15.18",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.18.tgz",
+            "integrity": "sha512-5GT+kcs2WVGjVs7+boataCkO5Fg0y4kCjzkB5bAip7H4jfnOS3dA6KPiww9W1OEKTKeAcUVhdZGvgI65OXmUnw==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/linux-loong64": {
+            "version": "0.15.18",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.18.tgz",
+            "integrity": "sha512-L4jVKS82XVhw2nvzLg/19ClLWg0y27ulRwuP7lcyL6AbUWB5aPglXY3M21mauDQMDfRLs8cQmeT03r/+X3cZYQ==",
+            "dev": true,
+            "optional": true
+        },
+        "buffer-from": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+            "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+            "dev": true
+        },
+        "esbuild": {
+            "version": "0.15.18",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.18.tgz",
+            "integrity": "sha512-x/R72SmW3sSFRm5zrrIjAhCeQSAWoni3CmHEqfQrZIQTM3lVCdehdwuIqaOtfC2slvpdlLa62GYoN8SxT23m6Q==",
+            "dev": true,
+            "requires": {
+                "@esbuild/android-arm": "0.15.18",
+                "@esbuild/linux-loong64": "0.15.18",
+                "esbuild-android-64": "0.15.18",
+                "esbuild-android-arm64": "0.15.18",
+                "esbuild-darwin-64": "0.15.18",
+                "esbuild-darwin-arm64": "0.15.18",
+                "esbuild-freebsd-64": "0.15.18",
+                "esbuild-freebsd-arm64": "0.15.18",
+                "esbuild-linux-32": "0.15.18",
+                "esbuild-linux-64": "0.15.18",
+                "esbuild-linux-arm": "0.15.18",
+                "esbuild-linux-arm64": "0.15.18",
+                "esbuild-linux-mips64le": "0.15.18",
+                "esbuild-linux-ppc64le": "0.15.18",
+                "esbuild-linux-riscv64": "0.15.18",
+                "esbuild-linux-s390x": "0.15.18",
+                "esbuild-netbsd-64": "0.15.18",
+                "esbuild-openbsd-64": "0.15.18",
+                "esbuild-sunos-64": "0.15.18",
+                "esbuild-windows-32": "0.15.18",
+                "esbuild-windows-64": "0.15.18",
+                "esbuild-windows-arm64": "0.15.18"
+            }
+        },
+        "esbuild-android-64": {
+            "version": "0.15.18",
+            "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.18.tgz",
+            "integrity": "sha512-wnpt3OXRhcjfIDSZu9bnzT4/TNTDsOUvip0foZOUBG7QbSt//w3QV4FInVJxNhKc/ErhUxc5z4QjHtMi7/TbgA==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-android-arm64": {
+            "version": "0.15.18",
+            "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.18.tgz",
+            "integrity": "sha512-G4xu89B8FCzav9XU8EjsXacCKSG2FT7wW9J6hOc18soEHJdtWu03L3TQDGf0geNxfLTtxENKBzMSq9LlbjS8OQ==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-darwin-64": {
+            "version": "0.15.18",
+            "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.18.tgz",
+            "integrity": "sha512-2WAvs95uPnVJPuYKP0Eqx+Dl/jaYseZEUUT1sjg97TJa4oBtbAKnPnl3b5M9l51/nbx7+QAEtuummJZW0sBEmg==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-darwin-arm64": {
+            "version": "0.15.18",
+            "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.18.tgz",
+            "integrity": "sha512-tKPSxcTJ5OmNb1btVikATJ8NftlyNlc8BVNtyT/UAr62JFOhwHlnoPrhYWz09akBLHI9nElFVfWSTSRsrZiDUA==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-freebsd-64": {
+            "version": "0.15.18",
+            "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.18.tgz",
+            "integrity": "sha512-TT3uBUxkteAjR1QbsmvSsjpKjOX6UkCstr8nMr+q7zi3NuZ1oIpa8U41Y8I8dJH2fJgdC3Dj3CXO5biLQpfdZA==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-freebsd-arm64": {
+            "version": "0.15.18",
+            "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.18.tgz",
+            "integrity": "sha512-R/oVr+X3Tkh+S0+tL41wRMbdWtpWB8hEAMsOXDumSSa6qJR89U0S/PpLXrGF7Wk/JykfpWNokERUpCeHDl47wA==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-linux-32": {
+            "version": "0.15.18",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.18.tgz",
+            "integrity": "sha512-lphF3HiCSYtaa9p1DtXndiQEeQDKPl9eN/XNoBf2amEghugNuqXNZA/ZovthNE2aa4EN43WroO0B85xVSjYkbg==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-linux-64": {
+            "version": "0.15.18",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.18.tgz",
+            "integrity": "sha512-hNSeP97IviD7oxLKFuii5sDPJ+QHeiFTFLoLm7NZQligur8poNOWGIgpQ7Qf8Balb69hptMZzyOBIPtY09GZYw==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-linux-arm": {
+            "version": "0.15.18",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.18.tgz",
+            "integrity": "sha512-UH779gstRblS4aoS2qpMl3wjg7U0j+ygu3GjIeTonCcN79ZvpPee12Qun3vcdxX+37O5LFxz39XeW2I9bybMVA==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-linux-arm64": {
+            "version": "0.15.18",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.18.tgz",
+            "integrity": "sha512-54qr8kg/6ilcxd+0V3h9rjT4qmjc0CccMVWrjOEM/pEcUzt8X62HfBSeZfT2ECpM7104mk4yfQXkosY8Quptug==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-linux-mips64le": {
+            "version": "0.15.18",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.18.tgz",
+            "integrity": "sha512-Mk6Ppwzzz3YbMl/ZZL2P0q1tnYqh/trYZ1VfNP47C31yT0K8t9s7Z077QrDA/guU60tGNp2GOwCQnp+DYv7bxQ==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-linux-ppc64le": {
+            "version": "0.15.18",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.18.tgz",
+            "integrity": "sha512-b0XkN4pL9WUulPTa/VKHx2wLCgvIAbgwABGnKMY19WhKZPT+8BxhZdqz6EgkqCLld7X5qiCY2F/bfpUUlnFZ9w==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-linux-riscv64": {
+            "version": "0.15.18",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.18.tgz",
+            "integrity": "sha512-ba2COaoF5wL6VLZWn04k+ACZjZ6NYniMSQStodFKH/Pu6RxzQqzsmjR1t9QC89VYJxBeyVPTaHuBMCejl3O/xg==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-linux-s390x": {
+            "version": "0.15.18",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.18.tgz",
+            "integrity": "sha512-VbpGuXEl5FCs1wDVp93O8UIzl3ZrglgnSQ+Hu79g7hZu6te6/YHgVJxCM2SqfIila0J3k0csfnf8VD2W7u2kzQ==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-netbsd-64": {
+            "version": "0.15.18",
+            "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.18.tgz",
+            "integrity": "sha512-98ukeCdvdX7wr1vUYQzKo4kQ0N2p27H7I11maINv73fVEXt2kyh4K4m9f35U1K43Xc2QGXlzAw0K9yoU7JUjOg==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-openbsd-64": {
+            "version": "0.15.18",
+            "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.18.tgz",
+            "integrity": "sha512-yK5NCcH31Uae076AyQAXeJzt/vxIo9+omZRKj1pauhk3ITuADzuOx5N2fdHrAKPxN+zH3w96uFKlY7yIn490xQ==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-sunos-64": {
+            "version": "0.15.18",
+            "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.18.tgz",
+            "integrity": "sha512-On22LLFlBeLNj/YF3FT+cXcyKPEI263nflYlAhz5crxtp3yRG1Ugfr7ITyxmCmjm4vbN/dGrb/B7w7U8yJR9yw==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-windows-32": {
+            "version": "0.15.18",
+            "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.18.tgz",
+            "integrity": "sha512-o+eyLu2MjVny/nt+E0uPnBxYuJHBvho8vWsC2lV61A7wwTWC3jkN2w36jtA+yv1UgYkHRihPuQsL23hsCYGcOQ==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-windows-64": {
+            "version": "0.15.18",
+            "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.18.tgz",
+            "integrity": "sha512-qinug1iTTaIIrCorAUjR0fcBk24fjzEedFYhhispP8Oc7SFvs+XeW3YpAKiKp8dRpizl4YYAhxMjlftAMJiaUw==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-windows-arm64": {
+            "version": "0.15.18",
+            "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.18.tgz",
+            "integrity": "sha512-q9bsYzegpZcLziq0zgUi5KqGVtfhjxGbnksaBFYmWLxeV/S1fK4OLdq2DFYnXcLMjlZw2L0jLsk1eGoB522WXQ==",
+            "dev": true,
+            "optional": true
+        },
+        "fast-check": {
+            "version": "3.10.0",
+            "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.10.0.tgz",
+            "integrity": "sha512-I2FldZwnCbcY6iL+H0rp9m4D+O3PotuFu9FasWjMCzUedYHMP89/37JbSt6/n7Yq/IZmJDW0B2h30sPYdzrfzw==",
+            "requires": {
+                "pure-rand": "^6.0.0"
+            }
+        },
+        "fsevents": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+            "dev": true,
+            "optional": true
+        },
+        "get-tsconfig": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.3.0.tgz",
+            "integrity": "sha512-YCcF28IqSay3fqpIu5y3Krg/utCBHBeoflkZyHj/QcqI2nrLPC3ZegS9CmIo+hJb8K7aiGsuUl7PwWVjNG2HQQ==",
+            "dev": true
+        },
+        "pure-rand": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.2.tgz",
+            "integrity": "sha512-6Yg0ekpKICSjPswYOuC5sku/TSWaRYlA0qsXqJgM/d/4pLPHPuTxK7Nbf7jFKzAeedUhR8C7K9Uv63FBsSo8xQ=="
+        },
+        "source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true
+        },
+        "source-map-support": {
+            "version": "0.5.21",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+            "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+            "dev": true,
+            "requires": {
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
+            }
+        },
+        "tsx": {
+            "version": "3.12.2",
+            "resolved": "https://registry.npmjs.org/tsx/-/tsx-3.12.2.tgz",
+            "integrity": "sha512-ykAEkoBg30RXxeOMVeZwar+JH632dZn9EUJVyJwhfag62k6UO/dIyJEV58YuLF6e5BTdV/qmbQrpkWqjq9cUnQ==",
+            "dev": true,
+            "requires": {
+                "@esbuild-kit/cjs-loader": "^2.4.1",
+                "@esbuild-kit/core-utils": "^3.0.0",
+                "@esbuild-kit/esm-loader": "^2.5.4",
+                "fsevents": "~2.3.2"
+            }
+        },
+        "typescript": {
+            "version": "4.9.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+            "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+            "dev": true
+        }
+    }
+}

--- a/test/fixtures/typescript-effect-schema/package.json
+++ b/test/fixtures/typescript-effect-schema/package.json
@@ -1,0 +1,18 @@
+{
+    "name": "typescript-effect-schema",
+    "version": "0.1.0",
+    "type": "module",
+    "description": "Test builds.",
+    "scripts": {
+        "test": "tsx main.ts"
+    },
+    "author": "",
+    "license": "Apache-2.0",
+    "devDependencies": {
+        "tsx": "^3.12.2",
+        "typescript": "^4.3.5"
+    },
+    "dependencies": {
+        "@effect/schema": "^0.21.1"
+    }
+}

--- a/test/fixtures/typescript-effect-schema/tsconfig.json
+++ b/test/fixtures/typescript-effect-schema/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "compilerOptions": {
+        "target": "es6"
+    },
+    "files": [
+        "*.ts"
+    ]
+}

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -419,7 +419,7 @@ export const CJSONLanguage: Language = {
         "fcca3.json",
         "bug427.json",
         "github-events.json",
-        "keywords.json",
+        "keywords.json"
     ],
     allowMissingNull: false,
     features: ["minmax", "minmaxlength", "pattern", "enum", "union", "no-defaults"],
@@ -439,7 +439,7 @@ export const CJSONLanguage: Language = {
         /* Map in Array in TopLevel is not supported (for the current implementation, can be added later, need recursivity) */
         "combinations2.json",
         /* Array in Array in Union is not supported (for the current implementation, can be added later, need recursivity) */
-        "combinations4.json",
+        "combinations4.json"
     ],
     skipMiscJSON: false,
     skipSchema: [
@@ -470,12 +470,10 @@ export const CJSONLanguage: Language = {
         "optional-any.schema",
         "required-non-properties.schema",
         /* Other cases not supported */
-        "implicit-class-array-union.schema",
+        "implicit-class-array-union.schema"
     ],
     rendererOptions: {},
-    quickTestRendererOptions: [
-        { "source-style": "single-source" }
-    ],
+    quickTestRendererOptions: [{ "source-style": "single-source" }],
     sourceFiles: ["src/language/CJSON.ts"]
 };
 
@@ -871,161 +869,149 @@ export const FlowLanguage: Language = {
 };
 
 export const Scala3Language: Language = {
-  name: "scala3",
-  base: "test/fixtures/scala3",  
-  runCommand(sample: string) {
-    return `cp "${sample}" sample.json && ./run.sh`;
-  },
-  diffViaSchema: true,
-  skipDiffViaSchema: [
-    "bug427.json",
-    "keywords.json",
+    name: "scala3",
+    base: "test/fixtures/scala3",
+    runCommand(sample: string) {
+        return `cp "${sample}" sample.json && ./run.sh`;
+    },
+    diffViaSchema: true,
+    skipDiffViaSchema: ["bug427.json", "keywords.json"],
+    allowMissingNull: true,
+    features: ["enum", "union", "no-defaults"],
+    output: "TopLevel.scala",
+    topLevel: "TopLevel",
+    skipJSON: [
+        // These tests have "_" as a param name. Scala can't do this?
+        "blns-object.json",
+        "identifiers.json",
+        "simple-identifiers.json",
+        "keywords.json",
 
-  ],
-  allowMissingNull: true,
-  features: ["enum", "union", "no-defaults"],
-  output: "TopLevel.scala",
-  topLevel: "TopLevel",
-  skipJSON: [
-    // These tests have "_" as a param name. Scala can't do this?     
-    "blns-object.json",
-    "identifiers.json",
-    "simple-identifiers.json",
-    "keywords.json",
+        // these actually work as far as I can tell, but seem to fail because properties are sorted differently
+        // I don't think they fail... but I can't figure out sorting so hey ho let's skip them
+        "github-events.json",
+        "0a358.json",
+        "0a91a.json",
+        "34702.json",
+        "76ae1.json",
+        "af2d1.json",
+        "bug427.json",
+        "3d04a0.json",
 
-    // these actually work as far as I can tell, but seem to fail because properties are sorted differently
-    // I don't think they fail... but I can't figure out sorting so hey ho let's skip them
-    "github-events.json", 
-    "0a358.json",
-    "0a91a.json",
-    "34702.json",
-    "76ae1.json",
-    "af2d1.json",
-    "bug427.json",
-    "3d04a0.json",
+        // Top level primitives... trivial,
+        //  but annoying as it breaks compilation of the "Top Level" construct... which doesn't exist.
+        // It's too much hassle to fix
+        // and has no practical application in this context. Skip.
+        "no-classes.json",
 
-    // Top level primitives... trivial, 
-    //  but annoying as it breaks compilation of the "Top Level" construct... which doesn't exist. 
-    // It's too much hassle to fix
-    // and has no practical application in this context. Skip.
-    "no-classes.json",
-    
-    // spaces in variables names doesn't seem to work
-    "name-style.json",
+        // spaces in variables names doesn't seem to work
+        "name-style.json",
 
-/*
+        /*
 I havea no idea how to encode these tests correctly. 
 */
-    "kitchen-sink.json",
-    "26c9c.json",
-    "421d4.json",
-    "a0496.json",
-    "fcca3.json",
-    "ae9ca.json",
-    "617e8.json",
-    "5f7fe.json",
-    "f74d5.json",
-    "a3d8c.json",
-    "combinations1.json",
-    "combinations2.json",
-    "combinations3.json",
-    "combinations4.json",
-    "unions.json",
-    "nst-test-suite.json", 
-
-  ],
-  skipSchema: [
-    // 12 skips
-    "required.schema",    
-    "multi-type-enum.schema", // I think it doesn't correctly realise this is an array of enums.
-    "integer-string.schema",
-    "intersection.schema",
-    "implicit-class-array-union.schema",
-    "date-time-or-string.schema",
-    "implicit-one-of.schema",
-    "go-schema-pattern-properties.schema",
-    "enum.schema",
-    "class-with-additional.schema",
-    "class-map-union.schema",
-    "keyword-unions.schema"
-  ],
-  skipMiscJSON: false,
-  rendererOptions: {framework: "circe" },
-  quickTestRendererOptions: [],
-  sourceFiles: ["src/Language/Scala3.ts"],
+        "kitchen-sink.json",
+        "26c9c.json",
+        "421d4.json",
+        "a0496.json",
+        "fcca3.json",
+        "ae9ca.json",
+        "617e8.json",
+        "5f7fe.json",
+        "f74d5.json",
+        "a3d8c.json",
+        "combinations1.json",
+        "combinations2.json",
+        "combinations3.json",
+        "combinations4.json",
+        "unions.json",
+        "nst-test-suite.json"
+    ],
+    skipSchema: [
+        // 12 skips
+        "required.schema",
+        "multi-type-enum.schema", // I think it doesn't correctly realise this is an array of enums.
+        "integer-string.schema",
+        "intersection.schema",
+        "implicit-class-array-union.schema",
+        "date-time-or-string.schema",
+        "implicit-one-of.schema",
+        "go-schema-pattern-properties.schema",
+        "enum.schema",
+        "class-with-additional.schema",
+        "class-map-union.schema",
+        "keyword-unions.schema"
+    ],
+    skipMiscJSON: false,
+    rendererOptions: { framework: "circe" },
+    quickTestRendererOptions: [],
+    sourceFiles: ["src/Language/Scala3.ts"]
 };
 
 export const Smithy4sLanguage: Language = {
-  name: "smithy4a",
-  base: "test/fixtures/smithy4s",  
-  runCommand(sample: string) {
-    return `cp "${sample}" sample.json && ./run.sh`;
-  },
-  diffViaSchema: true,
-  skipDiffViaSchema: [
-    "bug427.json",
-    "keywords.json",
+    name: "smithy4a",
+    base: "test/fixtures/smithy4s",
+    runCommand(sample: string) {
+        return `cp "${sample}" sample.json && ./run.sh`;
+    },
+    diffViaSchema: true,
+    skipDiffViaSchema: ["bug427.json", "keywords.json"],
+    allowMissingNull: true,
+    features: ["enum", "union", "no-defaults"],
+    output: "TopLevel.scala",
+    topLevel: "TopLevel",
+    skipJSON: [
+        // These tests have "_" as a param name. Scala can't do this?
+        "blns-object.json",
+        "identifiers.json",
+        "simple-identifiers.json",
+        "keywords.json",
 
-  ],
-  allowMissingNull: true,
-  features: ["enum", "union", "no-defaults"],
-  output: "TopLevel.scala",
-  topLevel: "TopLevel",
-  skipJSON: [
-    // These tests have "_" as a param name. Scala can't do this?     
-    "blns-object.json",
-    "identifiers.json",
-    "simple-identifiers.json",
-    "keywords.json",
+        // these actually work as far as I can tell, but seem to fail because properties are sorted differently
+        // I don't think they fail... but I can't figure out sorting so hey ho let's skip them
+        "github-events.json",
+        "0a358.json",
+        "0a91a.json",
+        "34702.json",
+        "76ae1.json",
+        "af2d1.json",
+        "bug427.json",
+        "3d04a0.json",
 
-    // these actually work as far as I can tell, but seem to fail because properties are sorted differently
-    // I don't think they fail... but I can't figure out sorting so hey ho let's skip them
-    "github-events.json", 
-    "0a358.json",
-    "0a91a.json",
-    "34702.json",
-    "76ae1.json",
-    "af2d1.json",
-    "bug427.json",
-    "3d04a0.json",
+        // Top level primitives... trivial,
+        //  but annoying as it breaks compilation of the "Top Level" construct... which doesn't exist.
+        // It's too much hassle to fix
+        // and has no practical application in this context. Skip.
+        "no-classes.json",
 
-    // Top level primitives... trivial, 
-    //  but annoying as it breaks compilation of the "Top Level" construct... which doesn't exist. 
-    // It's too much hassle to fix
-    // and has no practical application in this context. Skip.
-    "no-classes.json",
-    
-    // spaces in variables names doesn't seem to work
-    "name-style.json",
+        // spaces in variables names doesn't seem to work
+        "name-style.json",
 
-/*
+        /*
 I havea no idea how to encode these tests correctly. 
 */
-    "kitchen-sink.json",
-    "26c9c.json",
-    "421d4.json",
-    "a0496.json",
-    "fcca3.json",
-    "ae9ca.json",
-    "617e8.json",
-    "5f7fe.json",
-    "f74d5.json",
-    "a3d8c.json",
-    "combinations1.json",
-    "combinations2.json",
-    "combinations3.json",
-    "combinations4.json",
-    "unions.json",
-    "nst-test-suite.json", 
-
-  ],
-  skipSchema: [
-
-  ],
-  skipMiscJSON: false,
-  rendererOptions: {framework: "just-types" },
-  quickTestRendererOptions: [],
-  sourceFiles: ["src/Language/Smithy4s.ts"],
+        "kitchen-sink.json",
+        "26c9c.json",
+        "421d4.json",
+        "a0496.json",
+        "fcca3.json",
+        "ae9ca.json",
+        "617e8.json",
+        "5f7fe.json",
+        "f74d5.json",
+        "a3d8c.json",
+        "combinations1.json",
+        "combinations2.json",
+        "combinations3.json",
+        "combinations4.json",
+        "unions.json",
+        "nst-test-suite.json"
+    ],
+    skipSchema: [],
+    skipMiscJSON: false,
+    rendererOptions: { framework: "just-types" },
+    quickTestRendererOptions: [],
+    sourceFiles: ["src/Language/Smithy4s.ts"]
 };
 
 export const KotlinLanguage: Language = {
@@ -1519,4 +1505,120 @@ export const TypeScriptZodLanguage: Language = {
     rendererOptions: {},
     quickTestRendererOptions: [{ "array-type": "list" }],
     sourceFiles: ["src/language/TypeScriptZod.ts"]
+};
+
+export const TypeScriptEffectSchemaLanguage: Language = {
+    name: "typescript-effect-schema",
+    base: "test/fixtures/typescript-effect-schema",
+    setupCommand: "npm install",
+    runCommand(sample: string) {
+        return `npm run --silent test "${sample}"`;
+    },
+    diffViaSchema: true,
+    skipDiffViaSchema: [
+        // Schema generated type uses first key as type name, JSON uses last
+        "0cffa.json",
+        "f6a65.json",
+        "c3303.json",
+        "7681c.json",
+        "127a1.json",
+        "26b49.json",
+
+        "bug863.json",
+        "reddit.json",
+        "github-events.json",
+        "nbl-stats.json",
+        "0a91a.json",
+        "0e0c2.json",
+        "29f47.json",
+        "2df80.json",
+        "27332.json",
+        "34702.json",
+        "6de06.json",
+        "76ae1.json",
+        "af2d1.json",
+        "be234.json",
+        "e8b04.json"
+    ],
+    allowMissingNull: false,
+    features: ["enum", "union", "no-defaults"],
+    output: "TopLevel.ts",
+    topLevel: "TopLevel",
+    skipJSON: [
+        // Uses generated schema before it's defined
+        "be234.json",
+        "76ae1.json",
+        "6de06.json",
+        "2df80.json",
+        "29f47.json",
+        "spotify-album.json",
+        "reddit.json",
+        "github-events.json",
+
+        // Does not handle recursive
+        "direct-recursive.json",
+        "list.json",
+        "bug790.json",
+
+        // Does not handle top level array
+        "bug863.json",
+
+        "no-classes.json",
+        "00c36.json",
+        "10be4.json",
+        "050b0.json",
+        "06bee.json",
+        "07c75.json",
+        "3536b.json",
+        "13d8d.json",
+        "43970.json",
+        "570ec.json",
+        "4d6fb.json",
+        "66121.json",
+        "5eae5.json",
+        "6eb00.json",
+        "7f568.json",
+        "7fbfb.json",
+        "8592b.json",
+        "9847b.json",
+        "996bd.json",
+        "9a503.json",
+        "9eed5.json",
+        "ad8be.json",
+        "ae7f0.json",
+        "b4865.json",
+        "cda6c.json",
+        "c8c7e.json",
+        "e53b5.json",
+        "f3139.json",
+        "f22f5.json",
+        "nbl-stats.json",
+        "bug855-short.json",
+        "combinations4.json",
+        "identifiers.json",
+        "blns-object.json",
+        "recursive.json",
+        "bug427.json",
+        "nst-test-suite.json",
+        "keywords.json",
+        "ed095.json"
+    ],
+    skipMiscJSON: false,
+    skipSchema: [
+        "any.schema",
+        "class-map-union.schema",
+        "direct-union.schema",
+        "enum.schema",
+        "go-schema-pattern-properties.schema",
+        "implicit-class-array-union.schema",
+        "intersection.schema",
+        "multi-type-enum.schema",
+        "keyword-unions.schema",
+        "optional-any.schema",
+        "required.schema",
+        "required-non-properties.schema"
+    ],
+    rendererOptions: {},
+    quickTestRendererOptions: [{ "array-type": "list" }],
+    sourceFiles: ["src/language/TypeScriptEffectSchema.ts"]
 };


### PR DESCRIPTION
Adding support for [`@effect/schema`](https://www.npmjs.com/package/@effect/schema), which is a modern alternative to Zod with full support for decoding / encoding (Zod only does decoding).

In order to prevent `const` statements not being defined yet when referencing them for object types, I used `@effect/schema`'s lazy feature. This can be further optimized by only doing that when it's actually needed. Trying to implement that though proved very difficult, so for now this is a fully working reference implementation.

Note, that the reformatting is just reflecting the `.prettierrc` of this repo. Let me know if you want that to be disabled.