### PR TITLE
Fix cpp constraints

### DIFF
--- a/packages/quicktype-core/src/language/CPlusPlus/CPlusPlusRenderer.ts
+++ b/packages/quicktype-core/src/language/CPlusPlus/CPlusPlusRenderer.ts
@@ -932,21 +932,21 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
                 false
             );
 
-            // Explicitly comparing the minMax values to undefined here allows them to have the valid value of zero
+            // Check the minMax values for truthiness or if they're equal to zero, as zero is a valid value too
             res.set(jsonName, [
                 this.constraintMember(jsonName),
                 "(",
-                minMax?.[0] !== undefined && cppType === "int64_t" ? String(minMax[0]) : this._nulloptType,
+                (minMax?.[0] || minMax?.[0] === 0) && cppType === "int64_t" ? String(minMax[0]) : this._nulloptType,
                 ", ",
-                minMax?.[1] !== undefined && cppType === "int64_t" ? String(minMax[1]) : this._nulloptType,
+                (minMax?.[1] || minMax?.[1] === 0) && cppType === "int64_t" ? String(minMax[1]) : this._nulloptType,
                 ", ",
-                minMax?.[0] !== undefined && cppType === "double" ? String(minMax[0]) : this._nulloptType,
+                (minMax?.[0] || minMax?.[0] === 0) && cppType === "double" ? String(minMax[0]) : this._nulloptType,
                 ", ",
-                minMax?.[1] !== undefined && cppType === "double" ? String(minMax[1]) : this._nulloptType,
+                (minMax?.[1] || minMax?.[1] === 0) && cppType === "double" ? String(minMax[1]) : this._nulloptType,
                 ", ",
-                minMaxLength?.[0] !== undefined ? String(minMaxLength[0]) : this._nulloptType,
+                minMaxLength?.[0] || minMaxLength?.[0] === 0 ? String(minMaxLength[0]) : this._nulloptType,
                 ", ",
-                minMaxLength?.[1] !== undefined ? String(minMaxLength[1]) : this._nulloptType,
+                minMaxLength?.[1] || minMaxLength?.[1] === 0 ? String(minMaxLength[1]) : this._nulloptType,
                 ", ",
                 pattern === undefined
                     ? this._nulloptType

--- a/packages/quicktype-core/src/language/CPlusPlus/CPlusPlusRenderer.ts
+++ b/packages/quicktype-core/src/language/CPlusPlus/CPlusPlusRenderer.ts
@@ -926,23 +926,27 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
                 },
                 true,
                 false,
-                property.isOptional
+                // Since we're only generating this to compare types, whether its optional doesn't matter - we just
+                // need cppType() to spit out the actual underlying type, without wrapping it in the optional<>
+                // container.
+                false
             );
 
+            // Explicitly comparing the minMax values to undefined here allows them to have the valid value of zero
             res.set(jsonName, [
                 this.constraintMember(jsonName),
                 "(",
-                minMax?.[0] && cppType === "int64_t" ? String(minMax[0]) : this._nulloptType,
+                minMax?.[0] !== undefined && cppType === "int64_t" ? String(minMax[0]) : this._nulloptType,
                 ", ",
-                minMax?.[1] && cppType === "int64_t" ? String(minMax[1]) : this._nulloptType,
+                minMax?.[1] !== undefined && cppType === "int64_t" ? String(minMax[1]) : this._nulloptType,
                 ", ",
-                minMax?.[0] && cppType === "double" ? String(minMax[0]) : this._nulloptType,
+                minMax?.[0] !== undefined && cppType === "double" ? String(minMax[0]) : this._nulloptType,
                 ", ",
-                minMax?.[1] && cppType === "double" ? String(minMax[1]) : this._nulloptType,
+                minMax?.[1] !== undefined && cppType === "double" ? String(minMax[1]) : this._nulloptType,
                 ", ",
-                minMaxLength?.[0] ? String(minMaxLength[0]) : this._nulloptType,
+                minMaxLength?.[0] !== undefined ? String(minMaxLength[0]) : this._nulloptType,
                 ", ",
-                minMaxLength?.[1] ? String(minMaxLength[1]) : this._nulloptType,
+                minMaxLength?.[1] !== undefined ? String(minMaxLength[1]) : this._nulloptType,
                 ", ",
                 pattern === undefined
                     ? this._nulloptType


### PR DESCRIPTION
## Description

 - Fix code in CPlusPlusRenderer that was detecting the C++ type incorrectly, as it was doing it in a way where optional types will never have constraints applied. The code was assuming the `cppType` function would only return a single string, but when an optional value is provided it actually returns an array such as `[ 'std::optional', '<', 'int64_t', '>']`. Comparing that against a string will always fail, and whether or not it's optional doesn't actually matter in this case anyway as we're just using `cppType` to detect which kind of constraints to apply to the underlying type.

 - Fix code in CPlusPlusRenderer where constraints with a value of zero (such as a minimum value of 0) would not get applied because the code was just checking for truthiness. Code now checks for truthiness or if the value is explicitly zero, so null and undefined should still be excluded correctly. 

## Motivation and Context

Generating C++ code from a JSON schema that had constraints would generate code to handle the constraints, but set all the constraint values to null (thus bypassing them entirely). 

## Previous Behaviour / Output

Given this JSON Schema as input:

```json
{
  "$schema": "https://json-schema.org/draft/2020-12/schema",
  "$ref": "#/definitions/Test",
  "definitions": {
    "Test": {
      "type": "object",
      "additionalProperties": false,
      "properties": {
        "testProp": {
          "type": "number",
          "minimum": 0.0,
          "maximum": 1.0
        },
        "testPropInt": {
          "type": "integer",
          "minimum": 0,
          "maximum": 1
        },
        "testPropString": {
          "type": "string",
          "minLength": 0,
          "maxLength": 1
        }
      },
      "required": [
      ],
      "title": "Test"
    }
  }
}
```

Quicktype would generate the following C++ class initializer (details vary depending on settings, but the symptom is always the same):

```cpp
...
class Test {
    public:
    Test() :
        test_prop_constraint(boost::none, boost::none, boost::none, boost::none, boost::none, boost::none, boost::none),
        test_prop_int_constraint(boost::none, boost::none, boost::none, boost::none, boost::none, boost::none, boost::none),
        test_prop_string_constraint(boost::none, boost::none, boost::none, boost::none, boost::none, 1, boost::none)
    {}
...
```

Note how the constraint objects are initialized entirely with "none" values, or in the case of `test_prop_string_constraint` the 0 is ignored (in the string's case, a minimum length check of 0 isn't actually that useful, but it shows another hidden bug that I can't really demonstrate on the other types in the original code: that if a value of 0 is specified, it's ignored due to only checking for truthiness)

## New Behaviour / Output

Given the same input above, quicktype now generates the following:

```cpp
...
class Test {
    public:
    Test() :
        test_prop_constraint(boost::none, boost::none, 0, 1, boost::none, boost::none, boost::none),
        test_prop_int_constraint(0, 1, boost::none, boost::none, boost::none, boost::none, boost::none),
        test_prop_string_constraint(boost::none, boost::none, boost::none, boost::none, 0, 1, boost::none)
    {}
...
```

Note that the constraints are actually correctly filled out this time.

## How Has This Been Tested?

Tested using the above test schema, as well as the actual schema for my project (which I can't post publicly, sorry). 
