### PR TITLE
README: document esbuild ESM bundling workaround for quicktype-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,23 @@ main();
 
 The argument to `quicktype` is a complex object with many optional properties. [Explore its definition](https://github.com/quicktype/quicktype/blob/master/packages/quicktype-core/src/Run.ts#L637) to understand what options are allowed.
 
+#### Bundling `quicktype-core` as ESM
+
+`quicktype-core` ships both CommonJS and ESM builds. If you bundle it into an ESM output for Node with esbuild (`--format=esm --platform=node`), the bundle may throw at runtime:
+
+```
+Error: Dynamic require of "process" is not supported
+```
+
+This is not specific to quicktype: some of its dependencies (e.g. `yaml`) expose an ESM entry that wraps a CommonJS core, and esbuild replaces `require` calls inside inlined CommonJS with a shim that throws in ESM output. The standard workaround is to inject a `createRequire` banner:
+
+```bash
+esbuild main.js --bundle --format=esm --platform=node \
+    --banner:js="import { createRequire } from 'module'; const require = createRequire(import.meta.url);"
+```
+
+Bundling to CommonJS output (`--format=cjs`) works without any workaround.
+
 ### Adding Custom logic or Rendering:
 
 Quicktype supports creating your own custom languages and rendering output, you can extend existing classes or create your own to be using by the `quicktype function`.<br/>


### PR DESCRIPTION
## Summary

Adds a short "Bundling `quicktype-core` as ESM" note to the README, under the *Calling `quicktype` from JavaScript* section.

While verifying the 24.0.1 release (#2906), I found that bundling `quicktype-core` into ESM output for Node with esbuild (`--format=esm --platform=node`) produces a bundle that throws at runtime:

```
Error: Dynamic require of "process" is not supported
```

This isn't a quicktype bug — dependencies like `yaml` expose an ESM entry that wraps a CommonJS core, and esbuild's require shim throws in ESM output — but users bundling for ESM will hit it, so it's worth a mention. The note documents the standard `createRequire` banner workaround (verified working on Node 20/22/24) and points out that CJS-format bundles need no workaround.

## Testing

- Reproduced the failure and verified the banner workaround with esbuild against `quicktype-core@24.0.1` on Node 20.19.4, 22.23.1, and 24.6.0.
- Docs-only change; no code affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)