### PR TITLE
Centralize clustered skipSchema entries into reason-named lists

### DIFF
--- a/test/languages.ts
+++ b/test/languages.ts
@@ -11,6 +11,41 @@ const easySampleJSONs = [
     "getting-started.json",
 ];
 
+// Shared `skipSchema` lists for failure modes that many languages have in
+// common.  Spread these into a language's `skipSchema` instead of repeating
+// the individual entries.  When a new test schema hits one of these failure
+// modes, add it to the shared list so every affected language skips it at
+// once.
+
+// The generated code does not reject invalid enum values, so the
+// `.fail.enum.json` samples for these enum-bearing schemas do not fail as
+// expected.  Add any new schema whose fail sample relies on enum-value
+// rejection.
+const skipsEnumValueValidation = [
+    "enum.schema",
+    "enum-large.schema",
+    "optional-enum.schema",
+];
+
+// The language makes no int/double distinction in unions (e.g. an integer is
+// implicitly accepted where a float union member is expected), so fail
+// samples that rely on rejecting an int where a double is expected (or vice
+// versa) do not fail.  Add any new schema whose fail sample relies on the
+// int/float distinction.
+const skipsIntFloatUnions = [
+    "integer-float-union.schema",
+    "minmax.schema",
+    "union-int-double.schema",
+];
+
+// Untyped unions are unsupported: class|map unions and implicit class|array
+// unions either don't compile or don't fail on the expected-failure samples.
+// Add any new schema that relies on such unions.
+const skipsUntypedUnions = [
+    "class-map-union.schema",
+    "implicit-class-array-union.schema",
+];
+
 export type LanguageFeature =
     | "enum"
     | "union"
