### PR TITLE
Getters for optional values in cpp should return a const reference

### DIFF
--- a/packages/quicktype-core/src/language/CPlusPlus/CPlusPlusRenderer.ts
+++ b/packages/quicktype-core/src/language/CPlusPlus/CPlusPlusRenderer.ts
@@ -1829,6 +1829,40 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
                 this.ensureBlankLine();
             }
         );
+
+        this.ensureBlankLine();
+
+        this.emitBlock(
+            [
+                "inline void ",
+                checkConst,
+                "(",
+                this._stringType.getConstType(),
+                " name, ",
+                this.withConst(classConstraint),
+                " & c, ",
+                "const ",
+                this._optionalType,
+                "<",
+                cppType,
+                "> & value)"
+            ],
+            false,
+            () => {
+                this.emitBlock(
+                    ["if (value)"],
+                    false,
+                    () => {
+                        this.emitLine(
+                            checkConst,
+                            "(name, c, *value);"
+                        );
+                    }
+                );
+                this.ensureBlankLine();
+            }
+        );
+
         this.ensureBlankLine();
     }
 
@@ -1918,7 +1952,12 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
         }
 
         const checkConst = this.lookupGlobalName(GlobalNames.CheckConstraint);
-        this.emitNumericCheckConstraints(checkConst, classConstraint, getterMinIntValue, getterMaxIntValue, "int64_t");
+        this.emitNumericCheckConstraints(
+            checkConst, 
+            classConstraint, 
+            getterMinIntValue, 
+            getterMaxIntValue, 
+            "int64_t");
         this.emitNumericCheckConstraints(
             checkConst,
             classConstraint,
@@ -2034,6 +2073,39 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
                         );
                     });
                 });
+                this.ensureBlankLine();
+            }
+        );
+
+        this.ensureBlankLine();
+
+        this.emitBlock(
+            [
+                "inline void ",
+                checkConst,
+                "(",
+                this._stringType.getConstType(),
+                " name, ",
+                this.withConst(classConstraint),
+                " & c, ",
+                "const ",
+                this._optionalType,
+                "<",
+                this._stringType.getType(),
+                ">& value)"
+            ],
+            false,
+            () => {
+                this.emitBlock(
+                    ["if (value)"],
+                    false,
+                    () => {
+                        this.emitLine(
+                            checkConst,
+                            "(name, c, *value);"
+                        );
+                    }
+                );
                 this.ensureBlankLine();
             }
         );

--- a/packages/quicktype-core/src/language/CPlusPlus/CPlusPlusRenderer.ts
+++ b/packages/quicktype-core/src/language/CPlusPlus/CPlusPlusRenderer.ts
@@ -848,7 +848,7 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
                  * a member called 'value' value = value will screw up the compiler
                  */
                 const checkConst = this.lookupGlobalName(GlobalNames.CheckConstraint);
-                if (property.type instanceof UnionType && property.type.findMember("null") !== undefined)  {
+                if (property.type instanceof UnionType && property.type.findMember("null") !== undefined) {
                     this.emitLine(rendered, " ", getterName, "() const { return ", name, "; }");
                     if (constraints?.has(jsonName)) {
                         this.emitLine(

--- a/packages/quicktype-core/src/language/CPlusPlus/CPlusPlusRenderer.ts
+++ b/packages/quicktype-core/src/language/CPlusPlus/CPlusPlusRenderer.ts
@@ -1953,10 +1953,10 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
 
         const checkConst = this.lookupGlobalName(GlobalNames.CheckConstraint);
         this.emitNumericCheckConstraints(
-            checkConst, 
-            classConstraint, 
-            getterMinIntValue, 
-            getterMaxIntValue, 
+            checkConst,
+            classConstraint,
+            getterMinIntValue,
+            getterMaxIntValue,
             "int64_t");
         this.emitNumericCheckConstraints(
             checkConst,

--- a/packages/quicktype-core/src/language/CPlusPlus/CPlusPlusRenderer.ts
+++ b/packages/quicktype-core/src/language/CPlusPlus/CPlusPlusRenderer.ts
@@ -848,7 +848,7 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
                  * a member called 'value' value = value will screw up the compiler
                  */
                 const checkConst = this.lookupGlobalName(GlobalNames.CheckConstraint);
-                if (property.type instanceof UnionType && property.type.findMember("null") !== undefined) {
+                if (property.type instanceof UnionType && property.type.findMember("null") !== undefined)  {
                     this.emitLine(rendered, " ", getterName, "() const { return ", name, "; }");
                     if (constraints?.has(jsonName)) {
                         this.emitLine(

--- a/packages/quicktype-core/src/language/CPlusPlus/CPlusPlusRenderer.ts
+++ b/packages/quicktype-core/src/language/CPlusPlus/CPlusPlusRenderer.ts
@@ -848,10 +848,7 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
                  * a member called 'value' value = value will screw up the compiler
                  */
                 const checkConst = this.lookupGlobalName(GlobalNames.CheckConstraint);
-                if (
-                    (property.type instanceof UnionType && property.type.findMember("null") !== undefined) ||
-                    (property.isOptional && property.type.kind !== "null" && property.type.kind !== "any")
-                ) {
+                if (property.type instanceof UnionType && property.type.findMember("null") !== undefined) {
                     this.emitLine(rendered, " ", getterName, "() const { return ", name, "; }");
                     if (constraints?.has(jsonName)) {
                         this.emitLine(


### PR DESCRIPTION
**Overview**
Fixes #2674.  I can't entirely confirm that it doesn't have some unintended side effects, but this does fix the return type of optional values.

**Test file:**
`{
  "$schema": "http://json-schema.org/draft-06/schema#",
  "$ref": "#/definitions/foo",
  "definitions": {
    "coordinate": {
      "type": "object",
      "required": [
          "latitude",
          "longitude"
      ],
      "additionalProperties": false,
      "properties":
      {
        "latitude": {
          "type": "integer",
          "minimum": 0,
          "maximum": 999999
        },
        "longitude": {
          "type": "number",
          "minimum": 0,
          "maximum": 999999
        },
        "baz": {
          "type": "string",
          "minLength": 0,
          "maxLength": 999,
          "pattern": "*"
        }
      }
    },
    "coordinates": {
      "type": "array",
      "items": {
          "$ref": "#/definitions/coordinate"
      }
    },
    "foo": {
      "type": "object",
       "required": [
       ],
       "additionalProperties": false,
       "properties": 
       {
         "coordinates": {
           "$ref": "#/definitions/coordinates"
         },
         "bar" : {
           "type": "number"
         }
      }
    }
  }
}
`

**Diff of generated file changes:**
![Screenshot from 2025-01-16 09-53-48](https://github.com/user-attachments/assets/4c1491a8-1655-46f8-919c-86fb35481aee)
![Screenshot from 2025-01-16 09-55-05](https://github.com/user-attachments/assets/2fbbe707-d89d-496d-bc5c-bace80c19847)

