### PR TITLE
Python: Ensure default properties follows non-default properties in dataclasses

### DIFF
--- a/packages/quicktype-core/src/language/Python.ts
+++ b/packages/quicktype-core/src/language/Python.ts
@@ -444,7 +444,7 @@ export class PythonRenderer extends ConvenienceRenderer {
     ): ReadonlyMap<string, ClassProperty> {
         if (this.pyOptions.features.dataClasses) {
             return mapSortBy(properties, (p: ClassProperty) => {
-                return p.type instanceof UnionType && nullableFromUnion(p.type) != null ? 1 : 0;
+                return ((p.type instanceof UnionType && nullableFromUnion(p.type) != null) || p.isOptional) ? 1 : 0;
             });
         } else {
             return super.sortClassProperties(properties, propertyNames);


### PR DESCRIPTION
fixes #2226