### PR TITLE
Add derive PartialEq option for Rust

### DIFF
--- a/packages/quicktype-core/src/language/Rust.ts
+++ b/packages/quicktype-core/src/language/Rust.ts
@@ -48,6 +48,7 @@ export const rustOptions = {
     ]),
     deriveDebug: new BooleanOption("derive-debug", "Derive Debug impl", false),
     deriveClone: new BooleanOption("derive-clone", "Derive Clone impl", false),
+    derivePartialEq: new BooleanOption("derive-partial-eq", "Derive PartialEq impl", false),
     edition2018: new BooleanOption("edition-2018", "Edition 2018", true),
     leadingComments: new BooleanOption("leading-comments", "Leading Comments", true)
 };
@@ -124,6 +125,7 @@ export class RustTargetLanguage extends TargetLanguage {
             rustOptions.visibility,
             rustOptions.deriveDebug,
             rustOptions.deriveClone,
+            rustOptions.derivePartialEq,
             rustOptions.edition2018,
             rustOptions.leadingComments
         ];
@@ -375,6 +377,7 @@ export class RustRenderer extends ConvenienceRenderer {
             "#[derive(",
             this._options.deriveDebug ? "Debug, " : "",
             this._options.deriveClone ? "Clone, " : "",
+            this._options.derivePartialEq ? "PartialEq, " : "",
             "Serialize, Deserialize)]"
         );
 
@@ -420,6 +423,7 @@ export class RustRenderer extends ConvenienceRenderer {
             "#[derive(",
             this._options.deriveDebug ? "Debug, " : "",
             this._options.deriveClone ? "Clone, " : "",
+            this._options.derivePartialEq ? "PartialEq, " : "",
             "Serialize, Deserialize)]"
         );
         this.emitLine("#[serde(untagged)]");
@@ -441,6 +445,7 @@ export class RustRenderer extends ConvenienceRenderer {
             "#[derive(",
             this._options.deriveDebug ? "Debug, " : "",
             this._options.deriveClone ? "Clone, " : "",
+            this._options.derivePartialEq ? "PartialEq, " : "",
             "Serialize, Deserialize)]"
         );
 


### PR DESCRIPTION
Add `--derive-partial-eq` option for Rust. Enables deriving PartialEq trait.