### PR TITLE
Fix: throw error for undefined enum for both small and large enum in C++

### DIFF
--- a/packages/quicktype-core/src/language/CPlusPlus/CPlusPlusRenderer.ts
+++ b/packages/quicktype-core/src/language/CPlusPlus/CPlusPlusRenderer.ts
@@ -1986,10 +1986,10 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
                         );
                         onFirst = false;
                     });
-                    this.emitLine(
-                        'else { throw std::runtime_error("Input JSON does not conform to schema!"); }',
-                    );
                 }
+                this.emitLine(
+                    'else { throw std::runtime_error("Input JSON does not conform to schema!"); }',
+                );
             },
         );
         this.ensureBlankLine();

--- a/test/inputs/schema/enum-large.1.fail.enum.json
+++ b/test/inputs/schema/enum-large.1.fail.enum.json
@@ -1,0 +1,4 @@
+{
+  "callsign": "zulu",
+  "priority": "low"
+}

--- a/test/inputs/schema/enum-large.1.json
+++ b/test/inputs/schema/enum-large.1.json
@@ -1,0 +1,4 @@
+{
+  "callsign": "alpha",
+  "priority": "low"
+}

--- a/test/inputs/schema/enum-large.2.fail.enum.json
+++ b/test/inputs/schema/enum-large.2.fail.enum.json
@@ -1,0 +1,4 @@
+{
+  "callsign": "alpha",
+  "priority": "urgent"
+}

--- a/test/inputs/schema/enum-large.2.json
+++ b/test/inputs/schema/enum-large.2.json
@@ -1,0 +1,4 @@
+{
+  "callsign": "november",
+  "priority": "medium"
+}

--- a/test/inputs/schema/enum-large.3.json
+++ b/test/inputs/schema/enum-large.3.json
@@ -1,0 +1,4 @@
+{
+  "callsign": "tango",
+  "priority": "high"
+}

--- a/test/inputs/schema/enum-large.schema
+++ b/test/inputs/schema/enum-large.schema
@@ -1,0 +1,35 @@
+{
+  "type": "object",
+  "properties": {
+    "callsign": {
+      "type": "string",
+      "enum": [
+        "alpha",
+        "bravo",
+        "charlie",
+        "delta",
+        "echo",
+        "foxtrot",
+        "golf",
+        "hotel",
+        "india",
+        "juliett",
+        "kilo",
+        "lima",
+        "mike",
+        "november",
+        "oscar",
+        "papa",
+        "quebec",
+        "romeo",
+        "sierra",
+        "tango"
+      ]
+    },
+    "priority": {
+      "type": "string",
+      "enum": ["low", "medium", "high"]
+    }
+  },
+  "required": ["callsign", "priority"]
+}

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -293,6 +293,7 @@ export const CrystalLanguage: Language = {
     skipSchema: [
         // Crystal does not handle enum mapping
         "enum.schema",
+        "enum-large.schema",
         // Crystal does not support top-level primitives
         "top-level-enum.schema",
         "keyword-unions.schema",
@@ -505,6 +506,7 @@ export const CJSONLanguage: Language = {
         "integer-float-union.schema",
         /* Enum with invalid values are not checked (for the current implementation, can be added later, should abord parsing and return NULL) */
         "enum.schema",
+        "enum-large.schema",
         /* Union, Map and Arrays with invalid types are not checked (for the current implementation, can be added later, should abord parsing and return NULL) */
         "class-with-additional.schema",
         "go-schema-pattern-properties.schema",
@@ -737,6 +739,7 @@ export const SwiftLanguage: Language = {
         "intersection.schema",
         "go-schema-pattern-properties.schema",
         "enum.schema",
+        "enum-large.schema",
         "date-time.schema",
         "class-with-additional.schema",
         "class-map-union.schema",
@@ -1001,6 +1004,7 @@ I havea no idea how to encode these tests correctly.
         "implicit-one-of.schema",
         "go-schema-pattern-properties.schema",
         "enum.schema",
+        "enum-large.schema",
         "class-with-additional.schema",
         "class-map-union.schema",
         "keyword-unions.schema",
@@ -1278,6 +1282,7 @@ export const DartLanguage: Language = {
     skipSchema: [
         "enum-with-null.schema",
         "enum.schema",
+        "enum-large.schema",
         "bool-string.schema",
         "intersection.schema",
         "keyword-enum.schema",
@@ -1424,6 +1429,7 @@ export const HaskellLanguage: Language = {
         "class-map-union.schema",
         "direct-union.schema",
         "enum.schema",
+        "enum-large.schema",
         "go-schema-pattern-properties.schema",
         "implicit-class-array-union.schema",
         "intersection.schema",
@@ -1560,6 +1566,7 @@ export const TypeScriptZodLanguage: Language = {
         "class-map-union.schema",
         "direct-union.schema",
         "enum.schema",
+        "enum-large.schema",
         "go-schema-pattern-properties.schema",
         "implicit-class-array-union.schema",
         "intersection.schema",
@@ -1676,6 +1683,7 @@ export const TypeScriptEffectSchemaLanguage: Language = {
         "class-map-union.schema",
         "direct-union.schema",
         "enum.schema",
+        "enum-large.schema",
         "go-schema-pattern-properties.schema",
         "implicit-class-array-union.schema",
         "intersection.schema",


### PR DESCRIPTION
Current version throws for an unknown enum if the enum is considered small and handled with if-else
```
    inline void from_json(const json & j, Extrasystole & x) {
        if (j == "coupled_pvc") x = Extrasystole::CoupledPvc;
         ...
        else { throw std::runtime_error("Input JSON does not conform to schema!"); }
```

For a large enum implemented with map, the throw is missing
```
    inline void from_json(const json & j, BasicRhythm & x) {
        static std::unordered_map<std::string, BasicRhythm> enumValues {
            {"sinus", BasicRhythm::Sinus},
            ...
        };
        auto iter = enumValues.find(j.get<std::string>());
        if (iter != enumValues.end()) {
            x = iter->second;
        }
}
```
resulting in the property being a valid value which is inconsistent with the json.

This change adds the throw at the end of the large enum.
```
        ....
        if (iter != enumValues.end()) {
            x = iter->second;
        }
        else { throw std::runtime_error("Input JSON does not conform to schema!"); }
```
