### PR TITLE
Replace typescript-json-schema fork with upstream, dropping deprecated glob@7/inflight

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1196,38 +1196,6 @@
                 "@jridgewell/sourcemap-codec": "^1.4.10"
             }
         },
-        "node_modules/@mark.probst/typescript-json-schema": {
-            "version": "0.55.0",
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "@types/json-schema": "^7.0.9",
-                "@types/node": "^16.9.2",
-                "glob": "^7.1.7",
-                "path-equal": "^1.1.2",
-                "safe-stable-stringify": "^2.2.0",
-                "ts-node": "^10.9.1",
-                "typescript": "4.9.4",
-                "yargs": "^17.1.1"
-            },
-            "bin": {
-                "typescript-json-schema": "bin/typescript-json-schema"
-            }
-        },
-        "node_modules/@mark.probst/typescript-json-schema/node_modules/@types/node": {
-            "version": "16.18.11",
-            "license": "MIT"
-        },
-        "node_modules/@mark.probst/typescript-json-schema/node_modules/typescript": {
-            "version": "4.9.4",
-            "license": "Apache-2.0",
-            "bin": {
-                "tsc": "bin/tsc",
-                "tsserver": "bin/tsserver"
-            },
-            "engines": {
-                "node": ">=4.2.0"
-            }
-        },
         "node_modules/@napi-rs/wasm-runtime": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
@@ -2990,7 +2958,9 @@
             }
         },
         "node_modules/acorn": {
-            "version": "8.11.3",
+            "version": "8.17.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+            "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
             "license": "MIT",
             "bin": {
                 "acorn": "bin/acorn"
@@ -3008,8 +2978,13 @@
             }
         },
         "node_modules/acorn-walk": {
-            "version": "8.2.0",
+            "version": "8.3.5",
+            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+            "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
             "license": "MIT",
+            "dependencies": {
+                "acorn": "^8.11.0"
+            },
             "engines": {
                 "node": ">=0.4.0"
             }
@@ -3061,6 +3036,7 @@
         },
         "node_modules/ansi-regex": {
             "version": "5.0.1",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -3186,6 +3162,7 @@
         },
         "node_modules/balanced-match": {
             "version": "1.0.0",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/base64-js": {
@@ -3296,6 +3273,7 @@
         },
         "node_modules/brace-expansion": {
             "version": "1.1.11",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
@@ -3692,6 +3670,7 @@
         },
         "node_modules/cliui": {
             "version": "8.0.1",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "string-width": "^4.2.0",
@@ -3804,6 +3783,7 @@
         },
         "node_modules/concat-map": {
             "version": "0.0.1",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/concat-stream": {
@@ -4235,6 +4215,7 @@
         },
         "node_modules/emoji-regex": {
             "version": "8.0.0",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/end-of-stream": {
@@ -5078,6 +5059,7 @@
         },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/fsevents": {
@@ -5122,7 +5104,6 @@
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
             "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=18"
@@ -5184,6 +5165,7 @@
         },
         "node_modules/glob": {
             "version": "7.2.3",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "fs.realpath": "^1.0.0",
@@ -5513,6 +5495,7 @@
         },
         "node_modules/inflight": {
             "version": "1.0.6",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "once": "^1.3.0",
@@ -5674,6 +5657,7 @@
         },
         "node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -6745,6 +6729,7 @@
         },
         "node_modules/minimatch": {
             "version": "3.1.2",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
@@ -6765,7 +6750,6 @@
             "version": "7.1.3",
             "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
             "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-            "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": ">=16 || 14 >=14.17"
@@ -7194,6 +7178,7 @@
         },
         "node_modules/once": {
             "version": "1.4.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "wrappy": "1"
@@ -7524,6 +7509,7 @@
         },
         "node_modules/path-is-absolute": {
             "version": "1.0.1",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -8000,6 +7986,7 @@
         },
         "node_modules/require-directory": {
             "version": "2.1.1",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -8154,9 +8141,10 @@
             "license": "MIT"
         },
         "node_modules/safe-stable-stringify": {
-            "version": "2.4.3",
-            "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
-            "integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+            "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+            "license": "MIT",
             "engines": {
                 "node": ">=10"
             }
@@ -8918,6 +8906,7 @@
         },
         "node_modules/string-width": {
             "version": "4.2.3",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "emoji-regex": "^8.0.0",
@@ -8944,6 +8933,7 @@
         },
         "node_modules/strip-ansi": {
             "version": "6.0.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^5.0.1"
@@ -9882,6 +9872,251 @@
                 "node": ">=14.17"
             }
         },
