### PR TITLE
Fix published .d.ts files breaking strict consumers (skipLibCheck: false)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
             ],
             "dependencies": {
                 "@glideapps/ts-necessities": "^2.2.3",
+                "@types/readable-stream": "4.0.10",
                 "chalk": "^4.1.2",
                 "collection-utils": "^1.0.1",
                 "command-line-args": "^5.2.1",
@@ -2148,7 +2149,6 @@
         },
         "node_modules/@types/readable-stream": {
             "version": "4.0.10",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/node": "*",
@@ -2202,7 +2202,6 @@
         },
         "node_modules/@types/urijs": {
             "version": "1.19.25",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/vscode": {
@@ -10556,6 +10555,8 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@glideapps/ts-necessities": "2.2.3",
+                "@types/readable-stream": "4.0.10",
+                "@types/urijs": "^1.19.25",
                 "browser-or-node": "^3.0.0",
                 "collection-utils": "^1.0.1",
                 "is-url": "^1.2.4",
@@ -10575,11 +10576,8 @@
                 "@types/node": "~20.19.0",
                 "@types/pako": "^1.0.0",
                 "@types/pluralize": "0.0.30",
-                "@types/readable-stream": "4.0.10",
                 "@types/unicode-properties": "^1.3.0",
-                "@types/urijs": "^1.19.25",
                 "@types/wordwrap": "^1.0.3",
-                "command-line-args": "^5.2.1",
                 "typescript": "~5.8.3"
             },
             "engines": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     ],
     "dependencies": {
         "@glideapps/ts-necessities": "^2.2.3",
+        "@types/readable-stream": "4.0.10",
         "chalk": "^4.1.2",
         "collection-utils": "^1.0.1",
         "command-line-args": "^5.2.1",

--- a/packages/quicktype-core/package.json
+++ b/packages/quicktype-core/package.json
@@ -15,6 +15,8 @@
     },
     "dependencies": {
         "@glideapps/ts-necessities": "2.2.3",
+        "@types/readable-stream": "4.0.10",
+        "@types/urijs": "^1.19.25",
         "browser-or-node": "^3.0.0",
         "collection-utils": "^1.0.1",
         "is-url": "^1.2.4",
@@ -34,11 +36,8 @@
         "@types/node": "~20.19.0",
         "@types/pako": "^1.0.0",
         "@types/pluralize": "0.0.30",
-        "@types/readable-stream": "4.0.10",
         "@types/unicode-properties": "^1.3.0",
-        "@types/urijs": "^1.19.25",
         "@types/wordwrap": "^1.0.3",
-        "command-line-args": "^5.2.1",
         "typescript": "~5.8.3"
     },
     "files": ["dist"],

--- a/packages/quicktype-core/src/RendererOptions/types.ts
+++ b/packages/quicktype-core/src/RendererOptions/types.ts
@@ -12,10 +12,11 @@ export type OptionType = "string" | "boolean" | "enum";
 // that package is a dependency of the quicktype CLI, not of quicktype-core,
 // so the type-only import leaked into the published declarations and broke
 // consumers that compile with `skipLibCheck: false` (issue #2904).  The
