### PR TITLE
Support prerelease publishing from release tags

### DIFF
--- a/.github/workflows/publish-npm.yaml
+++ b/.github/workflows/publish-npm.yaml
@@ -9,7 +9,6 @@ concurrency:
 
 jobs:
     publish-npm:
-        if: github.event.release.prerelease == false
         runs-on: ubuntu-22.04
         permissions:
             # Required for npm Trusted Publishing (OIDC): npm mints

--- a/.github/workflows/publish-vscode.yaml
+++ b/.github/workflows/publish-vscode.yaml
@@ -9,7 +9,10 @@ concurrency:
 
 jobs:
     publish-vscode:
-        if: github.event.release.prerelease == false
+        # The Marketplace does not accept SemVer prerelease suffixes. npm
+        # prereleases still publish from -preN tags; the extension waits for
+        # the corresponding stable release.
+        if: ${{ !contains(github.event.release.tag_name, '-pre') }}
         runs-on: ubuntu-22.04
         permissions:
             contents: read

--- a/script/publish-npm.sh
+++ b/script/publish-npm.sh
@@ -10,6 +10,7 @@ set -e
 
 : "${RELEASE_VERSION:?RELEASE_VERSION must be set from the GitHub release tag}"
 ./script/release-version.ts stamp "$RELEASE_VERSION"
