### PR TITLE
Rust: prevent generated types from shadowing std prelude names

### DIFF
--- a/packages/quicktype-core/src/language/Rust/constants.ts
+++ b/packages/quicktype-core/src/language/Rust/constants.ts
@@ -73,4 +73,20 @@ export const keywords = [
 
     // Conflict between `std::Option` and potentially generated Option
     "option",
+
+    // Prelude and standard-library names that generated code refers to
+    // unqualified; a generated type with one of these names would shadow
+    // them and break compilation (e.g. a struct named `Option`).
+    "Option",
+    "Some",
+    "None",
+    "Result",
+    "Ok",
+    "Err",
+    "String",
+    "Vec",
+    "Box",
+    // Generated code contains `use std::collections::HashMap;`, which a
+    // type of the same name would conflict with.
+    "HashMap",
 ] as const;

--- a/test/inputs/json/priority/bug2521.json
+++ b/test/inputs/json/priority/bug2521.json
@@ -1,0 +1,11 @@
+{
+    "options": [
+        {
+            "name": "test"
+        },
+        {
+            "name": "test2",
+            "foo": "bar"
+        }
+    ]
+}

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1035,6 +1035,11 @@ I havea no idea how to encode these tests correctly.
         "combinations4.json",
         "unions.json",
         "nst-test-suite.json",
+
+        // Scala3 has the same prelude-shadowing bug that this input
+        // guards against in Rust (issue #2521): a field named "options"
+        // generates `case class Option`, which shadows scala.Option.
+        "bug2521.json",
     ],
     skipSchema: [
         // 12 skips


### PR DESCRIPTION
## Problem

A JSON field named `"options"` makes quicktype's Rust output declare `pub struct Option`, which shadows std's `Option` in the generated module. Any sibling field of type `Option<T>` then refers to the local zero-generic struct and the output fails to compile:

```
error[E0107]: struct takes 0 generic arguments but 1 generic argument was supplied
  --> module_under_test.rs:25:10
   |
25 |     foo: Option<String>,
   |          ^^^^^^-------- help: remove the unnecessary generics
```

## Root cause

The Rust `keywords` list in `packages/quicktype-core/src/language/Rust/constants.ts` only contains lowercase `"option"` (added for snake_case *field* names in #2385). Type names are PascalCase-styled, and forbidden-name matching is case-sensitive, so the type name `Option` slipped through `forbiddenNamesForGlobalNamespace`.

## Fix

Add the prelude names that generated Rust code references unqualified — `Option`, `Some`, `None`, `Result`, `Ok`, `Err`, `String`, `Vec`, `Box` — plus `HashMap` (generated code emits `use std::collections::HashMap;`) to the keywords list. Colliding types now get renamed, e.g. `pub struct OptionElement`.

## Tests (test written first)

`test/inputs/json/priority/bug2521.json` was added **before** the fix, and the failure was demonstrated first: with the fix stashed and master-equivalent code built, generating from that input produced `pub struct Option` alongside `foo: Option<String>`, and compiling the output with cargo (mirroring the rust fixture setup) failed with the E0107 error above. After the fix, the same input generates `pub struct OptionElement` and the generated code compiles and round-trips correctly.

The input is skipped for the `scala3` fixture (with a comment) because Scala3 has the same prelude-shadowing bug — it emits `case class Option (... foo : Option[String] ...)`, shadowing `scala.Option` — which is out of scope for this PR.

## Verification

- `FIXTURE=rust script/test test/inputs/json/priority/bug2521.json` passes (full cargo compile + run + diff-via-schema).
- The new priority input also passes locally for `golang`, `typescript`, `javascript`, `javascript-prop-types`, `typescript-zod`, and `typescript-effect-schema`.
- Generation-level smoke test (no crash, no obvious name conflict) for all other fixture languages; Haskell/C#/Crystal/Elixir name a type `Option`, which is not a prelude/stdlib name in those languages.
- Could **not** run locally (missing toolchains/deps: mvn, dotnet, kotlinc, dart, php, swift, elm, crystal, pike, ghc, elixir, boost, valgrind, mypy, bundler, flow binary) — those fixtures will exercise the new priority input in CI. The input is structurally trivial (array of objects + one optional string field), constructs all fixtures already cover.

Fixes #2521

🤖 Generated with [Claude Code](https://claude.com/claude-code)
