### PR TITLE
Pin publish workflow to npm 11 to fix broken npm publishing

### DIFF
--- a/.github/workflows/publish-npm.yaml
+++ b/.github/workflows/publish-npm.yaml
@@ -24,7 +24,10 @@ jobs:
             - uses: ./.github/workflows/setup
             # Trusted Publishing requires npm >= 11.5.1; the pinned Node
             # runtime ships an older npm, so upgrade it before publishing.
-            - run: npm install -g npm@latest
+            # Pinned to major 11: npm@latest moved to 12.0.0, which requires
+            # Node ^22.22.2 || ^24.15.0 || >=26 and EBADENGINEs on our pinned
+            # Node (.nvmrc), breaking every publish.
+            - run: npm install -g npm@11
             # Run via npm so node_modules/.bin is on PATH (patch-npm-version.ts
             # is executed through its ts-node shebang).
             - run: npm run pub:npm


### PR DESCRIPTION
## Root cause

Every `Publish npm packages` run since 2026-07-10 fails (last success: 2026-07-07, #2891). The failing step is `npm install -g npm@latest`:

```
npm error engine Not compatible with your version of node/npm: npm@12.0.0
npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error notsup Actual:   {"npm":"10.9.2","node":"v22.14.0"}
```

Upstream npm released **12.0.0** to the `latest` dist-tag between Jul 7 and Jul 10; it requires Node `^22.22.2 || ^24.15.0 || >=26`, but the workflow runs the `.nvmrc`-pinned Node **v22.14.0** → EBADENGINE. Today's dependabot merges only *triggered* the master pushes that exposed this — the failure is upstream, and their `npm ci` + `npm run build` steps all passed on master.

## Fix

Pin the upgrade to `npm@11` (currently 11.18.0):
- Trusted Publishing needs npm ≥ 11.5.1 ✓
- npm 11 supports Node `^20.17.0 || >=22.9.0`, compatible with v22.14.0 ✓
- This is the exact npm major the last successful publish used, and it won't break again on future `latest` engine bumps.

The alternative (bumping `.nvmrc` to ≥ 22.22.2) touches every CI job and still leaves publishes exposed to the next npm engines change. (PR #2892 modernizes Node across the repo; when it lands it can revisit this pin.)

## Not fixed here (needs maintainer action)

`Publish VS Code extension` fails for an unrelated reason: **the `VSCE_TOKEN` Personal Access Token has expired** ("Access Denied: The Personal Access Token used has expired"). A new Azure DevOps marketplace PAT needs to be generated and the repo secret updated — that cannot be fixed from a PR.

Note: more dependabot lockfile PRs are still landing (2893, 2839); they don't affect this workflow-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)