### PR TITLE
C++: return optional getters by const reference

### DIFF
--- a/packages/quicktype-core/src/language/CPlusPlus/CPlusPlusRenderer.ts
+++ b/packages/quicktype-core/src/language/CPlusPlus/CPlusPlusRenderer.ts
@@ -1006,11 +1006,8 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
                     GlobalNames.CheckConstraint,
                 );
                 if (
-                    (property.type instanceof UnionType &&
-                        property.type.findMember("null") !== undefined) ||
-                    (property.isOptional &&
-                        property.type.kind !== "null" &&
-                        property.type.kind !== "any")
+                    property.type instanceof UnionType &&
+                    property.type.findMember("null") !== undefined
                 ) {
                     this.emitLine(
                         rendered,
@@ -2311,6 +2308,29 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
             },
         );
         this.ensureBlankLine();
+
+        this.emitBlock(
+            [
+                "inline void ",
+                checkConst,
+                "(",
+                this._stringType.getConstType(),
+                " name, ",
+                this.withConst(classConstraint),
+                " & c, const ",
+                this._optionalType,
+                "<",
+                cppType,
+                "> & value)",
+            ],
+            false,
+            () => {
+                this.emitBlock(["if (value)"], false, () => {
+                    this.emitLine(checkConst, "(name, c, *value);");
+                });
+            },
+        );
+        this.ensureBlankLine();
     }
 
     protected emitConstraintClasses(): void {
@@ -2588,6 +2608,29 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
                     },
                 );
                 this.ensureBlankLine();
+            },
+        );
+        this.ensureBlankLine();
+
+        this.emitBlock(
+            [
+                "inline void ",
+                checkConst,
+                "(",
+                this._stringType.getConstType(),
+                " name, ",
+                this.withConst(classConstraint),
+                " & c, const ",
+                this._optionalType,
+                "<",
+                this._stringType.getType(),
+                "> & value)",
+            ],
+            false,
+            () => {
+                this.emitBlock(["if (value)"], false, () => {
+                    this.emitLine(checkConst, "(name, c, *value);");
+                });
             },
         );
     }

--- a/test/inputs/schema/optional-const-ref.1.fail.minmax.json
+++ b/test/inputs/schema/optional-const-ref.1.fail.minmax.json
@@ -1,0 +1,13 @@
+{
+  "coordinates": [
+    { "latitude": 34.5, "longitude": -12.25 }
+  ],
+  "requiredCoordinates": [
+    { "latitude": 48.5, "longitude": 16.25 }
+  ],
+  "count": 42,
+  "requiredCount": 0,
+  "weight": 63.5,
+  "label": "optional",
+  "requiredLabel": "required"
+}

--- a/test/inputs/schema/optional-const-ref.1.fail.minmaxlength.json
+++ b/test/inputs/schema/optional-const-ref.1.fail.minmaxlength.json
@@ -1,0 +1,13 @@
+{
+  "coordinates": [
+    { "latitude": 34.5, "longitude": -12.25 }
+  ],
+  "requiredCoordinates": [
+    { "latitude": 48.5, "longitude": 16.25 }
+  ],
+  "count": 42,
+  "requiredCount": 7,
+  "weight": 63.5,
+  "label": "optional",
+  "requiredLabel": "x"
+}

--- a/test/inputs/schema/optional-const-ref.1.json
+++ b/test/inputs/schema/optional-const-ref.1.json
@@ -1,0 +1,14 @@
+{
+  "coordinates": [
+    { "latitude": 34.5, "longitude": -12.25 },
+    { "latitude": -7.75, "longitude": 100.5 }
+  ],
+  "requiredCoordinates": [
+    { "latitude": 48.5, "longitude": 16.25 }
+  ],
+  "count": 42,
+  "requiredCount": 7,
+  "weight": 63.5,
+  "label": "optional",
+  "requiredLabel": "required"
+}

