### PR TITLE
Document LanguageName migration and keep the README sample typechecking

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -10,7 +10,59 @@ supported Node.js version do not need to install or configure a fetch
 polyfill.
 
 There are no intentional changes to generated code or the public quicktype
-API in this release. TypeScript compiler versions are also unchanged.
+API in this release. TypeScript compiler versions are also unchanged. Note,
+however, that TypeScript consumers upgrading from quicktype-core 23.0.x or
+earlier will encounter the stricter language-name typing described below,
+which was introduced in 23.1.0.
+
+## Stricter language-name typing in quicktype-core
+
+Since quicktype-core 23.1.0, the `lang` option of `quicktype()` and the
+first parameter of `jsonInputForTargetLanguage()` are typed as
+`LanguageName | TargetLanguage` instead of `string | TargetLanguage`.
+`LanguageName` is a union of all the language names quicktype supports, so
+typos in language names are now caught at compile time. Runtime behavior is
+unchanged.
+
+TypeScript code that wraps quicktype in a helper taking `targetLanguage:
+string` — like older versions of the README sample — no longer typechecks,
+failing with errors such as:
+
+```
+error TS2345: Argument of type 'string' is not assignable to parameter of
+type '"ruby" | TargetLanguage<LanguageConfig> | "cjson" | ...'.
+```
+
+To migrate, either type the language parameter as `LanguageName`:
+
+```typescript
+import { type LanguageName } from "quicktype-core";
+
+async function quicktypeJSON(targetLanguage: LanguageName, ...) { ... }
+```
+
+or, if the language name is a `string` only known at runtime, narrow it
+with the `isLanguageName` type guard, which accepts everything quicktype
+itself accepts (canonical names like `"csharp"`, display names like `"C#"`,
+and file extensions like `"cs"`):
+
+```typescript
+import { isLanguageName } from "quicktype-core";
+
+if (!isLanguageName(maybeLanguage)) {
+    throw new Error(`Unknown target language: ${maybeLanguage}`);
+}
+// maybeLanguage is now a LanguageName
+```
+
+Alternatively, `languageNamed(name)` looks up the `TargetLanguage` instance
+for a name, returning `undefined` if there is none; an instance can be
+passed anywhere a language name is accepted.
+
+See the [README](README.md#calling-quicktype-from-javascript) for a
+complete, up-to-date usage sample.
+
+## Testing
 
 For contributors, `npm run test:unit` runs the Vitest regression suite and
 `npm run test:fixtures` runs the cross-language fixture harness. `npm test`

--- a/README.md
+++ b/README.md
@@ -131,16 +131,23 @@ $ npm install quicktype-core
 
 In general, first you create an `InputData` value with one or more JSON samples, JSON schemas, TypeScript sources, or other supported input types. Then you call `quicktype`, passing that `InputData` value and any options you want.
 
-```javascript
+The sample below is TypeScript; if you're calling quicktype from plain JavaScript, just leave out the type annotations. Note that the language parameters are typed as `LanguageName` — a union of all the language names quicktype supports — rather than `string`, so typos in language names are caught at compile time:
+
+```typescript
 import {
     quicktype,
     InputData,
     jsonInputForTargetLanguage,
     JSONSchemaInput,
-    FetchingJSONSchemaStore
+    FetchingJSONSchemaStore,
+    type LanguageName
 } from "quicktype-core";
 
-async function quicktypeJSON(targetLanguage, typeName, jsonString) {
+async function quicktypeJSON(
+    targetLanguage: LanguageName,
+    typeName: string,
+    jsonString: string
+) {
     const jsonInput = jsonInputForTargetLanguage(targetLanguage);
 
     // We could add multiple samples for the same desired
@@ -160,7 +167,11 @@ async function quicktypeJSON(targetLanguage, typeName, jsonString) {
     });
 }
 
-async function quicktypeJSONSchema(targetLanguage, typeName, jsonSchemaString) {
+async function quicktypeJSONSchema(
+    targetLanguage: LanguageName,
+    typeName: string,
+    jsonSchemaString: string
+) {
     const schemaInput = new JSONSchemaInput(new FetchingJSONSchemaStore());
 
     // We could add multiple schemas for multiple types,
@@ -177,15 +188,45 @@ async function quicktypeJSONSchema(targetLanguage, typeName, jsonSchemaString) {
 }
 
 async function main() {
+    const jsonString = `{ "name": "David", "age": 42 }`;
     const { lines: swiftPerson } = await quicktypeJSON("swift", "Person", jsonString);
     console.log(swiftPerson.join("\n"));
 
+    const jsonSchemaString = `{
+        "$schema": "http://json-schema.org/draft-06/schema#",
+        "type": "object",
+        "properties": {
+            "name": { "type": "string" },
+            "age": { "type": "integer" }
+        },
+        "required": ["name", "age"]
+    }`;
     const { lines: pythonPerson } = await quicktypeJSONSchema("python", "Person", jsonSchemaString);
     console.log(pythonPerson.join("\n"));
 }
 
 main();
 ```
+
+If the target language is only known at runtime — from a command-line argument or a config file, say — you have a `string`, which TypeScript won't accept as a `LanguageName`. Narrow it with the `isLanguageName` type guard, which accepts everything quicktype itself accepts: canonical names like `"csharp"`, display names like `"C#"`, and file extensions like `"cs"`:
+
+```typescript
+import { isLanguageName } from "quicktype-core";
+
+async function quicktypeDynamicJSON(
+    targetLanguage: string,
+    typeName: string,
+    jsonString: string
+) {
+    if (!isLanguageName(targetLanguage)) {
+        throw new Error(`Unknown target language: ${targetLanguage}`);
+    }
+
+    return await quicktypeJSON(targetLanguage, typeName, jsonString);
+}
+```
+
+Alternatively, `languageNamed(name)` looks up the `TargetLanguage` instance for a name (returning `undefined` if there is none), and an instance can be passed anywhere a language name is accepted.
 
 The argument to `quicktype` is a complex object with many optional properties. [Explore its definition](https://github.com/quicktype/quicktype/blob/master/packages/quicktype-core/src/Run.ts#L637) to understand what options are allowed.
 

--- a/test/unit/readme-sample.test.ts
+++ b/test/unit/readme-sample.test.ts
@@ -1,0 +1,127 @@
+// The README's "Calling quicktype from JavaScript" sample must typecheck
+// against the current quicktype-core API under tsc --strict.
+//
+// quicktype-core 23.1.0 changed the `lang` option of quicktype() and the
+// parameter of jsonInputForTargetLanguage() from `string | TargetLanguage`
+// to `LanguageName | TargetLanguage`. The README sample at the time wrapped
+// quicktype in a helper taking `targetLanguage: string`, so consumers who
+// copied it hit TS2345/TS2322 when upgrading — see
+// https://github.com/glideapps/quicktype/issues/2905.
+//
+// This test extracts the TypeScript code blocks from that README section
+// and compiles them with tsc --strict against the built quicktype-core.
+// It fails if the sample drifts from the API, or if the exports the sample
+// relies on (LanguageName, isLanguageName, ...) disappear from the public
+// entry point.
+
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+
+const repositoryRoot = process.cwd();
+const readmePath = path.join(repositoryRoot, "README.md");
+const coreTypesPath = path.join(
+    repositoryRoot,
+    "packages",
+    "quicktype-core",
+    "dist",
+    "index.d.ts",
+);
+const tscPath = path.join(
+    repositoryRoot,
+    "node_modules",
+    "typescript",
+    "bin",
+    "tsc",
+);
+
+const sectionHeading = "### Calling `quicktype` from JavaScript";
+
+// Extracts the fenced ```typescript blocks between `heading` and the next
+// heading of the same or higher level.
+function typescriptBlocksInSection(
+    markdown: string,
+    heading: string,
+): string[] {
+    const start = markdown.indexOf(`${heading}\n`);
+    expect(
+        start,
+        `README section ${JSON.stringify(heading)} exists`,
+    ).toBeGreaterThanOrEqual(0);
+
+    const rest = markdown.slice(start + heading.length);
+    const nextHeading = rest.search(/\n##+ /);
+    const section = nextHeading >= 0 ? rest.slice(0, nextHeading) : rest;
+
+    const blocks: string[] = [];
+    const fence = /```typescript\n([\s\S]*?)```/g;
+    for (
+        let match = fence.exec(section);
+        match !== null;
+        match = fence.exec(section)
+    ) {
+        blocks.push(match[1]);
+    }
+
+    return blocks;
+}
+
+let workDirectory: string;
+
+beforeAll(() => {
+    workDirectory = fs.mkdtempSync(
+        path.join(os.tmpdir(), "quicktype-readme-sample-"),
+    );
+});
+
+afterAll(() => {
+    fs.rmSync(workDirectory, { recursive: true, force: true });
+});
+
+describe("README quicktype-core sample", () => {
+    test("typechecks with tsc --strict against the built quicktype-core", () => {
+        expect(
+            fs.existsSync(coreTypesPath),
+            `quicktype-core must be built first (missing ${coreTypesPath}); run "npm run build"`,
+        ).toBe(true);
+
+        const readme = fs.readFileSync(readmePath, "utf8");
+        const blocks = typescriptBlocksInSection(readme, sectionHeading);
+        // The main sample plus the dynamic-language-name snippet.
+        expect(blocks.length).toBeGreaterThanOrEqual(2);
+
+        // The snippets are written to concatenate into a single valid
+        // module (no duplicate imports or declarations).
+        fs.writeFileSync(
+            path.join(workDirectory, "sample.ts"),
+            blocks.join("\n"),
+        );
+        fs.writeFileSync(
+            path.join(workDirectory, "tsconfig.json"),
+            JSON.stringify({
+                compilerOptions: {
+                    strict: true,
+                    noEmit: true,
+                    target: "es2020",
+                    lib: ["es2020", "dom"],
+                    module: "commonjs",
+                    moduleResolution: "node",
+                    esModuleInterop: true,
+                    skipLibCheck: true,
+                    types: [],
+                    baseUrl: ".",
+                    paths: { "quicktype-core": [coreTypesPath] },
+                },
+                files: ["sample.ts"],
+            }),
+        );
+
+        // Throws (failing the test with tsc's diagnostics) on any type error.
+        execFileSync(process.execPath, [tscPath, "-p", workDirectory], {
+            encoding: "utf8",
+        });
+    });
+});


### PR DESCRIPTION
Fixes #2905.

## Problem

Since quicktype-core 23.1.0, the `lang` option of `quicktype()` and the parameter of `jsonInputForTargetLanguage()` are typed as `LanguageName | TargetLanguage` instead of `string | TargetLanguage`. The widely-circulated README-style sample that wraps quicktype in a helper taking `targetLanguage: string` no longer typechecks (TS2345/TS2322), and the resolution — the exported `LanguageName` type and `isLanguageName()` type guard — was only discoverable by reading `dist/language/types.d.ts`. Anyone upgrading from 23.0.x straight to 24.0.0 hits this without any migration guidance.

## Approach

No API changes are needed — `LanguageName` and `isLanguageName` are already exported from quicktype-core's public entry point. The types stay strict; this PR documents them and pins the docs to the API with a test:

- **README**: the "Calling `quicktype` from JavaScript" sample is now TypeScript with `targetLanguage: LanguageName` parameters (with a note that plain-JS users just drop the annotations), is self-contained/runnable, and gains a snippet showing the escape hatch for dynamic language names: narrow a `string` with `isLanguageName()` (which accepts everything quicktype accepts — canonical names, display names, and extensions), with `languageNamed()` → `TargetLanguage` instance mentioned as the alternative.
- **MIGRATING.md**: new "Stricter language-name typing in quicktype-core" section describing when the change landed (23.1.0), the exact error symptoms, and both migration styles; the existing "no public API changes in 24" sentence is qualified so it no longer contradicts what upgraders from ≤23.0.x experience.
- **New test** `test/unit/readme-sample.test.ts`: extracts the TypeScript code blocks from that README section and compiles them with `tsc --strict` against the built quicktype-core, so the sample — and the public exports it relies on — can't silently rot again.

## Verification

- `npm run build` and `npm run test:unit` pass (8 files, 67 tests, including the new one).
- Negative check: compiling the old `targetLanguage: string` helper against the built package reproduces exactly the TS2345/TS2322 errors from the issue, confirming the test setup catches the regression class.
- End-to-end: `npm pack`ed quicktype-core 24.0.0 into a standalone scratch project, extracted the README snippets verbatim, compiled with `tsc --strict`, and ran them — the sample emits the expected Swift and Python output.
- No `package.json` versions touched, per repo convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)