+        "node_modules/typescript-json-schema": {
+            "version": "0.67.4",
+            "resolved": "https://registry.npmjs.org/typescript-json-schema/-/typescript-json-schema-0.67.4.tgz",
+            "integrity": "sha512-BhDCVfwGtPKKt9JOBvh6ocmSbEk7ftx7dpqqIpvGNrjzYcUKm8pnYwKSFfNJwqcp/qNTfZr9sKtVyTxx4V9iRA==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@types/json-schema": "^7.0.15",
+                "@types/node": "^24.10.2",
+                "glob": "^13.0.6",
+                "path-equal": "^1.2.5",
+                "safe-stable-stringify": "^2.5.0",
+                "ts-node": "^10.9.2",
+                "typescript": "~5.9.3",
+                "vm2": "^3.11.3",
+                "yargs": "^18.0.0"
+            },
+            "bin": {
+                "typescript-json-schema": "bin/typescript-json-schema"
+            }
+        },
+        "node_modules/typescript-json-schema/node_modules/@types/node": {
+            "version": "24.13.3",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+            "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+            "license": "MIT",
+            "dependencies": {
+                "undici-types": "~7.18.0"
+            }
+        },
+        "node_modules/typescript-json-schema/node_modules/ansi-regex": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+            "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+            }
+        },
+        "node_modules/typescript-json-schema/node_modules/ansi-styles": {
+            "version": "6.2.3",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+            "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/typescript-json-schema/node_modules/balanced-match": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+            "license": "MIT",
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
+        },
+        "node_modules/typescript-json-schema/node_modules/brace-expansion": {
+            "version": "5.0.7",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+            "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^4.0.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
+        },
+        "node_modules/typescript-json-schema/node_modules/cliui": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+            "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^7.2.0",
+                "strip-ansi": "^7.1.0",
+                "wrap-ansi": "^9.0.0"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/typescript-json-schema/node_modules/emoji-regex": {
+            "version": "10.6.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+            "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+            "license": "MIT"
+        },
+        "node_modules/typescript-json-schema/node_modules/glob": {
+            "version": "13.0.6",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+            "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "minimatch": "^10.2.2",
+                "minipass": "^7.1.3",
+                "path-scurry": "^2.0.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/typescript-json-schema/node_modules/lru-cache": {
+            "version": "11.5.2",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+            "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/typescript-json-schema/node_modules/minimatch": {
+            "version": "10.2.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "brace-expansion": "^5.0.5"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/typescript-json-schema/node_modules/path-scurry": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+            "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "lru-cache": "^11.0.0",
+                "minipass": "^7.1.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/typescript-json-schema/node_modules/string-width": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+            "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^10.3.0",
+                "get-east-asian-width": "^1.0.0",
+                "strip-ansi": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/typescript-json-schema/node_modules/strip-ansi": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+            "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^6.2.2"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
+        },
+        "node_modules/typescript-json-schema/node_modules/typescript": {
+            "version": "5.9.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
+            }
+        },
+        "node_modules/typescript-json-schema/node_modules/undici-types": {
+            "version": "7.18.2",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+            "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+            "license": "MIT"
+        },
+        "node_modules/typescript-json-schema/node_modules/wrap-ansi": {
+            "version": "9.0.2",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+            "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^6.2.1",
+                "string-width": "^7.0.0",
+                "strip-ansi": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/typescript-json-schema/node_modules/yargs": {
+            "version": "18.0.0",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+            "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+            "license": "MIT",
+            "dependencies": {
+                "cliui": "^9.0.1",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "string-width": "^7.2.0",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^22.0.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=23"
+            }
+        },
+        "node_modules/typescript-json-schema/node_modules/yargs-parser": {
+            "version": "22.0.0",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+            "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+            "license": "ISC",
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=23"
+            }
+        },
         "node_modules/typical": {
             "version": "4.0.0",
             "license": "MIT",
@@ -10244,6 +10479,22 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/vm2": {
+            "version": "3.11.5",
+            "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.11.5.tgz",
+            "integrity": "sha512-RSrkBiwrj6FRU+QdqNs6KG0XdlvJCjpQ4GXiqmMbrhmwfu5k/XIMpAer0L8f6iuf0uJ3a4T1xJN126Q8yf0VIA==",
+            "license": "MIT",
+            "dependencies": {
+                "acorn": "^8.15.0",
+                "acorn-walk": "^8.3.4"
+            },
+            "bin": {
+                "vm2": "bin/vm2"
+            },
+            "engines": {
+                "node": ">=6.0"
+            }
+        },
         "node_modules/watch": {
             "version": "1.0.2",
             "dev": true,
@@ -10370,6 +10621,7 @@
         },
         "node_modules/wrap-ansi": {
             "version": "7.0.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ansi-styles": "^4.0.0",
@@ -10402,6 +10654,7 @@
         },
         "node_modules/wrappy": {
             "version": "1.0.2",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/wsl-utils": {
@@ -10475,24 +10728,9 @@
                 "url": "https://github.com/sponsors/eemeli"
             }
         },