--- a/test/inputs/schema/optional-const-ref.2.fail.minmaxlength.json
+++ b/test/inputs/schema/optional-const-ref.2.fail.minmaxlength.json
@@ -1,0 +1,8 @@
+{
+  "requiredCoordinates": [
+    { "latitude": 48.5, "longitude": 16.25 }
+  ],
+  "requiredCount": 7,
+  "requiredLabel": "required",
+  "label": "x"
+}

--- a/test/inputs/schema/optional-const-ref.2.json
+++ b/test/inputs/schema/optional-const-ref.2.json
@@ -1,0 +1,7 @@
+{
+  "requiredCoordinates": [
+    { "latitude": 48.5, "longitude": 16.25 }
+  ],
+  "requiredCount": 7,
+  "requiredLabel": "required"
+}

--- a/test/inputs/schema/optional-const-ref.schema
+++ b/test/inputs/schema/optional-const-ref.schema
@@ -1,0 +1,63 @@
+{
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$ref": "#/definitions/TopLevel",
+  "definitions": {
+    "Coordinate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["latitude", "longitude"],
+      "properties": {
+        "latitude": {
+          "type": "number"
+        },
+        "longitude": {
+          "type": "number"
+        }
+      }
+    },
+    "TopLevel": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["requiredCoordinates", "requiredCount", "requiredLabel"],
+      "properties": {
+        "coordinates": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Coordinate"
+          }
+        },
+        "requiredCoordinates": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Coordinate"
+          }
+        },
+        "count": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100
+        },
+        "requiredCount": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100
+        },
+        "weight": {
+          "type": "number",
+          "minimum": 0.5,
+          "maximum": 99.5
+        },
+        "label": {
+          "type": "string",
+          "minLength": 2,
+          "maxLength": 16
+        },
+        "requiredLabel": {
+          "type": "string",
+          "minLength": 2,
+          "maxLength": 16
+        }
+      }
+    }
+  }
+}

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -514,6 +514,7 @@ export const CJSONLanguage: Language = {
         /* Constraints (min/max and regex) are not supported (for the current implementation, can be added later, should abord parsing and return NULL) */
         "minmaxlength.schema",
         "minmax.schema",
+        "optional-const-ref.schema",
         "pattern.schema",
         /* Required properties absent are not checked (for the current implementation, can be added later, should abord parsing and return NULL) */
         "intersection.schema",

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1292,6 +1292,9 @@ export const DartLanguage: Language = {
         "keyword-unions.schema",
         "ref-remote.schema",
         "uuid.schema",
+        /* Absent optional lists don't round-trip: the generated fromJson/toJson
+           turn them into [], so the output no longer matches the input */
+        "optional-const-ref.schema",
     ],
     skipMiscJSON: true,
     rendererOptions: {},


### PR DESCRIPTION
Fixes #2674. Supersedes #2675 — this is a re-port of @flounderpinto's correct fix onto current master (the original only conflicted because the renderer was since reformatted), with tests added. @flounderpinto is credited as co-author on the fix commit.

## The bug

In generated C++, getters for **optional** properties returned the `std::optional` / `boost::optional` **by value**, inconsistently with required properties, which return `const T &`:

```cpp
// before
boost::optional<std::vector<Coordinate>> get_coordinates() const { return coordinates; }
void set_coordinates(boost::optional<std::vector<Coordinate>> value) { this->coordinates = value; }
```

That makes natural user code undefined behavior or a silent no-op:

- `const auto &coords = *obj.get_coordinates(); for (auto &c : coords) ...` binds a reference into a **temporary** that is destroyed at the end of the full-expression. Verified on generated code with `g++ -std=c++17 -fsanitize=address`: **AddressSanitizer reports stack-use-after-scope**.
- `obj.get_coordinates()->clear();` compiles and **silently mutates the temporary** — the object is unchanged (verified: size stayed 2 after clearing).

## The fix

Optional properties now get the same accessors as required ones:

```cpp
// after
const boost::optional<std::vector<Coordinate>> & get_coordinates() const { return coordinates; }
boost::optional<std::vector<Coordinate>> & get_mutable_coordinates() { return coordinates; }
void set_coordinates(const boost::optional<std::vector<Coordinate>> & value) { this->coordinates = value; }
```

which is exactly the output #2674 asks for. Explicitly *nullable-union* properties (`anyOf: [T, null]`) conservatively keep the old by-value accessors, as in the original PR.

Since the const-reference setter now passes the whole optional to `CheckConstraint`, the generator also emits `CheckConstraint` overloads taking `const optional<T> &` for the numeric (`int64_t`, `double`) and string checkers, forwarding to the underlying checker when the value is set. **Without these overloads, any schema with constraints on an optional number/string property would generate non-compiling C++.** They work for both `std::optional` and `boost::optional` and for `--wstring`.

## Generated-API change (downstream impact)

The getter signature for optional properties changes from `optional<T>` to `const optional<T> &`. Code that relied on mutating the returned **temporary** (e.g. `obj.get_x().value() = y;`, `std::move(*obj.get_x())`) no longer compiles or changes meaning; that code was already broken (it never affected the object). Use the new `get_mutable_x()` for in-place mutation. The setter now takes `const optional<T> &` instead of by-value, which is source-compatible for callers.

## Tests

New schema fixture `test/inputs/schema/optional-const-ref.schema` (runs through all languages in CI): optional array-of-objects, optional constrained integer/number/string, plus required counterparts, modeled on the issue's repro. Samples:

- `*.1.json` — all optionals present (roundtrip)
- `*.2.json` — all optionals absent (roundtrip)
- `*.1.fail.minmax.json` / `*.1.fail.minmaxlength.json` — violate constraints on **required** properties
- `*.2.fail.minmaxlength.json` — violates the length constraint on the **optional** string, so CI exercises constraint enforcement through the new `CheckConstraint(const optional<T> &)` overload path

The schema is added to CJSON's `skipSchema` (CJSON declares the constraint features but doesn't implement enforcement, same as the existing `minmax.schema` skips).