+NPM_TAG=$(./script/release-version.ts npm-tag "$RELEASE_VERSION")
 
 publish_package() {
     local directory=$1
@@ -23,7 +24,7 @@ publish_package() {
     fi
 
     pushd "$directory"
-    npm publish
+    npm publish --tag "$NPM_TAG"
     popd
 }
 

--- a/script/release-version.ts
+++ b/script/release-version.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import * as semver from "semver";
 
 type PublishAction = "publish" | "skip";
+type NpmDistTag = "latest" | "pre";
 
 interface PackageManifest {
     version: string;
@@ -38,9 +39,13 @@ const internalDependencies = new Set([
 ]);
 
 export function parseReleaseTag(tag: string): string {
-    if (!/^v(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$/.test(tag)) {
+    if (
+        !/^v(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-pre[1-9]\d*)?$/.test(
+            tag,
+        )
+    ) {
         throw new Error(
-            `Release tag ${JSON.stringify(tag)} must have the form vMAJOR.MINOR.PATCH`,
+            `Release tag ${JSON.stringify(tag)} must have the form vMAJOR.MINOR.PATCH or vMAJOR.MINOR.PATCH-preN`,
         );
     }
 
@@ -53,15 +58,74 @@ export function parseReleaseTag(tag: string): string {
     return version;
 }
 
-function requireStableVersion(version: string): void {
-    if (
-        semver.valid(version) !== version ||
-        semver.prerelease(version) !== null
-    ) {
+function requireReleaseVersion(version: string): void {
+    if (!parseReleaseVersion(version)) {
         throw new Error(
-            `${JSON.stringify(version)} is not a stable SemVer version`,
+            `${JSON.stringify(version)} is not a supported release version`,
         );
     }
+}
+
+interface ReleaseVersion {
+    major: number;
+    minor: number;
+    patch: number;
+    prereleaseNumber?: number;
+}
+
+function parseReleaseVersion(version: string): ReleaseVersion | undefined {
+    const match =
+        /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-pre([1-9]\d*))?$/.exec(
+            version,
+        );
+    if (match === null || semver.valid(version) !== version) {
+        return undefined;
+    }
+    return {
+        major: Number(match[1]),
+        minor: Number(match[2]),
+        patch: Number(match[3]),
+        prereleaseNumber: match[4] === undefined ? undefined : Number(match[4]),
+    };
+}
+
+function compareReleaseVersions(left: string, right: string): number {
+    const parsedLeft = parseReleaseVersion(left);
+    const parsedRight = parseReleaseVersion(right);
+    if (parsedLeft === undefined || parsedRight === undefined) {
+        throw new Error("Cannot compare unsupported release versions");
+    }
+
+    for (const component of ["major", "minor", "patch"] as const) {
+        const difference = parsedLeft[component] - parsedRight[component];
+        if (difference !== 0) {
+            return difference;
+        }
+    }
+
+    if (parsedLeft.prereleaseNumber === undefined) {
+        return parsedRight.prereleaseNumber === undefined ? 0 : 1;
+    }
+    if (parsedRight.prereleaseNumber === undefined) {
+        return -1;
+    }
+    return parsedLeft.prereleaseNumber - parsedRight.prereleaseNumber;
+}
+
+function newestReleaseVersion(versions: readonly string[]): string | undefined {
+    return versions.reduce<string | undefined>(
+        (newest, candidate) =>
+            newest === undefined ||
+            compareReleaseVersions(candidate, newest) > 0
+                ? candidate
+                : newest,
+        undefined,
+    );
+}
+
+export function npmDistTag(version: string): NpmDistTag {
+    requireReleaseVersion(version);
+    return semver.prerelease(version) === null ? "latest" : "pre";
 }
 
 export function publishAction(
@@ -69,15 +133,13 @@ export function publishAction(
     publishedVersions: readonly string[],
     target: string,
 ): PublishAction {
-    requireStableVersion(version);
+    requireReleaseVersion(version);
     const validVersions = publishedVersions.filter(
-        (candidate) =>
-            semver.valid(candidate) === candidate &&
-            semver.prerelease(candidate) === null,
+        (candidate) => parseReleaseVersion(candidate) !== undefined,
     );
-    const newest = semver.rsort(validVersions)[0];
+    const newest = newestReleaseVersion(validVersions);
 
-    if (newest !== undefined && semver.gt(newest, version)) {
+    if (newest !== undefined && compareReleaseVersions(newest, version) > 0) {
         throw new Error(
             `${target} already has newer version ${newest}; refusing to publish ${version}`,
         );
@@ -89,7 +151,7 @@ export function publishAction(
 }
 
 export function stampManifests(root: string, version: string): void {
-    requireStableVersion(version);
+    requireReleaseVersion(version);
 
     for (const relativePath of manifests) {
         const path = join(root, relativePath);
@@ -115,14 +177,9 @@ export function validateAgainstPreviousReleases(
     currentReleaseId: number,
     releases: readonly GitHubRelease[],
 ): string | undefined {
-    requireStableVersion(version);
+    requireReleaseVersion(version);
     const previousVersions = releases
-        .filter(
-            (release) =>
-                !release.draft &&
-                !release.prerelease &&
-                release.id !== currentReleaseId,
-        )
+        .filter((release) => !release.draft && release.id !== currentReleaseId)
         .map((release) => {
             try {
                 return parseReleaseTag(release.tag_name);
@@ -131,9 +188,9 @@ export function validateAgainstPreviousReleases(
             }
         })
         .filter((candidate): candidate is string => candidate !== undefined);
-    const newest = semver.rsort(previousVersions)[0];
+    const newest = newestReleaseVersion(previousVersions);
 
-    if (newest !== undefined && !semver.gt(version, newest)) {
+    if (newest !== undefined && compareReleaseVersions(version, newest) <= 0) {
         throw new Error(
             `Release version ${version} must be greater than previous release ${newest}`,
         );
@@ -245,6 +302,12 @@ async function main(): Promise<void> {
             }
             console.log(publishAction(second, npmVersions(first), first));
             return;
+        case "npm-tag":
+            if (first === undefined) {
+                throw new Error("npm-tag requires a version");
+            }
+            console.log(npmDistTag(first));
+            return;
         case "marketplace-action":
             if (first === undefined) {
                 throw new Error("marketplace-action requires a version");
@@ -259,7 +322,7 @@ async function main(): Promise<void> {
             return;
         default:
             throw new Error(
-                "Usage: release-version.ts <validate|stamp|npm-action|marketplace-action> ...",
+                "Usage: release-version.ts <validate|stamp|npm-action|npm-tag|marketplace-action> ...",
             );
     }
 }

--- a/test/release-version.ts
+++ b/test/release-version.ts
@@ -9,6 +9,7 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+    npmDistTag,
     parseReleaseTag,
     publishAction,
     stampManifests,
@@ -16,21 +17,38 @@ import {
 } from "../script/release-version";
 
 assert.equal(parseReleaseTag("v24.1.2"), "24.1.2");
+assert.equal(parseReleaseTag("v25.0.0-pre1"), "25.0.0-pre1");
+assert.equal(parseReleaseTag("v25.0.0-pre10"), "25.0.0-pre10");
 for (const tag of [
     "24.1.2",
     "v24.1",
     "v24.1.2-beta.1",
+    "v25.0.0-pre0",
+    "v25.0.0-pre01",
     "v024.1.2",
     "release-v24.1.2",
 ]) {
     assert.throws(() => parseReleaseTag(tag));
 }
 
+assert.equal(npmDistTag("24.1.2"), "latest");
+assert.equal(npmDistTag("25.0.0-pre1"), "pre");
+
 assert.equal(
     publishAction("24.0.0", ["23.3.2", "24.0.0-beta.1"], "test"),
     "publish",
 );
 assert.equal(publishAction("24.0.0", ["23.3.2", "24.0.0"], "test"), "skip");
+assert.equal(
+    publishAction("25.0.0-pre2", ["24.0.0", "25.0.0-pre1"], "test"),
+    "publish",
+);
+assert.equal(publishAction("25.0.0-pre10", ["25.0.0-pre9"], "test"), "publish");
+assert.equal(publishAction("25.0.0", ["25.0.0-pre2"], "test"), "publish");
+assert.throws(
+    () => publishAction("25.0.0-pre2", ["25.0.0"], "test"),
+    /newer version/,
+);
 assert.throws(
     () => publishAction("24.0.0", ["24.0.1"], "test"),
     /newer version/,
@@ -43,6 +61,18 @@ const releases = [
     { id: 4, tag_name: "v25.0.0-beta.1", draft: false, prerelease: true },
 ];
 assert.equal(validateAgainstPreviousReleases("24.0.0", 2, releases), "23.3.0");
+assert.equal(
+    validateAgainstPreviousReleases("24.1.0-pre2", 6, [
+        ...releases,
+        {
+            id: 5,
+            tag_name: "v24.1.0-pre1",
+            draft: false,
+            prerelease: true,
+        },
+    ]),
+    "24.1.0-pre1",
+);
 assert.throws(
     () => validateAgainstPreviousReleases("23.2.0", 2, releases),
     /must be greater/,
@@ -94,6 +124,25 @@ try {
             assert.equal(
                 version,
                 name.startsWith("quicktype-") ? "24.0.0" : "1.0.0",
+            );
+        }
+    }
+
+    stampManifests(root, "25.0.0-pre1");
+    for (const relativePath of Object.keys(packageFiles)) {
+        const manifest = JSON.parse(
+            readFileSync(join(root, relativePath), "utf8"),
+        ) as {
+            version: string;
+            dependencies?: Record<string, string>;
+        };
+        assert.equal(manifest.version, "25.0.0-pre1");
+        for (const [name, version] of Object.entries(
+            manifest.dependencies ?? {},
+        )) {
+            assert.equal(
+                version,
+                name.startsWith("quicktype-") ? "25.0.0-pre1" : "1.0.0",
             );
         }
     }


### PR DESCRIPTION
## Summary

- accept GitHub release tags such as `v25.0.0-pre1`
- publish all npm packages under the `pre` dist-tag without moving `latest`
- validate prerelease ordering numerically and keep stable release behavior unchanged
- use the tag as the source of truth instead of GitHub's prerelease checkbox
- skip VS Code Marketplace publishing for `-preN` tags because the Marketplace rejects SemVer prerelease versions

## Impact

Creating a GitHub release tagged `v25.0.0-pre1` now performs the complete npm prerelease publication. A later `v25.0.0` release publishes normally under `latest`.

## Validation

- `npm run test:release`
- `npm run build`
- `npm run test:unit` (70 tests)
- Biome check for changed TypeScript files
- TypeScript no-emit check for the release helper and tests
- shell and workflow YAML syntax checks