### PR TITLE
[Rust] Missing reserved keyword

### DIFF
--- a/packages/quicktype-core/src/language/Rust.ts
+++ b/packages/quicktype-core/src/language/Rust.ts
@@ -143,6 +143,7 @@ const keywords = [
 
     // Keywords used in the language.
     "as",
+    "async",
     "box",
     "break",
     "const",


### PR DESCRIPTION
If there is a property in the input schema with the name `async` QuickTypes produces invalid rust because `async` is a reserved word.