### PR TITLE
Stop shipping the CI fetch shim (stray stdout line) in published packages

### DIFF
--- a/.github/workflows/publish-npm.yaml
+++ b/.github/workflows/publish-npm.yaml
@@ -7,6 +7,12 @@ on:
 jobs:
     publish-npm:
         runs-on: ubuntu-22.04
+        env:
+            # quicktype-core's build (packages/quicktype-core/env.sh) swaps in
+            # a CI-only fetch shim whenever $CI is set — which GitHub Actions
+            # always sets. PUBLISH=true makes it skip that swap so releases
+            # ship the real $fetch (issue #2874).
+            PUBLISH: "true"
         permissions:
             # Required for npm Trusted Publishing (OIDC): npm mints
             # short-lived, per-run credentials from this token instead

--- a/.github/workflows/publish-vscode.yaml
+++ b/.github/workflows/publish-vscode.yaml
@@ -7,6 +7,12 @@ on:
 jobs:
     publish-vscode:
         runs-on: ubuntu-22.04
+        env:
+            # quicktype-core's build (packages/quicktype-core/env.sh) swaps in
+            # a CI-only fetch shim whenever $CI is set — which GitHub Actions
+            # always sets. PUBLISH=true makes it skip that swap so the bundled
+            # extension ships the real $fetch (issue #2874).
+            PUBLISH: "true"
         steps:
             - uses: actions/checkout@v3
             - uses: ./.github/workflows/setup

--- a/packages/quicktype-core/src/input/io/$fetch.ci.ts
+++ b/packages/quicktype-core/src/input/io/$fetch.ci.ts
@@ -1,3 +1,3 @@
-console.info("=== RUNNING IN CI, USE FETCH.CI ===");
-
+// No logging here: this module runs at import time, and anything written to
+// stdout corrupts redirected CLI output (issue #2874).
 export const fetch = require("cross-fetch").default;

--- a/test/check-clean-import.ts
+++ b/test/check-clean-import.ts
@@ -1,0 +1,43 @@
+import { execFileSync } from "node:child_process";
+import * as path from "node:path";
+
+// Guard: importing the built quicktype-core must not write to stdout.
+//
+// quicktype-core's build (packages/quicktype-core/env.sh) swaps in a CI-only
+// fetch shim ($fetch.ci.ts) whenever $CI is set. That shim used to start with
+// a top-level console.info, so every published package since 23.3.1 printed
+// "=== RUNNING IN CI, USE FETCH.CI ===" on import — corrupting redirected CLI
+// output (`quicktype ... > out.ts` produced non-compiling code). See
+// https://github.com/glideapps/quicktype/issues/2874.
+//
+// This check requires the built package in a child process and fails the test
+// run if the import produces any stdout output. CI builds with $CI set, so it
+// exercises exactly the shim that used to do the printing.
+
+export function checkCoreImportKeepsStdoutClean(): void {
+    const coreDir = path.join(__dirname, "..", "packages", "quicktype-core");
+    const stdout = execFileSync(
+        process.execPath,
+        ["-e", `require(${JSON.stringify(coreDir)});`],
+        { encoding: "utf8" },
+    );
+    if (stdout !== "") {
+        console.error(
+            `error: requiring quicktype-core wrote to stdout:
+
+    ${JSON.stringify(stdout)}
+
+Importing quicktype-core must not print anything: CLI users redirect stdout
+(quicktype ... > out.ts), so any stray output corrupts generated code. See
+https://github.com/glideapps/quicktype/issues/2874`,
+        );
+        process.exit(1);
+    }
+}
+
+// Allow running the check standalone:
+//   npx ts-node --project test/tsconfig.json test/check-clean-import.ts
+if (require.main === module) {
+    checkCoreImportKeepsStdoutClean();
+    console.error("* importing quicktype-core keeps stdout clean");
+}

--- a/test/test.ts
+++ b/test/test.ts
@@ -5,6 +5,7 @@ import { inParallel } from "./lib/multicore";
 import { execAsync, type Sample } from "./utils";
 import { type Fixture, allFixtures } from "./fixtures";
 import { affectedFixtures, divideParallelJobs } from "./buildkite";