@@ -303,9 +338,7 @@ export const CrystalLanguage: Language = {
     ],
     skipSchema: [
         // Crystal does not handle enum mapping
-        "enum.schema",
-        "enum-large.schema",
-        "optional-enum.schema",
+        ...skipsEnumValueValidation,
         // Crystal does not support top-level primitives
         "top-level-enum.schema",
         "keyword-unions.schema",
@@ -514,22 +547,16 @@ export const CJSONLanguage: Language = {
         "vega-lite.schema",
         /* Enum as TopLevel is not supported */
         "top-level-enum.schema",
-        /* Union with Number and Integer are not supported */
-        "integer-float-union.schema",
-        "union-int-double.schema",
+        /* Union with Number and Integer are not supported; min/max constraints on numbers rely on the same distinction */
+        ...skipsIntFloatUnions,
         /* Enum with invalid values are not checked (for the current implementation, can be added later, should abord parsing and return NULL) */
-        "enum.schema",
-        "enum-large.schema",
-        "optional-enum.schema",
+        ...skipsEnumValueValidation,
         /* Union, Map and Arrays with invalid types are not checked (for the current implementation, can be added later, should abord parsing and return NULL) */
         "class-with-additional.schema",
         "go-schema-pattern-properties.schema",
         "multi-type-enum.schema",
-        /* Class elements with invalid type are not checked (for the current implementation, can be added later, should abord parsing and return NULL) */
-        "class-map-union.schema",
         /* Constraints (min/max and regex) are not supported (for the current implementation, can be added later, should abord parsing and return NULL) */
         "minmaxlength.schema",
-        "minmax.schema",
         "optional-const-ref.schema",
         /* Same unsupported min/max, length and regex constraints, applied to optional properties */
         "optional-constraints.schema",
@@ -542,8 +569,8 @@ export const CJSONLanguage: Language = {
         "direct-union.schema",
         "optional-any.schema",
         "required-non-properties.schema",
-        /* Other cases not supported */
-        "implicit-class-array-union.schema",
+        /* Class elements with invalid type are not checked (for the current implementation, can be added later, should abord parsing and return NULL) */
+        ...skipsUntypedUnions,
     ],
     rendererOptions: {},
     quickTestRendererOptions: [{ "source-style": "single-source" }],
@@ -750,17 +777,14 @@ export const SwiftLanguage: Language = {
         // The code we generate for top-level enums is incompatible with the driver
         "top-level-enum.schema",
         // This works on macOS, but on Linux one of the failure test cases doesn't fail
-        "implicit-class-array-union.schema",
+        ...skipsUntypedUnions,
         "required.schema",
         "multi-type-enum.schema",
         "intersection.schema",
         "go-schema-pattern-properties.schema",
-        "enum.schema",
-        "enum-large.schema",
-        "optional-enum.schema",
+        ...skipsEnumValueValidation,
         "date-time.schema",
         "class-with-additional.schema",
-        "class-map-union.schema",
         "vega-lite.schema",
         "top-level-primitive.schema",
     ],
@@ -1017,15 +1041,12 @@ I havea no idea how to encode these tests correctly.
         "multi-type-enum.schema", // I think it doesn't correctly realise this is an array of enums.
         "integer-string.schema",
         "intersection.schema",
-        "implicit-class-array-union.schema",
+        ...skipsUntypedUnions,
         "date-time-or-string.schema",
         "implicit-one-of.schema",
         "go-schema-pattern-properties.schema",
-        "enum.schema",
-        "enum-large.schema",
-        "optional-enum.schema",
+        ...skipsEnumValueValidation,
         "class-with-additional.schema",
-        "class-map-union.schema",
         "keyword-unions.schema",
     ],
     skipMiscJSON: false,
@@ -1155,9 +1176,10 @@ export const KotlinLanguage: Language = {
     ],
     skipSchema: [
         // Very weird - the types are correct, but it can (de)serialize the string,
-        // which is not represented in the types.
+        // which is not represented in the types (implicit-class-array-union);
+        // class-map-union: KlaxonException: Couldn't find a suitable constructor for class UnionValue to initialize with {}
+        ...skipsUntypedUnions,
         "class-with-additional.schema",
-        "implicit-class-array-union.schema",
         "go-schema-pattern-properties.schema",
         // IllegalArgumentException
         "accessors.schema",
@@ -1170,7 +1192,6 @@ export const KotlinLanguage: Language = {
         // produces {"foo" : "java.lang.Object@48d61b48"}
         "any.schema",
         // KlaxonException: Couldn't find a suitable constructor for class UnionValue to initialize with {}
-        "class-map-union.schema",
         "direct-union.schema",
         // Some weird name collision
         "keyword-enum.schema",
@@ -1239,9 +1260,10 @@ export const KotlinJacksonLanguage: Language = {
     ],
     skipSchema: [
         // Very weird - the types are correct, but it can (de)serialize the string,
-        // which is not represented in the types.
+        // which is not represented in the types (implicit-class-array-union);
+        // class-map-union: KlaxonException: Couldn't find a suitable constructor for class UnionValue to initialize with {}
+        ...skipsUntypedUnions,
         "class-with-additional.schema",
-        "implicit-class-array-union.schema",
         "go-schema-pattern-properties.schema",
         // IllegalArgumentException
         "accessors.schema",
@@ -1254,7 +1276,6 @@ export const KotlinJacksonLanguage: Language = {
         // produces {"foo" : "java.lang.Object@48d61b48"}
         "any.schema",
         // KlaxonException: Couldn't find a suitable constructor for class UnionValue to initialize with {}
-        "class-map-union.schema",
         "direct-union.schema",
         // Some weird name collision
         "keyword-enum.schema",
@@ -1300,6 +1321,9 @@ export const DartLanguage: Language = {
     ],
     skipSchema: [
         "enum-with-null.schema",
+        // Deliberately NOT ...skipsEnumValueValidation: Dart runs
+        // optional-enum.schema as its own regression test (see PR #2720),
+        // so only these two enum schemas are skipped.
         "enum.schema",
         "enum-large.schema",
         "bool-string.schema",
@@ -1362,15 +1386,13 @@ export const PikeLanguage: Language = {
     skipSchema: [
         "top-level-enum.schema", // output generated properly, but not a class
         "keyword-unions.schema", // seems like a problem with deserializing
-        "integer-float-union.schema", // no implicit cast int <-> float in Pike
-        "union-int-double.schema", // no implicit cast int <-> float in Pike
-        "minmax.schema", // no implicit cast int <-> float in Pike
+        // no implicit cast int <-> float in Pike
+        ...skipsIntFloatUnions,
         // all below: not failing on expected failure. That's because Pike's quite tolerant with assignments.
         "go-schema-pattern-properties.schema",
         "class-with-additional.schema",
         "multi-type-enum.schema",
-        "class-map-union.schema",
-        "implicit-class-array-union.schema",
+        ...skipsUntypedUnions,
     ],
     rendererOptions: {},
     quickTestRendererOptions: [],
@@ -1449,13 +1471,10 @@ export const HaskellLanguage: Language = {
     skipMiscJSON: false,
     skipSchema: [
         "any.schema",
-        "class-map-union.schema",
+        ...skipsUntypedUnions,
         "direct-union.schema",
-        "enum.schema",
-        "enum-large.schema",
-        "optional-enum.schema",
+        ...skipsEnumValueValidation,
         "go-schema-pattern-properties.schema",
-        "implicit-class-array-union.schema",
         "intersection.schema",
         "multi-type-enum.schema",
         "keyword-unions.schema",
@@ -1587,13 +1606,10 @@ export const TypeScriptZodLanguage: Language = {
     skipMiscJSON: false,
     skipSchema: [
         "any.schema",
-        "class-map-union.schema",
+        ...skipsUntypedUnions,
         "direct-union.schema",
-        "enum.schema",
-        "enum-large.schema",
-        "optional-enum.schema",
+        ...skipsEnumValueValidation,
         "go-schema-pattern-properties.schema",
-        "implicit-class-array-union.schema",
         "intersection.schema",
         "multi-type-enum.schema",
         "keyword-unions.schema",
@@ -1705,13 +1721,10 @@ export const TypeScriptEffectSchemaLanguage: Language = {
     skipMiscJSON: false,
     skipSchema: [
         "any.schema",
-        "class-map-union.schema",
+        ...skipsUntypedUnions,
         "direct-union.schema",
-        "enum.schema",
-        "enum-large.schema",
-        "optional-enum.schema",
+        ...skipsEnumValueValidation,
         "go-schema-pattern-properties.schema",
-        "implicit-class-array-union.schema",
         "intersection.schema",
         "multi-type-enum.schema",
         "keyword-unions.schema",


### PR DESCRIPTION
## Motivation

Several recent PRs that added new test fixtures needed extra CI rounds because a new schema hit a failure mode that 7–9 languages already skip for sibling schemas — but each language's `skipSchema` had its own verbatim copy of the cluster, so the new entry had to be discovered and propagated by hand, one red CI run at a time. This PR centralizes those clusters into shared, reason-named `const` arrays that are spread into the languages they apply to. Adding a future schema to a cluster is now a one-line change that propagates automatically, and the array names/comments document *why* the skips exist.

**Refactor only — zero behavior change** (see verification below).

## The three shared lists

| Array | Entries | Spread into |
|---|---|---|
| `skipsEnumValueValidation` | `enum.schema`, `enum-large.schema`, `optional-enum.schema` | CJSON, Crystal, Haskell, Scala3, Swift, TypeScriptZod, TypeScriptEffectSchema (7) |
| `skipsIntFloatUnions` | `integer-float-union.schema`, `minmax.schema`, `union-int-double.schema` | CJSON, Pike (2) |
| `skipsUntypedUnions` | `class-map-union.schema`, `implicit-class-array-union.schema` | CJSON, Haskell, Kotlin, KotlinJackson, Pike, Scala3, Swift, TypeScriptZod, TypeScriptEffectSchema (9) |

Language-specific nuance comments (Crystal's "does not handle enum mapping", Pike's "no implicit cast int <-> float", Kotlin's KlaxonException details, CJSON's implementation notes) are kept above the spreads.

## Deliberate exceptions

- **Dart** skips `enum.schema` and `enum-large.schema` but intentionally **runs** `optional-enum.schema` — it's Dart's own regression test from #2720. Dart keeps bespoke entries, now with a comment warning against "cleaning it up" into the shared list.
- **CJSON / C#-SystemTextJson** both skip `minmaxlength.schema`, `optional-constraints.schema`, `optional-const-ref.schema`, but for unrelated root causes (CJSON: constraints not implemented; STJ: CS8602 warnings polluting stdout). Coincidental overlap, deliberately **not** merged into a shared list.
- All other skip entries remain bespoke.

## Verification (behavior identity)

A script loads `test/languages.ts` via ts-node and dumps every exported `Language`'s **sorted `skipSchema`** plus `skipJSON`, `includeJSON`, `skipDiffViaSchema`, and `skipMiscJSON` for all 30 exported language configs, as JSON.

- Run on clean master (`4669e44c`) → `before.json`; run after this refactor → `after.json`.
- **`diff before.json after.json` is empty** — the computed skip sets are byte-identical.
- `npx tsc --noEmit -p test/tsconfig.json`: clean (exit 0), same as master.
- `npx biome check test/languages.ts`: exactly the same 3 pre-existing findings as master (1× `lint/style/useNodejsImportProtocol`, 2× `lint/style/noUnusedTemplateLiteral`) — no new findings.
- Sanity count: `.schema` string literals in the file dropped from 189 to 152, i.e. exactly the expected −37 (removed 21+6+18 = 45 duplicated entries, added 3+3+2 = 8 array-definition entries).

## Note on #2875

Open PR #2875 adds `const-non-string.schema` to the enum cluster across the same languages. Whichever PR merges second gets a trivial conflict; the fixup is to add `"const-non-string.schema"` to `skipsEnumValueValidation` plus one bespoke Dart entry (Dart again keeps `optional-` variants runnable per its own rules — follow that PR's Dart hunk as written).

🤖 Generated with [Claude Code](https://claude.com/claude-code)