-        "node_modules/yargs": {
-            "version": "17.6.2",
-            "license": "MIT",
-            "dependencies": {
-                "cliui": "^8.0.1",
-                "escalade": "^3.1.1",
-                "get-caller-file": "^2.0.5",
-                "require-directory": "^2.1.1",
-                "string-width": "^4.2.3",
-                "y18n": "^5.0.5",
-                "yargs-parser": "^21.1.1"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
         "node_modules/yargs-parser": {
             "version": "21.1.1",
+            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": ">=12"
@@ -10613,28 +10851,14 @@
             "version": "24.0.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@mark.probst/typescript-json-schema": "0.55.0",
                 "quicktype-core": "file:../quicktype-core",
-                "typescript": "4.9.5"
+                "typescript-json-schema": "0.67.4"
             },
             "devDependencies": {
                 "@types/node": "~20.19.0"
             },
             "engines": {
                 "node": ">=20.0.0"
-            }
-        },
-        "packages/quicktype-typescript-input/node_modules/typescript": {
-            "version": "4.9.5",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-            "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-            "license": "Apache-2.0",
-            "bin": {
-                "tsc": "bin/tsc",
-                "tsserver": "bin/tsserver"
-            },
-            "engines": {
-                "node": ">=4.2.0"
             }
         },
         "packages/quicktype-vscode": {

--- a/packages/quicktype-typescript-input/package.json
+++ b/packages/quicktype-typescript-input/package.json
@@ -15,8 +15,7 @@
     },
     "dependencies": {
         "quicktype-core": "file:../quicktype-core",
-        "typescript": "4.9.5",
-        "@mark.probst/typescript-json-schema": "0.55.0"
+        "typescript-json-schema": "0.67.4"
     },
     "devDependencies": {
         "@types/node": "~20.19.0"

--- a/packages/quicktype-typescript-input/src/index.ts
+++ b/packages/quicktype-typescript-input/src/index.ts
@@ -1,13 +1,16 @@
 import {
-    type PartialArgs,
-    generateSchema,
-} from "@mark.probst/typescript-json-schema";
-import {
     type JSONSchemaSourceData,
     defined,
     messageError,
 } from "quicktype-core";
-import * as ts from "typescript";
+import {
+    type PartialArgs,
+    generateSchema,
+    // Use the TypeScript instance that typescript-json-schema is compiled
+    // against, so the program we create is guaranteed to be compatible with
+    // `generateSchema`.
+    ts,
+} from "typescript-json-schema";
 
 const settings: PartialArgs = {
     required: true,
@@ -43,7 +46,6 @@ export function schemaForTypeScriptSources(
         });
     }
 
-    // this breaks after upgrading to TS 5+
     const schema = generateSchema(program, "*", settings);
     const uris: string[] = [];
     let topLevelName = "";

--- a/test/unit/typescript-input.test.ts
+++ b/test/unit/typescript-input.test.ts
@@ -1,0 +1,124 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import { schemaForTypeScriptSources } from "quicktype-typescript-input";
+import { afterAll, describe, expect, test } from "vitest";
+
+// schemaForTypeScriptSources compiles with `rootDir: "."`, so the input files
+// must live under the current working directory (the repository root when
+// vitest runs). Use a temp directory inside the repository and pass paths
+// relative to the working directory.
+const temporaryDirectory = fs.mkdtempSync(
+    path.join(process.cwd(), ".tmp-typescript-input-test-"),
+);
+
+afterAll(() => {
+    fs.rmSync(temporaryDirectory, { recursive: true, force: true });
+});
+
+let uniqueFileIndex = 0;
+
+function schemaForSource(source: string) {
+    const fileName = path.join(
+        path.relative(process.cwd(), temporaryDirectory),
+        `input-${uniqueFileIndex++}.ts`,
+    );
+    fs.writeFileSync(fileName, source);
+    const result = schemaForTypeScriptSources([fileName]);
+    return {
+        name: result.name ?? "",
+        schema: JSON.parse(result.schema),
+        uris: result.uris,
+    };
+}
+
+describe("schemaForTypeScriptSources", () => {
+    test("converts a simple interface", () => {
+        const { schema, uris } = schemaForSource(`
+            export interface Person {
+                name: string;
+                age?: number;
+            }
+        `);
+
+        const person = schema.definitions.Person;
+        expect(person.type).toBe("object");
+        expect(person.properties.name.type).toBe("string");
+        expect(person.properties.age.type).toBe("number");
+        expect(person.required).toEqual(["name"]);
+        expect(person.additionalProperties).toBe(false);
+        expect(uris).toEqual(["#/definitions/"]);
+    });
+
+    test("a #TopLevel marker selects the top-level type and is stripped", () => {
+        const { name, schema, uris } = schemaForSource(`
+            /**
+             * The root type. #TopLevel
+             */
+            export interface Root {
+                id: number;
+                child: Child;
+            }
+
+            export interface Child {
+                label: string;
+            }
+        `);
+
+        expect(name).toBe("Root");
+        expect(uris).toEqual(["#/definitions/Root"]);
+        expect(schema.definitions.Root.description).not.toContain("#TopLevel");
+    });
+
+    test("export default types are rewritten to a named ref", () => {
+        const { name, schema } = schemaForSource(`
+            export default interface Person {
+                name: string;
+            }
+        `);
+
+        expect(name).toBe("Person");
+        expect(schema.definitions.default).toEqual({
+            $ref: "#/definitions/Person",
+        });
+        expect(schema.definitions.Person.type).toBe("object");
+    });
+
+    test("class property initializers become defaults", () => {
+        const { schema } = schemaForSource(`
+            export class Config {
+                public name: string = "default-name";
+
+                public count: number = 42;
+            }
+        `);
+
+        const config = schema.definitions.Config;
+        expect(config.properties.name.default).toBe("default-name");
+        expect(config.properties.count.default).toBe(42);
+    });
+
+    // The previously used fork of typescript-json-schema threw
+    // "Unsupported type: bigint" here.
+    test("bigint properties are converted to numbers", () => {
+        const { schema } = schemaForSource(`
+            export interface WithBigint {
+                big: bigint;
+            }
+        `);
+
+        expect(schema.definitions.WithBigint.properties.big.type).toBe(
+            "number",
+        );
+    });
+
+    test("compiler errors are reported as quicktype errors", () => {
+        expect(() =>
+            schemaForSource(`
+                export interface Broken {
+                    name: DoesNotExist;
+                }
+            `),
+        ).toThrow(/TypeScript error/);
+    });
+});


### PR DESCRIPTION
Fixes #2622

## Problem

Every `npm install` of quicktype warns:

```
npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. ...
npm warn deprecated glob@7.2.3: Old versions of glob are not supported, ...
```

via `quicktype-typescript-input` → `@mark.probst/typescript-json-schema@0.55.0` → `glob@7.2.3` → `inflight@1.0.6`.

## Approach

Switch `quicktype-typescript-input` from the fork to upstream `typescript-json-schema@0.67.4`, which depends on `glob@13` (no `inflight`).

Why the fork is no longer needed:

- Diffing the published fork tarball against upstream `0.55.0` shows the fork's **only** source change is a defensive bigint guard in `extractLiteralValue` (added in 2018), plus a TypeScript version pin. Upstream has since gained proper bigint support (the fork actually *threw* `Unsupported type: bigint` on `bigint` properties; upstream converts them to `number`).
- Upstream `0.55.0`+ already evaluated class property initializers with Node's `vm`; `0.67.x` merely swapped that for the (actively maintained again, advisory-free) `vm2` sandbox — no behavior change for quicktype.

This also lets us drop the package's stale `typescript@4.9.5` pin entirely: we now import the `ts` instance that `typescript-json-schema` re-exports, so the `ts.Program` we create is always compiled by the exact TypeScript version the schema generator is built against. That resolves the old `// this breaks after upgrading to TS 5+` FIXME (the fork was compiled against TS 4.9 and could not consume a TS 5 program) and removes the need to keep two `typescript` versions in sync by hand.

Added `test/unit/typescript-input.test.ts` covering `schemaForTypeScriptSources`: simple interfaces, the `export default` ref rewrite, `#TopLevel` marker handling, property-initializer defaults (the `vm2` path), bigint conversion, and compiler-error reporting.

No workspace package versions were bumped (versions are stamped at release).

## Verification

- **Output equivalence**: generated TypeScript from 83 test JSON inputs (priority/misc/samples) plus 5 hand-written edge cases (export default, `#TopLevel`, class initializers, enums, bigint), then ran the built CLI with `--src-lang typescript` on all of them before and after the change. Generated C# is **byte-for-byte identical** for all 87 inputs that worked before; the bigint input goes from a hard error to correct output. Raw schema differences are cosmetic only (single-value enums emitted as `const`, which `quicktype-core` already normalizes; enum values in declaration order).
- `npm run build` and `npm run test:unit` (72 tests) pass; `QUICKTEST=true FIXTURE=javascript,typescript npm run test:fixtures -- test/inputs/json/samples/pokedex.json` passes. The `json-ts-csharp` fixture in CI covers the JSON→TS→C# roundtrip.
- **Consumer install**: packed `quicktype-typescript-input` (with the `file:` dep stamped as at release) and installed it in a scratch project — zero deprecation warnings, `npm audit` clean, and `npm ls glob inflight` shows only `glob@13.0.6`, no `inflight`:

  ```
  └─┬ quicktype-typescript-input@24.0.0
    └─┬ typescript-json-schema@0.67.4
      └── glob@13.0.6
  ```

- In the workspace lockfile, the only remaining `glob@7`/`inflight` chains are devDependencies (eslint, vscode test tooling) that never reach consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)