### PR TITLE
Document LanguageName and the isLanguageName validation pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,25 @@ main();
 
 The argument to `quicktype` is a complex object with many optional properties. [Explore its definition](https://github.com/quicktype/quicktype/blob/master/packages/quicktype-core/src/Run.ts#L637) to understand what options are allowed.
 
+#### TypeScript: the `lang` option is a `LanguageName`, not a `string`
+
+In TypeScript, the `lang` option of `quicktype` and the argument of `jsonInputForTargetLanguage` are typed as `LanguageName`, a union of all supported language names — passing a plain `string` is a compile-time error. If the language name is known statically, just pass the literal (`lang: "swift"`). For wrappers that take the language name at runtime — from CLI arguments or configuration — validate it with the `isLanguageName` type guard instead of casting:
+
+```typescript
+import { type LanguageName, isLanguageName, quicktype } from "quicktype-core";
+
+async function quicktypeJSON(targetLanguage: LanguageName, typeName: string, jsonString: string) {
+    // same body as above
+}
+
+const lang = process.argv[2]; // untrusted string
+if (!isLanguageName(lang)) {
+    throw new Error(`Unknown language: ${lang}`);
+}
+// lang now has type LanguageName
+const { lines } = await quicktypeJSON(lang, "Person", jsonString);
+```
+
 #### Bundling `quicktype-core` as ESM
 
 `quicktype-core` ships both CommonJS and ESM builds. If you bundle it into an ESM output for Node with esbuild (`--format=esm --platform=node`), the bundle may throw at runtime:

--- a/packages/quicktype-core/src/language/All.ts
+++ b/packages/quicktype-core/src/language/All.ts
@@ -67,6 +67,14 @@ export const all = [
 
 all satisfies readonly TargetLanguage[];
 
+/**
+ * Returns the `TargetLanguage` registered under `name`.
+ *
+ * `name` must be one of the `LanguageName` literals, so plain strings from
+ * CLI arguments or configuration must first be narrowed with
+ * {@link isLanguageName}.  Throws if no language in `targetLanguages` is
+ * named `name`, which can only happen when passing a custom language list.
+ */
 export function languageNamed<Name extends LanguageName>(
     name: Name,
     targetLanguages: readonly TargetLanguage[] = all,
@@ -81,6 +89,21 @@ export function languageNamed<Name extends LanguageName>(
     return foundLanguage as LanguageNameMap[Name];
 }
 
+/**
+ * Type guard that narrows a runtime `string` to `LanguageName`.
+ *
+ * Use this to validate untrusted input — CLI arguments, configuration
+ * files, HTTP parameters — before passing it to `quicktype` or
+ * `jsonInputForTargetLanguage`, instead of casting with `as LanguageName`.
+ *
+ * @example
+ * const lang = process.argv[2];
+ * if (!isLanguageName(lang)) {
+ *     throw new Error(`Unknown language: ${lang}`);
+ * }
+ * // lang now has type LanguageName
+ * await quicktype({ inputData, lang });
+ */
 export function isLanguageName(maybeName: string): maybeName is LanguageName {
     if (
         all.some((lang) =>

--- a/packages/quicktype-core/src/language/types.ts
+++ b/packages/quicktype-core/src/language/types.ts
@@ -4,9 +4,18 @@ import type { all } from "./All.js";
 
 type AllLanguages = (typeof all)[number];
 
+/** The display name of a built-in target language, e.g. `"C++"` or `"TypeScript"`. */
 export type LanguageDisplayName<
     Language extends TargetLanguage = AllLanguages,
 > = Language["displayName"];
+/**
+ * The union of all name aliases of the built-in target languages, e.g.
+ * `"c++"`, `"ts"`, `"typescript"`.  This is what `quicktype`'s `lang`
+ * option and `jsonInputForTargetLanguage` accept instead of `string`.
+ *
+ * To use a runtime `string` where a `LanguageName` is expected, narrow
+ * it with the `isLanguageName` type guard rather than casting.
+ */
 export type LanguageName<Language extends TargetLanguage = AllLanguages> =
     Language["names"][number];
 


### PR DESCRIPTION
## Description

Fixes #2905 — documentation for the 24.0.0 `lang` typing change, as requested in [this comment](https://github.com/glideapps/quicktype/issues/2905#issuecomment-4942756944).

In 24.0.0, `quicktype()`'s `lang` option and `jsonInputForTargetLanguage()`'s parameter are the strict literal union `LanguageName | TargetLanguage`, so the widely-circulated wrapper samples taking `targetLanguage: string` fail with TS2345/TS2322. The resolution existed but was undocumented.

## What was already there vs. what this adds

- **Already exported** from the `quicktype-core` public entry: `LanguageName`, `LanguageDisplayName`, `isLanguageName`, `languageNamed` (via `src/language/index.ts`). No export changes were needed.
- **Added TSDoc** on `LanguageName` / `LanguageDisplayName` (`language/types.ts`) and on `isLanguageName` / `languageNamed` (`language/All.ts`), with an `@example` showing runtime narrowing.
- **Added a README subsection** after the "Calling quicktype from JavaScript" sample: *"TypeScript: the `lang` option is a `LanguageName`, not a `string`"* — pass a literal when the language is static; narrow untrusted CLI/config strings with the `isLanguageName` type guard instead of an `as LanguageName` cast, exactly the pattern the issue comment asked for.

## Verification

- Full build + 59/59 unit tests.
- The documented pattern was typechecked (`tsc --strict`) as an external consumer against the built package types: the guard narrows `string` → `LanguageName` and the call compiles; a negative control passing the un-narrowed `string` fails with the exact TS2345 from the issue.
- Biome clean on touched files.

Note: the issue also floats mentioning the break in the 24.0.0 release notes — that's a GitHub-Release edit outside this PR, left to maintainer discretion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)