-// fields below that have no quicktype-specific meaning (`alias`, `group`,
-// `defaultOption`, `lazyMultiple`, `type`) mirror the previously inherited
-// fields of command-line-args' `OptionDefinition`, so option definitions
-// remain directly consumable by `commandLineArgs` in the CLI.
+// `alias` and `defaultOption` fields below mirror the previously inherited
+// command-line-args fields of the same names, so the CLI's option
+// definitions remain directly consumable by `commandLineArgs` (the CLI adds
+// `type` itself at the call site).  The other previously inherited fields
+// (`group`, `lazyMultiple`, `type`) were dropped as unused.
 export interface OptionDefinition<Name extends string = string, T = unknown> {
     /** Option Name */
     name: Name;
@@ -23,12 +24,6 @@ export interface OptionDefinition<Name extends string = string, T = unknown> {
     alias?: string;
     /** Whether the CLI treats this option as the default positional argument */
     defaultOption?: boolean;
-    /** CLI option group(s) this option belongs to */
-    group?: string | string[];
-    /** Whether repeated CLI values require repeating the option name */
-    lazyMultiple?: boolean;
-    /** Converts a CLI string input to the option's value type */
-    type?: (input: string) => unknown;
     /** Option Description */
     description: string;
     /** Category of Option */

--- a/packages/quicktype-core/src/RendererOptions/types.ts
+++ b/packages/quicktype-core/src/RendererOptions/types.ts
@@ -1,5 +1,4 @@
 import type { EnumOption, Option } from "./index";
-import type { OptionDefinition as CommandLineArgsOptionDefinition } from "command-line-args";
 
 /**
  * Primary options show up in the web UI in the "Language" settings tab,
@@ -9,10 +8,27 @@ import type { OptionDefinition as CommandLineArgsOptionDefinition } from "comman
 export type OptionKind = "primary" | "secondary" | "cli";
 export type OptionType = "string" | "boolean" | "enum";
 
-export interface OptionDefinition<Name extends string = string, T = unknown>
-    extends CommandLineArgsOptionDefinition {
+// This interface used to extend command-line-args' `OptionDefinition`, but
+// that package is a dependency of the quicktype CLI, not of quicktype-core,
+// so the type-only import leaked into the published declarations and broke
+// consumers that compile with `skipLibCheck: false` (issue #2904).  The
+// fields below that have no quicktype-specific meaning (`alias`, `group`,
+// `defaultOption`, `lazyMultiple`, `type`) mirror the previously inherited
+// fields of command-line-args' `OptionDefinition`, so option definitions
+// remain directly consumable by `commandLineArgs` in the CLI.
+export interface OptionDefinition<Name extends string = string, T = unknown> {
     /** Option Name */
     name: Name;
+    /** Single-character CLI alias, e.g. `-o` for `--out` */
+    alias?: string;
+    /** Whether the CLI treats this option as the default positional argument */
+    defaultOption?: boolean;
+    /** CLI option group(s) this option belongs to */
+    group?: string | string[];
+    /** Whether repeated CLI values require repeating the option name */
+    lazyMultiple?: boolean;
+    /** Converts a CLI string input to the option's value type */
+    type?: (input: string) => unknown;
     /** Option Description */
     description: string;
     /** Category of Option */

--- a/test/unit/core-package.test.ts
+++ b/test/unit/core-package.test.ts
@@ -39,6 +39,69 @@ function findNodeImports(directory: string): string[] {
     return offenders;
 }
 
+// Matches module specifiers that can appear in declaration files: static
+// imports/re-exports (`from "urijs"`), inline type imports (`import("urijs")`),
+// and triple-slash type references (`/// <reference types="node" />`).
+const declarationSpecifierPattern =
+    /(?:from\s+|import\s*\(\s*)["']([^"']+)["']|\/\/\/\s*<reference\s+types\s*=\s*["']([^"']+)["']/g;
+
+function findDeclarationFiles(directory: string): string[] {
+    const files: string[] = [];
+
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+        const fullPath = path.join(directory, entry.name);
+        if (entry.isDirectory()) {
+            files.push(...findDeclarationFiles(fullPath));
+        } else if (entry.isFile() && entry.name.endsWith(".d.ts")) {
+            files.push(fullPath);
+        }
+    }
+
+    return files;
+}
+
+// "lodash/fp" -> "lodash", "@glideapps/ts-necessities/dist/x" -> "@glideapps/ts-necessities"
+function packageNameOfSpecifier(specifier: string): string {
+    const parts = specifier.split("/");
+    return specifier.startsWith("@") ? parts.slice(0, 2).join("/") : parts[0];
+}
+
+// "@glideapps/ts-necessities" -> "@types/glideapps__ts-necessities"
+function typesPackageFor(packageName: string): string {
+    return packageName.startsWith("@")
+        ? `@types/${packageName.slice(1).replace("/", "__")}`
+        : `@types/${packageName}`;
+}
+
+function packageShipsTypes(
+    packageName: string,
+    fromDirectory: string,
+): boolean {
+    let manifestPath: string;
+    try {
+        manifestPath = require.resolve(`${packageName}/package.json`, {
+            paths: [fromDirectory],
+        });
+    } catch {
+        return false;
+    }
+
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8")) as {
+        exports?: unknown;
+        types?: string;
+        typings?: string;
+    };
+    if (manifest.types !== undefined || manifest.typings !== undefined) {
+        return true;
+    }
+
+    if (JSON.stringify(manifest.exports ?? null).includes('"types"')) {
+        return true;
+    }
+
+    return fs.existsSync(path.join(path.dirname(manifestPath), "index.d.ts"));
+}
+
 describe("quicktype-core package", () => {
     // Importing the built quicktype-core must not print anything: CLI users
     // redirect stdout (`quicktype ... > out.ts`), so any stray output
@@ -67,4 +130,71 @@ describe("quicktype-core package", () => {
     test("does not use node:-prefixed imports in browser-compatible source", () => {
         expect(findNodeImports(coreSourceDirectory)).toEqual([]);
     });
+
+    // Every bare module specifier in the published .d.ts files must resolve
+    // to type declarations out of the package's own runtime dependencies,
+    // because consumers who compile with `skipLibCheck: false` typecheck
+    // those files.  quicktype-core 24.0.0 shipped a type-only import of
+    // "command-line-args" (a dependency of the CLI, not of quicktype-core;
+    // TS2307 for consumers) and imports of the untyped "urijs" and
+    // "readable-stream" whose @types packages were only devDependencies
+    // (TS7016 under strict) — see
+    // https://github.com/glideapps/quicktype/issues/2904.
+    test.each([
+        ".",
+        "packages/quicktype-core",
+        "packages/quicktype-graphql-input",
+        "packages/quicktype-typescript-input",
+    ])(
+        "declaration files in %s only reference dependencies that resolve with types",
+        (relativePackageDirectory) => {
+            const packageDirectory = path.join(
+                repositoryRoot,
+                relativePackageDirectory,
+            );
+            const declarationFiles = findDeclarationFiles(
+                path.join(packageDirectory, "dist"),
+            );
+            expect(declarationFiles.length).toBeGreaterThan(0);
+
+            const manifest = JSON.parse(
+                fs.readFileSync(
+                    path.join(packageDirectory, "package.json"),
+                    "utf8",
+                ),
+            ) as { dependencies: Record<string, string> };
+            const dependencies = manifest.dependencies;
+
+            const offenders: string[] = [];
+            for (const declarationFile of declarationFiles) {
+                const contents = fs.readFileSync(declarationFile, "utf8");
+                for (const match of contents.matchAll(
+                    declarationSpecifierPattern,
+                )) {
+                    const specifier = match[1] ?? match[2];
+                    if (specifier.startsWith(".")) continue;
+
+                    const packageName = packageNameOfSpecifier(specifier);
+                    const problem =
+                        dependencies[packageName] === undefined
+                            ? "is not a runtime dependency"
+                            : dependencies[typesPackageFor(packageName)] ===
+                                    undefined &&
+                                !packageShipsTypes(
+                                    packageName,
+                                    packageDirectory,
+                                )
+                              ? "has no type declarations"
+                              : undefined;
+                    if (problem !== undefined) {
+                        offenders.push(
+                            `${path.relative(repositoryRoot, declarationFile)}: "${specifier}" ${problem}`,
+                        );
+                    }
+                }
+            }
+
+            expect(offenders).toEqual([]);
+        },
+    );
 });


### PR DESCRIPTION
Fixes #2904

## Problem

quicktype-core 24.0.0's published TypeScript declarations fail to typecheck in consumer projects compiling with `"strict": true, "skipLibCheck": false`:

1. `dist/RendererOptions/types.d.ts` contained `import type { OptionDefinition as CommandLineArgsOptionDefinition } from "command-line-args"` — but `command-line-args` is a dependency of the CLI package, not of quicktype-core, so the import can't resolve in a consumer's `node_modules` (TS2307).
2. `dist/input/JSONSchemaInput.d.ts`, `dist/input/io/NodeIO.d.ts`, and `dist/input/io/get-stream/index.d.ts` import `urijs` and `readable-stream`, which ship no type declarations; `@types/urijs` and `@types/readable-stream` were only devDependencies (TS7016 under strict).

## Approach

- **Phantom `command-line-args` import**: quicktype-core's `OptionDefinition` extended command-line-args' `OptionDefinition` purely so the CLI can pass option definitions straight to `commandLineArgs`. The two previously inherited fields the CLI actually uses (`alias` and `defaultOption`) are now inlined into the interface, making the declarations self-contained; the unused inherited fields (`group`, `lazyMultiple`, `type` — the CLI overwrites `type` at the `commandLineArgs` call site anyway) are dropped. `command-line-args` is dropped from quicktype-core's devDependencies (nothing else in the package references it).
- **Untyped `urijs`/`readable-stream`**: `@types/urijs` and `@types/readable-stream` move from devDependencies to regular dependencies of quicktype-core. The public API genuinely exposes these types — `Ref.addressURI`/`Ref.parseURI` take/return urijs `URI` instances, and `getStream`/`readableFromFileOrURL` use readable-stream's `Readable` — so per the standard rule, the `@types` packages the declarations reference must be regular dependencies. (Replacing them with hand-rolled structural types would misrepresent the API or require breaking changes; switching to Node's stream types would break browser consumers, which is why `readable-stream` is used in the first place.)
- The root `quicktype` package's own published declarations (`dist/index.d.ts`, `dist/TypeSource.d.ts`, `dist/CompressedJSONFromStream.d.ts`) also import `readable-stream`, so `@types/readable-stream` is added to its dependencies as well.
- **Regression guard**: a new Vitest unit test scans every published package's emitted `.d.ts` files (CI builds before running unit tests) and asserts that each bare import specifier is a declared runtime dependency that resolves with type declarations — either the package ships its own types or the matching `@types/*` package is also a dependency. It fails on both bug classes (verified by re-introducing the phantom import).

No version bumps, per repo convention.

## Verification

- `npm run build` (whole monorepo) succeeds; `node dist/index.js --version` works.
- `npm run test:unit`: 70/70 tests pass (including 4 new declaration-surface checks).
- End-to-end strict consumer check: `npm pack`ed the built quicktype-core into a scratch project (`npm install ./quicktype-core-24.0.0.tgz typescript@5.8 @types/node`) and compiled the issue's exact repro with `tsc --strict --module commonjs --target es2020 --esModuleInterop --skipLibCheck false main.ts` — compiles with **zero errors** and the generated program runs correctly. The same scratch setup against the published 24.0.0 reproduces all four errors from the issue (1× TS2307, 3× TS7016).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
