### PR TITLE
Fix C++ constraints for optional properties and zero-valued bounds

### DIFF
--- a/packages/quicktype-core/src/language/CPlusPlus/CPlusPlusRenderer.ts
+++ b/packages/quicktype-core/src/language/CPlusPlus/CPlusPlusRenderer.ts
@@ -1108,6 +1108,10 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
             const { minMax, minMaxLength, pattern } = constraints;
 
             // TODO is there a better way to check if property.type is an integer or a number?
+            // We only generate this to classify the underlying type, so we
+            // always pass `false` for `isOptional` — otherwise `cppType`
+            // wraps the type in the optional<> container and the comparisons
+            // below never match.
             const cppType = this.cppType(
                 property.type,
                 {
@@ -1117,31 +1121,37 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
                 },
                 true,
                 false,
-                property.isOptional,
+                false,
             );
 
+            // Compare bounds against `undefined` explicitly, since 0 is a
+            // valid constraint value too.
             res.set(jsonName, [
                 this.constraintMember(jsonName),
                 "(",
-                minMax?.[0] && cppType === "int64_t"
+                minMax?.[0] !== undefined && cppType === "int64_t"
                     ? String(minMax[0])
                     : this._nulloptType,
                 ", ",
-                minMax?.[1] && cppType === "int64_t"
+                minMax?.[1] !== undefined && cppType === "int64_t"
                     ? String(minMax[1])
                     : this._nulloptType,
                 ", ",
-                minMax?.[0] && cppType === "double"
+                minMax?.[0] !== undefined && cppType === "double"
                     ? String(minMax[0])
                     : this._nulloptType,
                 ", ",
-                minMax?.[1] && cppType === "double"
+                minMax?.[1] !== undefined && cppType === "double"
                     ? String(minMax[1])
                     : this._nulloptType,
                 ", ",
-                minMaxLength?.[0] ? String(minMaxLength[0]) : this._nulloptType,
+                minMaxLength?.[0] !== undefined
+                    ? String(minMaxLength[0])
+                    : this._nulloptType,
                 ", ",
-                minMaxLength?.[1] ? String(minMaxLength[1]) : this._nulloptType,
+                minMaxLength?.[1] !== undefined
+                    ? String(minMaxLength[1])
+                    : this._nulloptType,
                 ", ",
                 pattern === undefined
                     ? this._nulloptType

--- a/test/inputs/schema/optional-constraints.1.fail.minmax.json
+++ b/test/inputs/schema/optional-constraints.1.fail.minmax.json
@@ -1,0 +1,4 @@
+{
+  "reqZeroMin": 0,
+  "optInt": -1
+}

--- a/test/inputs/schema/optional-constraints.1.fail.minmaxlength.json
+++ b/test/inputs/schema/optional-constraints.1.fail.minmaxlength.json
@@ -1,0 +1,4 @@
+{
+  "reqZeroMin": 0,
+  "optString": "ab"
+}

--- a/test/inputs/schema/optional-constraints.1.fail.pattern.json
+++ b/test/inputs/schema/optional-constraints.1.fail.pattern.json
@@ -1,0 +1,4 @@
+{
+  "reqZeroMin": 0,
+  "optPattern": "ABC"
+}

--- a/test/inputs/schema/optional-constraints.1.json
+++ b/test/inputs/schema/optional-constraints.1.json
@@ -1,0 +1,7 @@
+{
+  "reqZeroMin": 0,
+  "optInt": 0,
+  "optDouble": 0.5,
+  "optString": "abc",
+  "optPattern": "abc"
+}

--- a/test/inputs/schema/optional-constraints.2.fail.minmax.json
+++ b/test/inputs/schema/optional-constraints.2.fail.minmax.json
@@ -1,0 +1,3 @@
+{
+  "reqZeroMin": -1
+}

--- a/test/inputs/schema/optional-constraints.2.json
+++ b/test/inputs/schema/optional-constraints.2.json
@@ -1,0 +1,3 @@
+{
+  "reqZeroMin": 50
+}

--- a/test/inputs/schema/optional-constraints.3.fail.minmax.json
+++ b/test/inputs/schema/optional-constraints.3.fail.minmax.json
@@ -1,0 +1,4 @@
+{
+  "reqZeroMin": 0,
+  "optDouble": 200.5
+}

--- a/test/inputs/schema/optional-constraints.schema
+++ b/test/inputs/schema/optional-constraints.schema
@@ -1,0 +1,30 @@
+{
+  "type": "object",
+  "properties": {
+    "reqZeroMin": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 100
+    },
+    "optInt": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 100
+    },
+    "optDouble": {
+      "type": "number",
+      "minimum": 0.5,
+      "maximum": 99.5
+    },
+    "optString": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 10
+    },
+    "optPattern": {
+      "type": "string",
+      "pattern": "^[a-z]+$"
+    }
+  },
+  "required": ["reqZeroMin"]
+}

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -514,6 +514,7 @@ export const CJSONLanguage: Language = {
         /* Constraints (min/max and regex) are not supported (for the current implementation, can be added later, should abord parsing and return NULL) */
         "minmaxlength.schema",
         "minmax.schema",
+        "optional-constraints.schema",
         "pattern.schema",
         /* Required properties absent are not checked (for the current implementation, can be added later, should abord parsing and return NULL) */
         "intersection.schema",

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -514,6 +514,7 @@ export const CJSONLanguage: Language = {
         /* Constraints (min/max and regex) are not supported (for the current implementation, can be added later, should abord parsing and return NULL) */
         "minmaxlength.schema",
         "minmax.schema",
+        /* Same unsupported min/max, length and regex constraints, applied to optional properties */
         "optional-constraints.schema",
         "pattern.schema",
         /* Required properties absent are not checked (for the current implementation, can be added later, should abord parsing and return NULL) */


### PR DESCRIPTION
Supersedes #2614 by @PMLavigne — that PR is correct but has rotted (the C++ renderer file was reformatted since, so it conflicts). This re-ports the same two fixes onto current master, credits Patrick via a `Co-authored-by` trailer, and adds the test coverage the original PR was missing.

## The bugs

Both are in `generateClassConstraints` in `packages/quicktype-core/src/language/CPlusPlus/CPlusPlusRenderer.ts`:

1. **Optional properties never get numeric constraints.** The code classifies a property's type by comparing `this.cppType(..., property.isOptional)` against the strings `"int64_t"` / `"double"`. For optional properties `cppType` returns a Sourcelike *array* (`[optionalType, "<", type, ">"]`), so the `===` string comparison always fails and `minimum`/`maximum` constraints on optional properties are silently dropped. Fix: pass `false` for `isOptional` — the call is only used to classify the underlying type. (String `minLength`/`maxLength`/`pattern` constraints were unaffected, since those branches don't consult `cppType`.)

2. **A bound of `0` is dropped, even on required properties.** Bounds were tested for truthiness (`minMax?.[0] && ...`), so `"minimum": 0` never made it into the generated code. Fix: explicit `!== undefined` checks.

## Before / after

For this schema:

```json
{
  "type": "object",
  "properties": {
    "reqZeroMin": { "type": "integer", "minimum": 0, "maximum": 100 },
    "optInt":     { "type": "integer", "minimum": 0, "maximum": 100 },
    "optDouble":  { "type": "number",  "minimum": 0.5, "maximum": 99.5 }
  },
  "required": ["reqZeroMin"]
}
```

generated constraint initializers on master (**before**):

```cpp
opt_double_constraint(boost::none, boost::none, boost::none, boost::none, boost::none, boost::none, boost::none),
opt_int_constraint(boost::none, boost::none, boost::none, boost::none, boost::none, boost::none, boost::none),
req_zero_min_constraint(boost::none, 100, boost::none, boost::none, boost::none, boost::none, boost::none)
```

**after** this PR:

```cpp
opt_double_constraint(boost::none, boost::none, 0.5, 99.5, boost::none, boost::none, boost::none),
opt_int_constraint(0, 100, boost::none, boost::none, boost::none, boost::none, boost::none),
req_zero_min_constraint(0, 100, boost::none, boost::none, boost::none, boost::none, boost::none)
```

Runtime behavior (compiled the generated code and fed it out-of-range inputs):

| input | master | this PR |
|---|---|---|
| `{"reqZeroMin": 0, "optInt": -1}` | accepted (wrong) | `Value too low for opt_int (-1<0)` |
| `{"reqZeroMin": -1}` | accepted (wrong) | `Value too low for req_zero_min (-1<0)` |
| `{"reqZeroMin": 0, "optDouble": 200.5}` | accepted (wrong) | `Value too high for opt_double (200.500000>99.500000)` |
| valid samples incl. boundary values `0` / `0.5` | accepted | accepted |

## Tests

This repo's test infrastructure for generated code is the language-fixture roundtrip in `test/`, so the test is a new JSON Schema fixture, added in its own commit *before* the fix: `test/inputs/schema/optional-constraints.schema` with a required `minimum: 0` integer (control for bug 2) and optional constrained integer / number / string-length / pattern properties, plus:

- valid samples `optional-constraints.1.json` (all properties at in-range/boundary values) and `.2.json` (optionals absent),
- `*.fail.minmax.json` samples violating the optional-int minimum, the required zero minimum, and the optional-double maximum — **on unpatched master the generated C++ accepts all three**, so the `cplusplus` schema fixture fails; with the fix it correctly rejects them,
- `*.fail.minmaxlength.json` / `*.fail.pattern.json` samples as regression coverage (these already passed on master).

The fail samples are feature-gated (`minmax`/`minmaxlength`/`pattern`), which only C++ and CJSON declare; the schema is added to CJSON's `skipSchema` alongside `minmax.schema` etc., since CJSON doesn't implement constraint checking. No other language runs the fail samples.

## Verified locally

- Demonstrated the bug on unpatched master and the fix after: generated C++ (`--lang c++`, both default/boost and `--no-boost`), compiled the `--no-boost` variant with `g++ 13 -std=c++17` (nlohmann/json v3.11.3), and ran all seven samples through a parse-and-reserialize runner — results in the table above; all five fail samples now throw, both valid samples still roundtrip.
- The boost variant was generated and inspected (identical apart from `boost::none` vs `std::nullopt`) but not compiled locally (no boost headers on this machine); CI's cplusplus fixture exercises it.
- `npx tsc --noEmit -p packages/quicktype-core` — clean; `npx tsc --noEmit -p test` — clean.
- `npx biome check`/`format` on the touched file — no new diagnostics (11 pre-existing lint findings, unchanged) and no formatting changes.

No package versions were bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)