+import { checkCoreImportKeepsStdoutClean } from "./check-clean-import";
 import { checkJavaEnumAcronymCasing } from "./check-java-acronym-names";
 import { checkCoreHasNoNodePrefixedImports } from "./check-no-node-imports";
 
@@ -21,6 +22,11 @@ async function main(sources: string[]) {
     // Cheap sanity check, run before any fixture: quicktype-core must not
     // use "node:"-prefixed imports or it breaks web bundlers (issue #2763).
     checkCoreHasNoNodePrefixedImports();
+
+    // Regression check for issue #2874: importing the built quicktype-core
+    // must not write to stdout — CI builds used to swap in a fetch shim that
+    // printed a banner on import, corrupting redirected CLI output.
+    checkCoreImportKeepsStdoutClean();
 
     // Regression check for issue #2850: Java enum constants must keep
     // acronyms uppercase for every --acronym-style. The fixture harness


### PR DESCRIPTION
## Problem

Every `quicktype-core` release since 23.3.1 prints

```
=== RUNNING IN CI, USE FETCH.CI ===
```

to **stdout on every import**. That corrupts redirected CLI output — `npx quicktype ... > out.ts` puts the banner at the top of the generated file, producing non-compiling code — and breaks any library consumer that expects a clean import.

## Root cause

- `packages/quicktype-core/env.sh` (run by the package's `build` script) sed-rewrites `$fetch` imports to `$fetch.ci` whenever `$CI` is set, unless `PUBLISH=true`.
- GitHub Actions always sets `CI`, and neither `.github/workflows/publish-npm.yaml` nor `script/publish-npm.sh` ever set `PUBLISH`, so every published build shipped the CI shim.
- `$fetch.ci.ts` began with a top-level `console.info(...)`, so the banner printed on every import. The shim also silently forces `cross-fetch` instead of native `fetch` in production builds.

## Fix

Both halves:

1. **Publish workflows** (`publish-npm.yaml`, `publish-vscode.yaml`): set `PUBLISH: "true"` in the job env so release builds skip the swap and ship the real `$fetch` (native fetch with cross-fetch fallback). `script/publish-npm.sh` only publishes prebuilt artifacts; the build happens in the workflow's setup step, so the job-level env is the right place.
2. **`$fetch.ci.ts`**: drop the `console.info` so even genuine CI test builds never write to stdout on import.

## Tests

**The regression test was written first and demonstrated failing before the fix.** `test/check-clean-import.ts` (wired into `test/test.ts` alongside the existing `checkCoreHasNoNodePrefixedImports` guard) requires the built `quicktype-core` package in a child process and fails the test run if the import writes anything to stdout. Since CI builds with `$CI` set, the check exercises exactly the shim that used to print.

Observed failure against a `CI=true` build of unfixed master:

```
error: requiring quicktype-core wrote to stdout:

    "=== RUNNING IN CI, USE FETCH.CI ===\n"
```

After fixing `$fetch.ci.ts` and rebuilding with `CI=true`, the check passes.

## Verification

- `CI=true npm run build` (pre-fix shim): `dist/input/io/NodeIO.js` imports `$fetch.ci`, check fails with the banner above.
- `CI=true npm run build` (fixed shim): still imports `$fetch.ci`, check passes — CI builds no longer pollute stdout.
- `CI=true PUBLISH=true npm run build`: env.sh skips the swap (`HAS PUBLISH, exit`), `dist` imports the real `$fetch`, import writes nothing to stdout.
- Plain build + end-to-end CLI: `node dist/index.js --lang typescript --src sample.json > out.ts` starts with the expected header comment and compiles under `tsc --noEmit --strict`.
- `FIXTURE=typescript-zod script/test` passes (210 tests, exit 0).
- Confirmed `env.sh`'s in-place `sed` mutation of `src/input/io/NodeIO.ts` was reverted before committing — the branch contains no sed-mutated sources.

**Not verifiable locally:** the publish workflows themselves (they only run on push to master with npm Trusted Publishing credentials). The `PUBLISH=true` behavior was verified by running the same build command locally; the next release should be confirmed clean with `node -e "require('quicktype-core')"`.

Fixes #2874

🤖 Generated with [Claude Code](https://claude.com/claude-code)