Note on the interaction with the `generateClassConstraints` bug (being fixed separately, re-port of #2614): on current master, constraint *values* for optional **numeric** properties come out as all-`nullopt`, so their enforcement can't be asserted yet — the fail fixtures therefore only rely on required-property constraints and the optional **string** constraint, which is unaffected. Once the #2614 re-port lands, optional numeric constraints will be enforced through the overloads added here with no further changes.

## Verified locally

- Before/after generation from the new fixture: by-value getters before; `const optional<T> &` getter + `get_mutable_*` + const-ref setter after, for both `boost::optional` (default) and `std::optional` (`--boost false`).
- Bug demo compiled against nlohmann/json with `g++ -O0 -std=c++17 -fsanitize=address` on unpatched master: mutation-through-getter silently lost, ASan stack-use-after-scope on reference-through-getter.
- After the fix, a behavior program (ASan clean) verified: reference stability of the getter, persistent mutation via `get_mutable_*`, JSON roundtrip with optionals present and absent, `ValueTooShortException` thrown through the optional-string setter, `ValueTooLowException` through the required-int setter, and `set_label(std::nullopt)` not throwing.
- Harness-equivalent run (same `main.cpp`, same `deepEquals` comparison as `test/fixtures.ts`) for both good samples and all three fail samples, with **both** `boost::optional` and `std::optional`.
- Regression: regenerated + compiled (`g++ -fsyntax-only -std=c++17`) 11 existing fixtures (`mutually-recursive`, `enum-with-null`, `union`, `minmax`, `minmaxlength`, `pattern`, `optional-any`, `class-map-union`, `required`, `accessors`, `implicit-one-of`) and roundtrip-ran `minmax`, `minmaxlength`, `pattern`, `optional-any`, `mutually-recursive` samples successfully.
- `npx tsc --noEmit -p packages/quicktype-core` passes; `biome check` on the touched file reports exactly the same pre-existing findings as master (no new ones).

Known gap: `--wstring` combined with `--boost false` and an optional string property doesn't compile on master **before or after** this change (the generated `Utf16_Utf8` converter has no `optional` overload) — pre-existing and untouched here; CI only compiles schema fixtures with default options.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
