### PR TITLE
Add TypeScript Zod support for strings with date-time format

### DIFF
--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1425,7 +1425,7 @@ export const TypeScriptZodLanguage: Language = {
         "e8b04.json"
     ],
     allowMissingNull: false,
-    features: ["enum", "union", "no-defaults"],
+    features: ["enum", "union", "no-defaults", "date-time"],
     output: "TopLevel.ts",
     topLevel: "TopLevel",
     skipJSON: [
@@ -1485,7 +1485,9 @@ export const TypeScriptZodLanguage: Language = {
         "bug427.json",
         "nst-test-suite.json",
         "keywords.json",
-        "ed095.json"
+        "ed095.json",
+        "7681c.json",
+        "32d5c.json"
     ],
     skipMiscJSON: false,
     skipSchema: [


### PR DESCRIPTION
The TypeScript Zod generator currently converts strings with the `date-time` format to `zod.string()`. This modifies the generator to emit `zod.coerce.date()` instead, matching the TypeScript Flow generator. 