### PR TITLE
typescript-zod: emit z.lazy() for recursive schemas instead of silently dropping them

### DIFF
--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -20,7 +20,7 @@ jobs:
 
             matrix:
                 fixture:
-                    - typescript,typescript-zod,typescript-effect-schema
+                    - typescript,typescript-zod,schema-typescript-zod,typescript-effect-schema
                     - javascript,schema-javascript
                     - golang,schema-golang
                     - cjson,schema-cjson

--- a/packages/quicktype-core/src/language/TypeScriptZod/TypeScriptZodRenderer.ts
+++ b/packages/quicktype-core/src/language/TypeScriptZod/TypeScriptZodRenderer.ts
@@ -33,6 +33,11 @@ import { legalizeName } from "../JavaScript/utils";
 import type { typeScriptZodOptions } from "./language";
 
 export class TypeScriptZodRenderer extends ConvenienceRenderer {
+    /** TypeRefs of object types that participate in a reference cycle.
+     * These must be emitted as z.lazy() schemas with an explicit type
+     * annotation, since zod cannot infer recursive types. */
+    private _recursiveTypeRefs: Set<number> = new Set();
+
     public constructor(
         targetLanguage: TargetLanguage,
         renderContext: RenderContext,
@@ -140,7 +145,59 @@ export class TypeScriptZodRenderer extends ConvenienceRenderer {
         return match;
     }
 
+    /** TypeScript type for `t`, used to annotate recursive schemas for
+     * which zod cannot infer the type. */
+    protected underlyingTypeFor(t: Type): Sourcelike {
+        if (["class", "object", "enum"].includes(t.kind)) {
+            return this.nameForNamedType(t);
+        }
+
+        return matchType<Sourcelike>(
+            t,
+            (_anyType) => "any",
+            (_nullType) => "null",
+            (_boolType) => "boolean",
+            (_integerType) => "number",
+            (_doubleType) => "number",
+            (_stringType) => "string",
+            (arrayType) => [
+                "Array<",
+                this.underlyingTypeFor(arrayType.items),
+                ">",
+            ],
+            (_classType) => panic("Should already be handled."),
+            (mapType) => [
+                "Record<string, ",
+                this.underlyingTypeFor(mapType.values),
+                ">",
+            ],
+            (_enumType) => panic("Should already be handled."),
+            (unionType) => {
+                const children = Array.from(unionType.getChildren()).map(
+                    (type: Type) => this.underlyingTypeFor(type),
+                );
+                return arrayIntercalate(" | ", children);
+            },
+            (_transformedStringType) => {
+                if (_transformedStringType.kind === "date-time") {
+                    return "Date";
+                }
+
+                return "string";
+            },
+        );
+    }
+
+    protected isRecursive(t: ObjectType): boolean {
+        return this._recursiveTypeRefs.has(t.typeRef);
+    }
+
     protected emitObject(name: Name, t: ObjectType): void {
+        if (this.isRecursive(t)) {
+            this.emitLazyObject(name, t);
+            return;
+        }
+
         this.ensureBlankLine();
         this.emitLine("\nexport const ", name, "Schema = ", "z.object({");
         this.indent(() => {
@@ -163,6 +220,65 @@ export class TypeScriptZodRenderer extends ConvenienceRenderer {
                 "Schema>;",
             );
         }
+    }
+
+    /** Emit a recursive object type. zod cannot infer recursive types, so
+     * the type is declared explicitly and the schema is wrapped in
+     * z.lazy() with a z.ZodType annotation. */
+    protected emitLazyObject(name: Name, t: ObjectType): void {
+        this.ensureBlankLine();
+        if (this._options.justSchema) {
+            this.emitLine(
+                "\nexport const ",
+                name,
+                "Schema: z.ZodType<any> = z.lazy(() =>",
+            );
+        } else {
+            this.emitLine("\nexport type ", name, " = {");
+            this.indent(() => {
+                this.forEachClassProperty(
+                    t,
+                    "none",
+                    (_, jsonName, property) => {
+                        this.emitLine(
+                            `"${utf16StringEscape(jsonName)}"`,
+                            property.isOptional ? "?" : "",
+                            ": ",
+                            this.underlyingTypeFor(property.type),
+                            ";",
+                        );
+                    },
+                );
+            });
+            this.emitLine("};");
+            this.emitLine(
+                "export const ",
+                name,
+                "Schema: z.ZodType<",
+                name,
+                "> = z.lazy(() =>",
+            );
+        }
+
+        this.indent(() => {
+            this.emitLine("z.object({");
+            this.indent(() => {
+                this.forEachClassProperty(
+                    t,
+                    "none",
+                    (_, jsonName, property) => {
+                        this.emitLine(
+                            `"${utf16StringEscape(jsonName)}"`,
+                            ": ",
+                            this.typeMapTypeForProperty(property),
+                            ",",
+                        );
+                    },
+                );
+            });
+            this.emitLine("})");
+        });
+        this.emitLine(");");
     }
 
     protected emitEnum(e: EnumType, enumName: Name): void {
@@ -282,10 +398,45 @@ export class TypeScriptZodRenderer extends ConvenienceRenderer {
             mapChildTypeRefs.push(childTypeRefs);
         });
 
+        // Find types that participate in a reference cycle: types from
+        // which we can get back to the same type by following child type
+        // references. Those can never be topologically ordered.
+        const indexForTypeRef = new Map<number, number>();
+        mapTypeRef.forEach((typeRef, index) =>
+            indexForTypeRef.set(typeRef, index),
+        );
+        this._recursiveTypeRefs = new Set();
+        mapType.forEach((_, startIndex) => {
+            const visited = new Set<number>();
+            const stack = [...mapChildTypeRefs[startIndex]];
+            while (stack.length > 0) {
+                const childRef = stack.pop() as number;
+                const childIndex = indexForTypeRef.get(childRef);
+                if (childIndex === undefined) continue;
+                if (childIndex === startIndex) {
+                    this._recursiveTypeRefs.add(mapTypeRef[startIndex]);
+                    break;
+                }
+
+                if (visited.has(childIndex)) continue;
+                visited.add(childIndex);
+                stack.push(...mapChildTypeRefs[childIndex]);
+            }
+        });
+
         // Items to process on this pass
         let indices: number[] = [];
         mapType.forEach((_, index) => {
-            indices.push(index);
+            if (this._recursiveTypeRefs.has(mapTypeRef[index])) {
+                // Recursive types are emitted first: they are wrapped in
+                // z.lazy(), so all their references to other schemas are
+                // deferred until parse time and don't constrain the
+                // output order, while other schemas can reference them
+                // directly.
+                order.push(index);
+            } else {
+                indices.push(index);
+            }
         });
         // items to process on the next pass
         let deferredIndices: number[] = [];
@@ -338,8 +489,9 @@ export class TypeScriptZodRenderer extends ConvenienceRenderer {
             passNum++;
 
             if (passNum > MAX_PASSES) {
-                // giving up
-                order.push(...deferredIndices);
+                // giving up: emit the stuck items anyway rather than
+                // silently dropping them
+                order.push(...indices);
                 console.warn(
                     "Exceeded maximum number of passes when determining output order, output may contain forward references",
                 );

--- a/packages/quicktype-core/src/language/TypeScriptZod/TypeScriptZodRenderer.ts
+++ b/packages/quicktype-core/src/language/TypeScriptZod/TypeScriptZodRenderer.ts
@@ -146,7 +146,15 @@ export class TypeScriptZodRenderer extends ConvenienceRenderer {
     }
 
     /** TypeScript type for `t`, used to annotate recursive schemas for
-     * which zod cannot infer the type. */
+     * which zod cannot infer the type.
+     *
+     * This intentionally duplicates neither `typeMapTypeFor` above nor
+     * `sourceFor` in the plain TypeScript renderer
+     * (`TypeScriptFlowBaseRenderer`): it must mirror exactly what
+     * `z.infer` would derive from the schemas emitted by
+     * `typeMapTypeFor` (e.g. `z.coerce.date()` implies `Date`), while
+     * `sourceFor` is shaped by ts/flow-specific options like
+     * `preferConstValues` and `declareUnions` that don't exist here. */
     protected underlyingTypeFor(t: Type): Sourcelike {
         if (["class", "object", "enum"].includes(t.kind)) {
             return this.nameForNamedType(t);

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -1596,6 +1596,7 @@ export const allFixtures: Fixture[] = [
     new JSONSchemaFixture(languages.ElmLanguage),
     new JSONSchemaFixture(languages.SwiftLanguage),
     new JSONSchemaFixture(languages.TypeScriptLanguage),
+    new JSONSchemaFixture(languages.TypeScriptZodLanguage),
     new JSONSchemaFixture(languages.FlowLanguage),
     new JSONSchemaFixture(languages.JavaScriptLanguage),
     new JSONSchemaFixture(languages.KotlinLanguage),

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1545,20 +1545,13 @@ export const TypeScriptZodLanguage: Language = {
     output: "TopLevel.ts",
     topLevel: "TopLevel",
     skipJSON: [
-        // Uses generated schema before it's defined
-        "be234.json",
-        "76ae1.json",
-        "6de06.json",
+        // The test driver can't find the top-level schema among the
+        // prefixed names (FluffyTopLevelSchema etc.)
         "2df80.json",
-        "29f47.json",
-        "spotify-album.json",
-        "reddit.json",
-        "github-events.json",
 
-        // Does not handle recursive
-        "direct-recursive.json",
-        "list.json",
-        "bug790.json",
+        // z.coerce.date() serializes timestamps with milliseconds, the
+        // input has none
+        "github-events.json",
 
         // Does not handle top level array
         "bug863.json",
@@ -1597,7 +1590,6 @@ export const TypeScriptZodLanguage: Language = {
         "combinations4.json",
         "identifiers.json",
         "blns-object.json",
-        "recursive.json",
         "bug427.json",
         "nst-test-suite.json",
         "keywords.json",
@@ -1611,6 +1603,11 @@ export const TypeScriptZodLanguage: Language = {
         ...skipsUntypedUnions,
         "direct-union.schema",
         ...skipsEnumValueValidation,
+        // zod validates the inherited Object.prototype.constructor when an
+        // optional "constructor" property is absent
+        "constructor.schema",
+        // z.coerce.date() serializes back as ISO UTC, not the input string
+        "date-time.schema",
         "go-schema-pattern-properties.schema",
         "intersection.schema",
         "multi-type-enum.schema",


### PR DESCRIPTION
## Problem

Converting a recursive JSON Schema (or recursive JSON input) with `--lang typescript-zod` produced broken output. Originally (#2508) the recursive reference was emitted without `z.lazy()`, which throws at runtime; on current master it is even worse — the output degenerates to just `import * as z from "zod";` plus an "Exceeded maximum number of passes" warning, with **all** schemas silently dropped.

## Root cause

`emitSchemas()` orders schemas topologically so every schema is defined before it is referenced. Types that participate in a reference cycle can never be placed by that loop. After 999 passes the bailout pushed `deferredIndices` — which had just been reset to `[]` — instead of the stuck `indices`, so recursive types *and everything depending on them* vanished from the output. And even with the bailout fixed, the renderer had no `z.lazy()` support, so recursive schemas referenced consts before their definition.

## The fix

- Detect object types that participate in a reference cycle by walking child type refs (`packages/quicktype-core/src/language/TypeScriptZod/TypeScriptZodRenderer.ts`).
- Emit those types with an explicitly declared TS type and a `z.lazy()`-wrapped schema, as zod cannot infer recursive types ([zod docs](https://github.com/colinhacks/zod#recursive-types)):

  ```ts
  export type Mydef1 = {
      "test"?: Mydef1;
  };
  export const Mydef1Schema: z.ZodType<Mydef1> = z.lazy(() =>
      z.object({
          "test": Mydef1Schema.optional(),
      })
  );
  ```

  Recursive types are emitted first: inside `z.lazy()` their references are deferred to parse time, so they don't constrain the topological order, while other schemas can reference them directly. With `--just-schema` the annotation falls back to `z.ZodType<any>`.
- Fix the bailout to push the stuck `indices` so schemas are never silently dropped even if ordering ever fails.

## Tests (written first)

**The regression test was added and shown to fail before the fix:**

- Wired up a `schema-typescript-zod` `JSONSchemaFixture` (`test/fixtures.ts`) and added it to the CI matrix (`.github/workflows/test-pr.yaml`). Running `FIXTURE=schema-typescript-zod script/test test/inputs/schema/mutually-recursive.schema` against the unfixed renderer failed: the generated `TopLevel.ts` contained only the zod import, so the test driver errored on both samples ("Could not run command for JSON output", exit 1). The issue's own schema likewise produced only `import * as z from "zod";`. After the fix both pass.
- Un-skipped the typescript-zod JSON fixture inputs that were skipped as "Does not handle recursive" (`direct-recursive.json`, `list.json`, `bug790.json`, `recursive.json`) and the "Uses generated schema before it's defined" group (`be234`, `76ae1`, `6de06`, `29f47`, `spotify-album`, `reddit`) — all pass now and guard against regressions in the existing CI fixture.
- New skips, each verified to be unrelated to this fix: `constructor.schema` (zod v3 validates the inherited `Object.prototype.constructor` when an optional `"constructor"` property is absent from the parsed object), `date-time.schema` / `github-events.json` (`z.coerce.date()` round-trips as ISO UTC with milliseconds, not the input string), `2df80.json` (the test driver can't find the top-level schema among the disambiguated `Fluffy`/`PurpleTopLevelSchema` names).

## Verification

- `FIXTURE=typescript-zod script/test`: all 210 tests pass locally (node + tsc).
- `FIXTURE=schema-typescript-zod script/test`: all schema inputs pass locally **except** `ref-remote.schema`, which could not be verified locally — its remote fetch from raw.githubusercontent.com fails in my environment for *all* languages (including master's plain typescript). A local simulation (same `$ref` target `list.schema`, via a file ref) generates correct `z.lazy()` output, and `list.schema` itself passes the fixture, so CI is expected to pass it.
- `vega-lite.schema` (large, heavily recursive) now generates, compiles, and validates.

Fixes #2508

🤖 Generated with [Claude Code](https://claude.com/claude-code)
