### PR TITLE
fix: increase --help output width from 80 to 120

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -347,7 +347,7 @@ function makeOptionDefinitions(targetLanguages: TargetLanguage[]): OptionDefinit
                       name: "lang",
                       alias: "l",
                       type: String,
-                      typeLabel: makeLangTypeLabel(targetLanguages),
+                      typeLabel: "LANG",
                       description: "The target language."
                   }
               ];

--- a/src/index.ts
+++ b/src/index.ts
@@ -495,10 +495,11 @@ const tableOptionsForOptions: TableOptions = {
     columns: [
         {
             name: "option",
-            width: 50
+            width: 60
         },
         {
-            name: "description"
+            name: "description",
+            width: 60
         }
     ]
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -357,7 +357,7 @@ function makeOptionDefinitions(targetLanguages: TargetLanguage[]): OptionDefinit
             alias: "s",
             type: String,
             defaultValue: undefined,
-            typeLabel: "json|schema|graphql|postman|typescript",
+            typeLabel: "SRC_LANG",
             description: "The source language (default is json)."
         },
         {
@@ -510,9 +510,13 @@ function makeSectionsBeforeRenderers(targetLanguages: TargetLanguage[]): UsageSe
         {
             header: "Synopsis",
             content: [
-                `$ quicktype [${chalk.bold("--lang")} LANG] [${chalk.bold("--out")} FILE] FILE|URL ...`,
+                `$ quicktype [${chalk.bold("--lang")} LANG] [${chalk.bold("--src-lang")} SRC_LANG] [${chalk.bold(
+                    "--out"
+                )} FILE] FILE|URL ...`,
                 "",
-                `  LANG ... ${makeLangTypeLabel(targetLanguages)}`
+                `  LANG ... ${makeLangTypeLabel(targetLanguages)}`,
+                "",
+                "SRC_LANG ... json|schema|graphql|postman|typescript"
             ]
         },
         {


### PR DESCRIPTION
I noticed that "command-line-usage" has print width of 80 by default, and it does not increase when the text would fit in the terminal window. Also, the descpition of `--lang` flag shifts layout the most, so I replaced list of languages with `LANG`, since `LANG` is already defined in synopsis. Additionally, I added `--src-lang` to synopsis

<details>
  <summary>Before</summary>
  
  ```log
Synopsis

  $ quicktype [--lang LANG] [--out FILE] FILE|URL ...                           
                                                                                
  LANG ... cs|go|rs|cr|cjson|c++|objc|java|ts|js|javascript-prop-               
  types|flow|swift|scala3|Smithy|kotlin|elm|schema|ruby|dart|py|pike|haskell|typescript- 
  zod|typescript-effect-schema|php                                              

Description

  Given JSON sample data, quicktype outputs code for working with that data in  
  C#, Go, Rust, Crystal, C (cJSON), C++, Objective-C, Java, TypeScript,         
  JavaScript, JavaScript PropTypes, Flow, Swift, Scala3, Smithy, Kotlin, Elm,   
  JSON Schema, Ruby, Dart, Python, Pike, Haskell, TypeScript Zod, TypeScript    
  Effect Schema, PHP.                                                           

Options

 -o, --out FILE                                                                          The 
                                                                                         output 
                                                                                         file. 
                                                                                         Determines 
                                                                                         --lang 
                                                                                         and 
                                                                                         --top-level. 
 -t, --top-level NAME                                                                    The 
                                                                                         name 
                                                                                         for 
                                                                                         the 
                                                                                         top 
                                                                                         level 
                                                                                         type. 
 -l, --lang cs|go|rs|cr|cjson|c++|objc|java|ts|js|javascript-prop-                       The 
 types|flow|swift|scala3|Smithy|kotlin|elm|schema|ruby|dart|py|pike|haskell|typescript-  target 
 zod|typescript-effect-schema|php                                                        language. 
 -s, --src-lang json|schema|graphql|postman|typescript                                   The 
                                                                                         source 
                                                                                         language 
                                                                                         (default 
                                                                                         is 
                                                                                         json). 
 --src FILE|URL|DIRECTORY                                                                The 
                                                                                         file, 
                                                                                         url, 
                                                                                         or 
                                                                                         data 
                                                                                         directory 
                                                                                         to 
                                                                                         type. 
 --src-urls FILE                                                                         Tracery 
                                                                                         grammar 
                                                                                         describing 
                                                                                         URLs 
                                                                                         to 
                                                                                         crawl. 
 --no-maps                                                                               Don't 
                                                                                         infer 
                                                                                         maps, 
                                                                                         always 
                                                                                         use 
                                                                                         classes. 
 --no-enums                                                                              Don't 
                                                                                         infer 
                                                                                         enums, 
                                                                                         always 
                                                                                         use 
                                                                                         strings. 
 --no-uuids                                                                              Don't 
                                                                                         convert 
                                                                                         UUIDs 
                                                                                         to 
                                                                                         UUID 
                                                                                         objects. 
 --no-date-times                                                                         Don't 
                                                                                         infer 
                                                                                         dates 
                                                                                         or 
                                                                                         times. 
 --no-integer-strings                                                                    Don't 
                                                                                         convert 
                                                                                         stringified 
                                                                                         integers 
                                                                                         to 
                                                                                         integers. 
 --no-boolean-strings                                                                    Don't 
                                                                                         convert 
                                                                                         stringified 
                                                                                         booleans 
                                                                                         to 
                                                                                         booleans. 
 --no-combine-classes                                                                    Don't 
                                                                                         combine 
                                                                                         similar 
                                                                                         classes. 
 --no-ignore-json-refs                                                                   Treat 
                                                                                         $ref 
                                                                                         as 
                                                                                         a 
                                                                                         reference 
                                                                                         in 
                                                                                         JSON. 
 --graphql-schema FILE                                                                   GraphQL 
                                                                                         introspection 
                                                                                         file. 
 --graphql-introspect URL                                                                Introspect 
                                                                                         GraphQL 
                                                                                         schema 
                                                                                         from 
                                                                                         a 
                                                                                         server. 
 --http-method METHOD                                                                    HTTP 
                                                                                         method 
                                                                                         to 
                                                                                         use 
                                                                                         for 
                                                                                         the 
                                                                                         GraphQL 
                                                                                         introspection 
                                                                                         query. 
 --http-header HEADER                                                                    Header(s) 
                                                                                         to 
                                                                                         attach 
                                                                                         to 
                                                                                         all 
                                                                                         HTTP 
                                                                                         requests, 
                                                                                         including 
                                                                                         the 
                                                                                         GraphQL 
                                                                                         introspection 
                                                                                         query. 
 -S, --additional-schema FILE                                                            Register 
                                                                                         the 
                                                                                         $id's 
                                                                                         of 
                                                                                         additional 
                                                                                         JSON 
                                                                                         Schema 
                                                                                         files. 
 --alphabetize-properties                                                                Alphabetize 
                                                                                         order 
                                                                                         of 
                                                                                         class 
                                                                                         properties. 
 --all-properties-optional                                                               Make 
                                                                                         all 
                                                                                         class 
                                                                                         properties 
                                                                                         optional. 
 --quiet                                                                                 Don't 
                                                                                         show 
                                                                                         issues 
                                                                                         in 
                                                                                         the 
                                                                                         generated 
                                                                                         code. 
 --debug OPTIONS or all                                                                  Comma 
                                                                                         separated 
                                                                                         debug 
                                                                                         options: 
                                                                                         print- 
                                                                                         graph, 
                                                                                         print- 
                                                                                         reconstitution, 
                                                                                         print- 
                                                                                         gather- 
                                                                                         names, 
                                                                                         print- 
                                                                                         transformations, 
                                                                                         print- 
                                                                                         schema- 
                                                                                         resolving, 
                                                                                         print- 
                                                                                         times, 
                                                                                         provenance 
 --telemetry enable|disable                                                              Enable 
                                                                                         anonymous 
                                                                                         telemetry 
                                                                                         to 
                                                                                         help 
                                                                                         improve 
                                                                                         quicktype 
 -h, --help                                                                              Get 
                                                                                         some 
                                                                                         help. 
 -v, --version                                                                           Display 
                                                                                         the 
                                                                                         version 
                                                                                         of 
                                                                                         quicktype 

Options for C#

 --framework NewtonSoft|SystemTextJson             Serialization framework      
 --namespace NAME                                  Generated namespace          
 --csharp-version 5|6                              C# version                   
 --density normal|dense                            Property density             
 --array-type array|list                           Use T[] or List<T>           
 --number-type double|decimal                      Type to use for numbers      
 --any-type object|dynamic                         Type to use for "any"        
 --[no-]virtual                                    Generate virtual properties  
                                                   (off by default)             
 --features complete|attributes-only|just-types-   Output features              
 and-namespace|just-types                                                       
 --base-class EntityData|Object                    Base class                   
 --[no-]check-required                             Fail if required properties  
                                                   are missing (off by default) 

Options for Go

 --[no-]just-types                                 Plain types only (off by     
                                                   default)                     
 --package NAME                                    Generated package name       
 --[no-]multi-file-output                          Renders each top-level       
                                                   object in its own Go file    
                                                   (off by default)             
 --[no-]just-types-and-package                     Plain types with package     
                                                   only (off by default)        
 --field-tags TAGS                                 list of tags which should be 
                                                   generated for fields         

Options for Rust

 --density normal|dense                            Density                      
 --visibility private|crate|public                 Field visibility             
 --[no-]derive-debug                               Derive Debug impl (off by    
                                                   default)                     
 --[no-]derive-clone                               Derive Clone impl (off by    
                                                   default)                     
 --[no-]derive-partial-eq                          Derive PartialEq impl (off   
                                                   by default)                  
 --[no-]edition-2018                               Edition 2018 (on by default) 
 --[no-]leading-comments                           Leading Comments (on by      
                                                   default)                     

Options for C (cJSON)

 --source-style single-source|multi-source         Source code generation type, 
                                                   whether to generate single   
                                                   or multiple source files     
 --integer-size int8_t|int16_t|int32_t|int64_t     Integer code generation type 
                                                   (int64_t by default)         
 --typedef-alias no-typedef|add-typedef            Add typedef alias to unions, 
                                                   structs, and enums (no       
                                                   typedef by default)          
 --print-style print-formatted|print-unformatted   Which cJSON print should be  
                                                   used (formatted by default)  
 --hashtable-size SIZE                             Hashtable size, used when    
                                                   maps are created (64 by      
                                                   default)                     
 --type-style pascal-case|underscore-case|camel-   Naming style for types       
 case|upper-underscore-case|pascal-case-upper-                                  
 acronyms|camel-case-upper-acronyms                                             
 --member-style underscore-case|pascal-            Naming style for members     
 case|camel-case|upper-underscore-case|pascal-                                  
 case-upper-acronyms|camel-case-upper-acronyms                                  
 --enumerator-style upper-underscore-              Naming style for enumerators 
 case|underscore-case|pascal-case|camel-                                        
 case|pascal-case-upper-acronyms|camel-case-                                    
 upper-acronyms                                                                 

Options for C++

 --[no-]just-types                                 Plain types only (off by     
                                                   default)                     
 --namespace NAME                                  Name of the generated        
                                                   namespace(s)                 
 --code-format with-struct|with-getter-setter      Generate classes with        
                                                   getters/setters, instead of  
                                                   structs                      
 --wstring use-string|use-wstring                  Store strings using Utf-16   
                                                   std::wstring, rather than    
                                                   Utf-8 std::string            
 --const-style west-const|east-const               Put const to the left/west   
                                                   (const T) or right/east (T   
                                                   const)                       
 --source-style single-source|multi-source         Source code generation type, 
                                                   whether to generate single   
                                                   or multiple source files     
 --include-location local-include|global-include   Whether json.hpp is to be    
                                                   located globally or locally  
 --type-style pascal-case|underscore-case|camel-   Naming style for types       
 case|upper-underscore-case|pascal-case-upper-                                  
 acronyms|camel-case-upper-acronyms                                             
 --member-style underscore-case|pascal-            Naming style for members     
 case|camel-case|upper-underscore-case|pascal-                                  
 case-upper-acronyms|camel-case-upper-acronyms                                  
 --enumerator-style upper-underscore-              Naming style for enumerators 
 case|underscore-case|pascal-case|camel-                                        
 case|pascal-case-upper-acronyms|camel-case-                                    
 upper-acronyms                                                                 
 --enum-type NAME                                  Type of enum class           
 --[no-]boost                                      Require a dependency on      
                                                   boost. Without boost, C++17  
                                                   is required (on by default)  
 --[no-]hide-null-optional                         Hide null value for optional 
                                                   field (off by default)       

Options for Objective-C

 --[no-]just-types                                 Plain types only (off by     
                                                   default)                     
 --class-prefix PREFIX                             Class prefix                 
 --features all|interface|implementation           Interface and implementation 
 --[no-]extra-comments                             Extra comments (off by       
                                                   default)                     
 --[no-]functions                                  C-style functions (off by    
                                                   default)                     

Options for Java

 --array-type array|list                           Use T[] or List<T>           
 --[no-]just-types                                 Plain types only (off by     
                                                   default)                     
 --datetime-provider java8|legacy                  Date time provider type      
 --acronym-style original|pascal|camel|lowerCase   Acronym naming style         
 --package NAME                                    Generated package name       
 --[no-]lombok                                     Use lombok (off by default)  
 --[no-]lombok-copy-annotations                    Copy accessor annotations    
                                                   (on by default)              

Options for TypeScript

 --[no-]just-types                                 Interfaces only (off by      
                                                   default)                     
 --[no-]nice-property-names                        Transform property names to  
                                                   be JavaScripty (off by       
                                                   default)                     
 --[no-]explicit-unions                            Explicitly name unions (off  
                                                   by default)                  
 --[no-]runtime-typecheck                          Verify JSON.parse results at 
                                                   runtime (on by default)      
 --[no-]runtime-typecheck-ignore-unknown-properties  Ignore unknown properties    
                                                   when verifying at runtime    
                                                   (off by default)             
 --acronym-style original|pascal|camel|lowerCase   Acronym naming style         
 --converters top-level|all-objects                Which converters to generate 
                                                   (top-level by default)       
 --raw-type json|any                               Type of raw input (json by   
                                                   default)                     
 --[no-]prefer-unions                              Use union type instead of    
                                                   enum (off by default)        
 --[no-]prefer-types                               Use types instead of         
                                                   interfaces (off by default)  

Options for JavaScript

 --[no-]runtime-typecheck                          Verify JSON.parse results at 
                                                   runtime (on by default)      
 --[no-]runtime-typecheck-ignore-unknown-properties  Ignore unknown properties    
                                                   when verifying at runtime    
                                                   (off by default)             
 --acronym-style original|pascal|camel|lowerCase   Acronym naming style         
 --converters top-level|all-objects                Which converters to generate 
                                                   (top-level by default)       
 --raw-type json|any                               Type of raw input (json by   
                                                   default)                     

Options for JavaScript PropTypes

 --acronym-style original|pascal|camel|lowerCase   Acronym naming style         
 --converters top-level|all-objects                Which converters to generate 
                                                   (top-level by default)       

Options for Flow

 --[no-]just-types                                 Interfaces only (off by      
                                                   default)                     
 --[no-]nice-property-names                        Transform property names to  
                                                   be JavaScripty (off by       
                                                   default)                     
 --[no-]explicit-unions                            Explicitly name unions (off  
                                                   by default)                  
 --[no-]runtime-typecheck                          Verify JSON.parse results at 
                                                   runtime (on by default)      
 --[no-]runtime-typecheck-ignore-unknown-properties  Ignore unknown properties    
                                                   when verifying at runtime    
                                                   (off by default)             
 --acronym-style original|pascal|camel|lowerCase   Acronym naming style         
 --converters top-level|all-objects                Which converters to generate 
                                                   (top-level by default)       
 --raw-type json|any                               Type of raw input (json by   
                                                   default)                     
 --[no-]prefer-unions                              Use union type instead of    
                                                   enum (off by default)        
 --[no-]prefer-types                               Use types instead of         
                                                   interfaces (off by default)  

Options for Swift

 --[no-]just-types                                 Plain types only (off by     
                                                   default)                     
 --struct-or-class struct|class                    Structs or classes           
 --density dense|normal                            Code density                 
 --[no-]initializers                               Generate initializers and    
                                                   mutators (on by default)     
 --[no-]coding-keys                                Explicit CodingKey values in 
                                                   Codable types (on by         
                                                   default)                     
 --access-level internal|public                    Access level                 
 --[no-]alamofire                                  Alamofire extensions (off by 
                                                   default)                     
 --[no-]support-linux                              Support Linux (off by        
                                                   default)                     
 --type-prefix PREFIX                              Prefix for type names        
 --protocol none|equatable|hashable                Make types implement         
                                                   protocol                     
 --acronym-style original|pascal|camel|lowerCase   Acronym naming style         
 --[no-]objective-c-support                        Objects inherit from         
                                                   NSObject and @objcMembers is 
                                                   added to classes (off by     
                                                   default)                     
 --[no-]optional-enums                             If no matching case is found 
                                                   enum value is set to null    
                                                   (off by default)             
 --[no-]sendable                                   Mark generated models as     
                                                   Sendable (off by default)    
 --[no-]swift-5-support                            Renders output in a Swift 5  
                                                   compatible mode (off by      
                                                   default)                     
 --[no-]multi-file-output                          Renders each top-level       
                                                   object in its own Swift file 
                                                   (off by default)             
 --[no-]mutable-properties                         Use var instead of let for   
                                                   object properties (off by    
                                                   default)                     

Options for Scala3

 --framework just-types|circe|upickle              Serialization framework 
 --package PACKAGE                                 Package                 

Options for Smithy

 --framework just-types                            Serialization framework 
 --package PACKAGE                                 Package                 

Options for Kotlin

 --framework just-types|jackson|klaxon|kotlinx     Serialization framework 
 --acronym-style original|pascal|camel|lowerCase   Acronym naming style    
 --package PACKAGE                                 Package                 

Options for Elm

 --[no-]just-types                                 Plain types only (off by     
                                                   default)                     
 --module NAME                                     Generated module name        
 --array-type array|list                           Use Array or List            

Options for Ruby

 --[no-]just-types                                 Plain types only (off by     
                                                   default)                     
 --strictness strict|coercible|none                Type strictness              
 --namespace NAME                                  Specify a wrapping Namespace 

Options for Dart

 --[no-]null-safety                                Null Safety (on by default)  
 --[no-]just-types                                 Types only (off by default)  
 --[no-]coders-in-class                            Put encoder & decoder in     
                                                   Class (off by default)       
 --[no-]from-map                                   Use method names fromMap() & 
                                                   toMap() (off by default)     
 --[no-]required-props                             Make all properties required 
                                                   (off by default)             
 --[no-]final-props                                Make all properties final    
                                                   (off by default)             
 --[no-]copy-with                                  Generate CopyWith method     
                                                   (off by default)             
 --[no-]use-freezed                                Generate class definitions   
                                                   with @freezed compatibility  
                                                   (off by default)             
 --[no-]use-hive                                   Generate annotations for     
                                                   Hive type adapters (off by   
                                                   default)                     
 --[no-]use-json-annotation                        Generate annotations for     
                                                   json_serializable (off by    
                                                   default)                     
 --part-name NAME                                  Use this name in `part`      
                                                   directive                    

Options for Python

 --python-version 3.5|3.6|3.7                      Python version               
 --[no-]just-types                                 Classes only (off by         
                                                   default)                     
 --[no-]nice-property-names                        Transform property names to  
                                                   be Pythonic (on by default)  

Options for Haskell

 --[no-]just-types                                 Plain types only (off by     
                                                   default)                     
 --module NAME                                     Generated module name        
 --array-type array|list                           Use Array or List            

Options for PHP

 --[no-]with-get                                   Create Getter (on by         
                                                   default)                     
 --[no-]fast-get                                   getter without validation    
                                                   (off by default)             
 --[no-]with-set                                   Create Setter (off by        
                                                   default)                     
 --[no-]with-closing                               PHP Closing Tag (off by      
                                                   default)                     
 --acronym-style original|pascal|camel|lowerCase   Acronym naming style         

Examples

  Generate C# to parse a Bitcoin API                                            
  $ quicktype -o LatestBlock.cs https://blockchain.info/latestblock             
                                                                                
  Generate Go code from a directory of samples containing:                      
    - Foo.json                                                                  
    + Bar                                                                       
      - bar-sample-1.json                                                       
      - bar-sample-2.json                                                       
    - Baz.url                                                                   
  $ quicktype -l go samples                                                     
                                                                                
  Generate JSON Schema, then TypeScript                                         
  $ quicktype -o schema.json https://blockchain.info/latestblock                
  $ quicktype -o bitcoin.ts --src-lang schema schema.json                       

  Learn more at quicktype.io
  ```
  
</details>

<details>
  <summary>After</summary>
  
  ```log
Synopsis

  $ quicktype [--lang LANG] [--src-lang SRC_LANG] [--out FILE] FILE|URL ...     
                                                                                
  LANG ... cs|go|rs|cr|cjson|c++|objc|java|ts|js|javascript-prop-               
  types|flow|swift|scala3|Smithy|kotlin|elm|schema|ruby|dart|py|pike|haskell|typescript- 
  zod|typescript-effect-schema|php                                              
                                                                                
  SRC_LANG ... json|schema|graphql|postman|typescript                           

Description

  Given JSON sample data, quicktype outputs code for working with that data in  
  C#, Go, Rust, Crystal, C (cJSON), C++, Objective-C, Java, TypeScript,         
  JavaScript, JavaScript PropTypes, Flow, Swift, Scala3, Smithy, Kotlin, Elm,   
  JSON Schema, Ruby, Dart, Python, Pike, Haskell, TypeScript Zod, TypeScript    
  Effect Schema, PHP.                                                           

Options

 -o, --out FILE                                              The output file. Determines --lang and --top-level.        
 -t, --top-level NAME                                        The name for the top level type.                           
 -l, --lang LANG                                             The target language.                                       
 -s, --src-lang SRC_LANG                                     The source language (default is json).                     
 --src FILE|URL|DIRECTORY                                    The file, url, or data directory to type.                  
 --src-urls FILE                                             Tracery grammar describing URLs to crawl.                  
 --no-maps                                                   Don't infer maps, always use classes.                      
 --no-enums                                                  Don't infer enums, always use strings.                     
 --no-uuids                                                  Don't convert UUIDs to UUID objects.                       
 --no-date-times                                             Don't infer dates or times.                                
 --no-integer-strings                                        Don't convert stringified integers to integers.            
 --no-boolean-strings                                        Don't convert stringified booleans to booleans.            
 --no-combine-classes                                        Don't combine similar classes.                             
 --no-ignore-json-refs                                       Treat $ref as a reference in JSON.                         
 --graphql-schema FILE                                       GraphQL introspection file.                                
 --graphql-introspect URL                                    Introspect GraphQL schema from a server.                   
 --http-method METHOD                                        HTTP method to use for the GraphQL introspection query.    
 --http-header HEADER                                        Header(s) to attach to all HTTP requests, including the    
                                                             GraphQL introspection query.                               
 -S, --additional-schema FILE                                Register the $id's of additional JSON Schema files.        
 --alphabetize-properties                                    Alphabetize order of class properties.                     
 --all-properties-optional                                   Make all class properties optional.                        
 --quiet                                                     Don't show issues in the generated code.                   
 --debug OPTIONS or all                                      Comma separated debug options: print-graph, print-         
                                                             reconstitution, print-gather-names, print-transformations, 
                                                             print-schema-resolving, print-times, provenance            
 --telemetry enable|disable                                  Enable anonymous telemetry to help improve quicktype       
 -h, --help                                                  Get some help.                                             
 -v, --version                                               Display the version of quicktype                           

Options for C#

 --framework NewtonSoft|SystemTextJson                       Serialization framework                                    
 --namespace NAME                                            Generated namespace                                        
 --csharp-version 5|6                                        C# version                                                 
 --density normal|dense                                      Property density                                           
 --array-type array|list                                     Use T[] or List<T>                                         
 --number-type double|decimal                                Type to use for numbers                                    
 --any-type object|dynamic                                   Type to use for "any"                                      
 --[no-]virtual                                              Generate virtual properties (off by default)               
 --features complete|attributes-only|just-types-and-         Output features                                            
 namespace|just-types                                                                                                   
 --base-class EntityData|Object                              Base class                                                 
 --[no-]check-required                                       Fail if required properties are missing (off by default)   

Options for Go

 --[no-]just-types                                           Plain types only (off by default)                          
 --package NAME                                              Generated package name                                     
 --[no-]multi-file-output                                    Renders each top-level object in its own Go file (off by   
                                                             default)                                                   
 --[no-]just-types-and-package                               Plain types with package only (off by default)             
 --field-tags TAGS                                           list of tags which should be generated for fields          

Options for Rust

 --density normal|dense                                      Density                                                    
 --visibility private|crate|public                           Field visibility                                           
 --[no-]derive-debug                                         Derive Debug impl (off by default)                         
 --[no-]derive-clone                                         Derive Clone impl (off by default)                         
 --[no-]derive-partial-eq                                    Derive PartialEq impl (off by default)                     
 --[no-]edition-2018                                         Edition 2018 (on by default)                               
 --[no-]leading-comments                                     Leading Comments (on by default)                           

Options for C (cJSON)

 --source-style single-source|multi-source                   Source code generation type, whether to generate single or 
                                                             multiple source files                                      
 --integer-size int8_t|int16_t|int32_t|int64_t               Integer code generation type (int64_t by default)          
 --typedef-alias no-typedef|add-typedef                      Add typedef alias to unions, structs, and enums (no        
                                                             typedef by default)                                        
 --print-style print-formatted|print-unformatted             Which cJSON print should be used (formatted by default)    
 --hashtable-size SIZE                                       Hashtable size, used when maps are created (64 by default) 
 --type-style pascal-case|underscore-case|camel-case|upper-  Naming style for types                                     
 underscore-case|pascal-case-upper-acronyms|camel-case-                                                                 
 upper-acronyms                                                                                                         
 --member-style underscore-case|pascal-case|camel-           Naming style for members                                   
 case|upper-underscore-case|pascal-case-upper-                                                                          
 acronyms|camel-case-upper-acronyms                                                                                     
 --enumerator-style upper-underscore-case|underscore-        Naming style for enumerators                               
 case|pascal-case|camel-case|pascal-case-upper-                                                                         
 acronyms|camel-case-upper-acronyms                                                                                     

Options for C++

 --[no-]just-types                                           Plain types only (off by default)                          
 --namespace NAME                                            Name of the generated namespace(s)                         
 --code-format with-struct|with-getter-setter                Generate classes with getters/setters, instead of structs  
 --wstring use-string|use-wstring                            Store strings using Utf-16 std::wstring, rather than Utf-8 
                                                             std::string                                                
 --const-style west-const|east-const                         Put const to the left/west (const T) or right/east (T      
                                                             const)                                                     
 --source-style single-source|multi-source                   Source code generation type,  whether to generate single   
                                                             or multiple source files                                   
 --include-location local-include|global-include             Whether json.hpp is to be located globally or locally      
 --type-style pascal-case|underscore-case|camel-case|upper-  Naming style for types                                     
 underscore-case|pascal-case-upper-acronyms|camel-case-                                                                 
 upper-acronyms                                                                                                         
 --member-style underscore-case|pascal-case|camel-           Naming style for members                                   
 case|upper-underscore-case|pascal-case-upper-                                                                          
 acronyms|camel-case-upper-acronyms                                                                                     
 --enumerator-style upper-underscore-case|underscore-        Naming style for enumerators                               
 case|pascal-case|camel-case|pascal-case-upper-                                                                         
 acronyms|camel-case-upper-acronyms                                                                                     
 --enum-type NAME                                            Type of enum class                                         
 --[no-]boost                                                Require a dependency on boost. Without boost, C++17 is     
                                                             required (on by default)                                   
 --[no-]hide-null-optional                                   Hide null value for optional field (off by default)        

Options for Objective-C

 --[no-]just-types                                           Plain types only (off by default)                          
 --class-prefix PREFIX                                       Class prefix                                               
 --features all|interface|implementation                     Interface and implementation                               
 --[no-]extra-comments                                       Extra comments (off by default)                            
 --[no-]functions                                            C-style functions (off by default)                         

Options for Java

 --array-type array|list                                     Use T[] or List<T>                                         
 --[no-]just-types                                           Plain types only (off by default)                          
 --datetime-provider java8|legacy                            Date time provider type                                    
 --acronym-style original|pascal|camel|lowerCase             Acronym naming style                                       
 --package NAME                                              Generated package name                                     
 --[no-]lombok                                               Use lombok (off by default)                                
 --[no-]lombok-copy-annotations                              Copy accessor annotations (on by default)                  

Options for TypeScript

 --[no-]just-types                                           Interfaces only (off by default)                           
 --[no-]nice-property-names                                  Transform property names to be JavaScripty (off by         
                                                             default)                                                   
 --[no-]explicit-unions                                      Explicitly name unions (off by default)                    
 --[no-]runtime-typecheck                                    Verify JSON.parse results at runtime (on by default)       
 --[no-]runtime-typecheck-ignore-unknown-properties          Ignore unknown properties when verifying at runtime (off   
                                                             by default)                                                
 --acronym-style original|pascal|camel|lowerCase             Acronym naming style                                       
 --converters top-level|all-objects                          Which converters to generate (top-level by default)        
 --raw-type json|any                                         Type of raw input (json by default)                        
 --[no-]prefer-unions                                        Use union type instead of enum (off by default)            
 --[no-]prefer-types                                         Use types instead of interfaces (off by default)           

Options for JavaScript

 --[no-]runtime-typecheck                                    Verify JSON.parse results at runtime (on by default)       
 --[no-]runtime-typecheck-ignore-unknown-properties          Ignore unknown properties when verifying at runtime (off   
                                                             by default)                                                
 --acronym-style original|pascal|camel|lowerCase             Acronym naming style                                       
 --converters top-level|all-objects                          Which converters to generate (top-level by default)        
 --raw-type json|any                                         Type of raw input (json by default)                        

Options for JavaScript PropTypes

 --acronym-style original|pascal|camel|lowerCase             Acronym naming style                                       
 --converters top-level|all-objects                          Which converters to generate (top-level by default)        

Options for Flow

 --[no-]just-types                                           Interfaces only (off by default)                           
 --[no-]nice-property-names                                  Transform property names to be JavaScripty (off by         
                                                             default)                                                   
 --[no-]explicit-unions                                      Explicitly name unions (off by default)                    
 --[no-]runtime-typecheck                                    Verify JSON.parse results at runtime (on by default)       
 --[no-]runtime-typecheck-ignore-unknown-properties          Ignore unknown properties when verifying at runtime (off   
                                                             by default)                                                
 --acronym-style original|pascal|camel|lowerCase             Acronym naming style                                       
 --converters top-level|all-objects                          Which converters to generate (top-level by default)        
 --raw-type json|any                                         Type of raw input (json by default)                        
 --[no-]prefer-unions                                        Use union type instead of enum (off by default)            
 --[no-]prefer-types                                         Use types instead of interfaces (off by default)           

Options for Swift

 --[no-]just-types                                           Plain types only (off by default)                          
 --struct-or-class struct|class                              Structs or classes                                         
 --density dense|normal                                      Code density                                               
 --[no-]initializers                                         Generate initializers and mutators (on by default)         
 --[no-]coding-keys                                          Explicit CodingKey values in Codable types (on by default) 
 --access-level internal|public                              Access level                                               
 --[no-]alamofire                                            Alamofire extensions (off by default)                      
 --[no-]support-linux                                        Support Linux (off by default)                             
 --type-prefix PREFIX                                        Prefix for type names                                      
 --protocol none|equatable|hashable                          Make types implement protocol                              
 --acronym-style original|pascal|camel|lowerCase             Acronym naming style                                       
 --[no-]objective-c-support                                  Objects inherit from NSObject and @objcMembers is added to 
                                                             classes (off by default)                                   
 --[no-]optional-enums                                       If no matching case is found enum value is set to null     
                                                             (off by default)                                           
 --[no-]sendable                                             Mark generated models as Sendable (off by default)         
 --[no-]swift-5-support                                      Renders output in a Swift 5 compatible mode (off by        
                                                             default)                                                   
 --[no-]multi-file-output                                    Renders each top-level object in its own Swift file (off   
                                                             by default)                                                
 --[no-]mutable-properties                                   Use var instead of let for object properties (off by       
                                                             default)                                                   

Options for Scala3

 --framework just-types|circe|upickle                        Serialization framework                                    
 --package PACKAGE                                           Package                                                    

Options for Smithy

 --framework just-types                                      Serialization framework                                    
 --package PACKAGE                                           Package                                                    

Options for Kotlin

 --framework just-types|jackson|klaxon|kotlinx               Serialization framework                                    
 --acronym-style original|pascal|camel|lowerCase             Acronym naming style                                       
 --package PACKAGE                                           Package                                                    

Options for Elm

 --[no-]just-types                                           Plain types only (off by default)                          
 --module NAME                                               Generated module name                                      
 --array-type array|list                                     Use Array or List                                          

Options for Ruby

 --[no-]just-types                                           Plain types only (off by default)                          
 --strictness strict|coercible|none                          Type strictness                                            
 --namespace NAME                                            Specify a wrapping Namespace                               

Options for Dart

 --[no-]null-safety                                          Null Safety (on by default)                                
 --[no-]just-types                                           Types only (off by default)                                
 --[no-]coders-in-class                                      Put encoder & decoder in Class (off by default)            
 --[no-]from-map                                             Use method names fromMap() & toMap() (off by default)      
 --[no-]required-props                                       Make all properties required (off by default)              
 --[no-]final-props                                          Make all properties final (off by default)                 
 --[no-]copy-with                                            Generate CopyWith method (off by default)                  
 --[no-]use-freezed                                          Generate class definitions with @freezed compatibility     
                                                             (off by default)                                           
 --[no-]use-hive                                             Generate annotations for Hive type adapters (off by        
                                                             default)                                                   
 --[no-]use-json-annotation                                  Generate annotations for json_serializable (off by         
                                                             default)                                                   
 --part-name NAME                                            Use this name in `part` directive                          

Options for Python

 --python-version 3.5|3.6|3.7                                Python version                                             
 --[no-]just-types                                           Classes only (off by default)                              
 --[no-]nice-property-names                                  Transform property names to be Pythonic (on by default)    

Options for Haskell

 --[no-]just-types                                           Plain types only (off by default)                          
 --module NAME                                               Generated module name                                      
 --array-type array|list                                     Use Array or List                                          

Options for PHP

 --[no-]with-get                                             Create Getter (on by default)                              
 --[no-]fast-get                                             getter without validation (off by default)                 
 --[no-]with-set                                             Create Setter (off by default)                             
 --[no-]with-closing                                         PHP Closing Tag (off by default)                           
 --acronym-style original|pascal|camel|lowerCase             Acronym naming style                                       

Examples

  Generate C# to parse a Bitcoin API                                            
  $ quicktype -o LatestBlock.cs https://blockchain.info/latestblock             
                                                                                
  Generate Go code from a directory of samples containing:                      
    - Foo.json                                                                  
    + Bar                                                                       
      - bar-sample-1.json                                                       
      - bar-sample-2.json                                                       
    - Baz.url                                                                   
  $ quicktype -l go samples                                                     
                                                                                
  Generate JSON Schema, then TypeScript                                         
  $ quicktype -o schema.json https://blockchain.info/latestblock                
  $ quicktype -o bitcoin.ts --src-lang schema schema.json                       

  Learn more at quicktype.io
  ```
  
</details>