### PR TITLE
Support for "const" in JSON Schema

### DIFF
--- a/packages/quicktype-core/src/language/TypeScriptFlow.ts
+++ b/packages/quicktype-core/src/language/TypeScriptFlow.ts
@@ -22,7 +22,12 @@ export const tsFlowOptions = Object.assign({}, javaScriptOptions, {
     nicePropertyNames: new BooleanOption("nice-property-names", "Transform property names to be JavaScripty", false),
     declareUnions: new BooleanOption("explicit-unions", "Explicitly name unions", false),
     preferUnions: new BooleanOption("prefer-unions", "Use union type instead of enum", false),
-    preferTypes: new BooleanOption("prefer-types", "Use types instead of interfaces", false)
+    preferTypes: new BooleanOption("prefer-types", "Use types instead of interfaces", false),
+    preferConstValues: new BooleanOption(
+        "prefer-const-values",
+        "Use string instead of enum for string enums with single value",
+        false
+    )
 });
 
 const tsFlowTypeAnnotations = {
@@ -108,6 +113,10 @@ export abstract class TypeScriptFlowBaseRenderer extends JavaScriptRenderer {
     }
 
     protected sourceFor(t: Type): MultiWord {
+        if (this._tsFlowOptions.preferConstValues && t.kind === "enum" && t instanceof EnumType && t.cases.size === 1) {
+            const item = t.cases.values().next().value;
+            return singleWord(`"${utf16StringEscape(item)}"`);
+        }
         if (["class", "object", "enum"].indexOf(t.kind) >= 0) {
             return singleWord(this.nameForNamedType(t));
         }
@@ -283,6 +292,9 @@ export class TypeScriptRenderer extends TypeScriptFlowBaseRenderer {
 
     protected emitEnum(e: EnumType, enumName: Name): void {
         this.emitDescription(this.descriptionForType(e));
+
+        // enums with only one value are emitted as constants
+        if (this._tsFlowOptions.preferConstValues && e.cases.size === 1) return;
 
         if (this._tsFlowOptions.preferUnions) {
             let items = "";


### PR DESCRIPTION
Hey everyone, I added support for `const` in JSON Schema. I created two commits, the first addresses the issue #1277 and the second improves handling of single value enums for typescript (because const is a single value enum).

If the property has the const type, I interpret it as an enum with a single value. For TypeScript, I added a new case that if an enum has only a single value, it is also created as a constant. This will also change normal enums with a single value. I don't know if this causes problems, for my use case this is okay. What do you think? If the typescript change is not accepted, I can remove it from the pull request.

Could someone please review my changes and give me feedback? Your assistance is greatly appreciated! :)