### PR TITLE
Adopt Biome lint rules

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -26,6 +26,7 @@
                 "noGlobalDirnameFilename": "on",
                 "noUnusedInstantiation": "on",
                 "useSingleJsDocAsterisk": "on",
+                "noConstructorReturn": "off",
                 "noVoidTypeReturn": "off"
             },
             "complexity": {

--- a/biome.json
+++ b/biome.json
@@ -21,9 +21,6 @@
         "enabled": true,
         "rules": {
             "preset": "recommended",
-            "style": {
-                "useTemplate": "off"
-            },
             "suspicious": {
                 "noExplicitAny": "off",
                 "noGlobalIsNan": "off",

--- a/biome.json
+++ b/biome.json
@@ -25,7 +25,8 @@
                 "noUndeclaredDependencies": "on",
                 "noGlobalDirnameFilename": "on",
                 "noUnusedInstantiation": "on",
-                "useSingleJsDocAsterisk": "on"
+                "useSingleJsDocAsterisk": "on",
+                "noVoidTypeReturn": "off"
             },
             "complexity": {
                 "noUselessReturn": "on",

--- a/biome.json
+++ b/biome.json
@@ -33,7 +33,8 @@
                 "useObjectSpread": "on",
                 "noYodaExpression": "on",
                 "noSubstr": "on",
-                "useExplicitLengthCheck": "on"
+                "useExplicitLengthCheck": "on",
+                "noMultiAssign": "on"
             },
             "suspicious": {
                 "noTemplateCurlyInString": "off"

--- a/biome.json
+++ b/biome.json
@@ -34,7 +34,6 @@
             },
             "correctness": {
                 "noConstructorReturn": "off",
-                "noSwitchDeclarations": "off",
                 "noVoidTypeReturn": "off"
             },
             "style": {

--- a/biome.json
+++ b/biome.json
@@ -35,7 +35,6 @@
             "correctness": {
                 "noConstructorReturn": "off",
                 "noSwitchDeclarations": "off",
-                "noUnusedVariables": "off",
                 "noVoidTypeReturn": "off",
                 "useParseIntRadix": "off"
             },

--- a/biome.json
+++ b/biome.json
@@ -40,7 +40,8 @@
                 "noUnusedTemplateLiteral": "on",
                 "useShorthandAssign": "on",
                 "noInferrableTypes": "on",
-                "useDefaultParameterLast": "on"
+                "useDefaultParameterLast": "on",
+                "useConsistentMethodSignatures": "on"
             },
             "suspicious": {
                 "noTemplateCurlyInString": "off"

--- a/biome.json
+++ b/biome.json
@@ -24,7 +24,6 @@
             "suspicious": {
                 "noExplicitAny": "off",
                 "noGlobalIsNan": "off",
-                "noPrototypeBuiltins": "off",
                 "noShadowRestrictedNames": "off",
                 "noTemplateCurlyInString": "off",
                 "noUselessEscapeInString": "off",

--- a/biome.json
+++ b/biome.json
@@ -37,6 +37,9 @@
                 "noRedundantDefaultExport": "on",
                 "noExcessiveNestedTestSuites": "on"
             },
+            "performance": {
+                "noDelete": "on"
+            },
             "style": {
                 "noUselessElse": "on",
                 "useCollapsedElseIf": "on",

--- a/biome.json
+++ b/biome.json
@@ -24,6 +24,9 @@
             "complexity": {
                 "noUselessReturn": "on"
             },
+            "style": {
+                "noUselessElse": "on"
+            },
             "suspicious": {
                 "noTemplateCurlyInString": "off"
             }

--- a/biome.json
+++ b/biome.json
@@ -23,7 +23,6 @@
             "preset": "recommended",
             "style": {
                 "noNonNullAssertion": "off",
-                "useNodejsImportProtocol": "off",
                 "useTemplate": "off"
             },
             "suspicious": {
@@ -42,6 +41,16 @@
     },
     "assist": { "actions": { "source": { "organizeImports": "off" } } },
     "overrides": [
+        {
+            "includes": ["packages/quicktype-core/src/**"],
+            "linter": {
+                "rules": {
+                    "style": {
+                        "useNodejsImportProtocol": "off"
+                    }
+                }
+            }
+        },
         {
             "includes": ["**/tsconfig.json", "**/tsconfig.*.json"],
             "json": {

--- a/biome.json
+++ b/biome.json
@@ -49,7 +49,8 @@
             },
             "suspicious": {
                 "noTemplateCurlyInString": "off",
-                "noEqualsToNull": "on"
+                "noEqualsToNull": "on",
+                "noUnusedExpressions": "on"
             }
         }
     },

--- a/biome.json
+++ b/biome.json
@@ -24,8 +24,7 @@
             "complexity": {
                 "noBannedTypes": "off",
                 "noUselessConstructor": "off",
-                "noUselessUndefinedInitialization": "off",
-                "useOptionalChain": "off"
+                "noUselessUndefinedInitialization": "off"
             },
             "style": {
                 "noNonNullAssertion": "off",

--- a/biome.json
+++ b/biome.json
@@ -25,7 +25,6 @@
                 "noBannedTypes": "off",
                 "noExtraBooleanCast": "off",
                 "noUselessConstructor": "off",
-                "noUselessContinue": "off",
                 "noUselessSwitchCase": "off",
                 "noUselessTernary": "off",
                 "noUselessUndefinedInitialization": "off",

--- a/biome.json
+++ b/biome.json
@@ -39,7 +39,8 @@
                 "useForOf": "on",
                 "noUnusedTemplateLiteral": "on",
                 "useShorthandAssign": "on",
-                "noInferrableTypes": "on"
+                "noInferrableTypes": "on",
+                "useDefaultParameterLast": "on"
             },
             "suspicious": {
                 "noTemplateCurlyInString": "off"

--- a/biome.json
+++ b/biome.json
@@ -22,7 +22,6 @@
         "rules": {
             "preset": "recommended",
             "style": {
-                "noNonNullAssertion": "off",
                 "useTemplate": "off"
             },
             "suspicious": {

--- a/biome.json
+++ b/biome.json
@@ -23,7 +23,6 @@
             "preset": "recommended",
             "style": {
                 "noNonNullAssertion": "off",
-                "useConst": "off",
                 "useExponentiationOperator": "off",
                 "useNodejsImportProtocol": "off",
                 "useTemplate": "off"

--- a/biome.json
+++ b/biome.json
@@ -21,6 +21,9 @@
         "enabled": true,
         "rules": {
             "preset": "recommended",
+            "complexity": {
+                "noUselessReturn": "on"
+            },
             "suspicious": {
                 "noTemplateCurlyInString": "off"
             }

--- a/biome.json
+++ b/biome.json
@@ -32,9 +32,6 @@
                 "useDateNow": "off",
                 "useOptionalChain": "off"
             },
-            "correctness": {
-                "noVoidTypeReturn": "off"
-            },
             "style": {
                 "noNonNullAssertion": "off",
                 "useConst": "off",

--- a/biome.json
+++ b/biome.json
@@ -32,7 +32,8 @@
                 "useConsistentBuiltinInstantiation": "on",
                 "useObjectSpread": "on",
                 "noYodaExpression": "on",
-                "noSubstr": "on"
+                "noSubstr": "on",
+                "useExplicitLengthCheck": "on"
             },
             "suspicious": {
                 "noTemplateCurlyInString": "off"

--- a/biome.json
+++ b/biome.json
@@ -48,7 +48,8 @@
                 "useReadonlyClassProperties": "on"
             },
             "suspicious": {
-                "noTemplateCurlyInString": "off"
+                "noTemplateCurlyInString": "off",
+                "noEqualsToNull": "on"
             }
         }
     },

--- a/biome.json
+++ b/biome.json
@@ -30,7 +30,6 @@
                 "noTemplateCurlyInString": "off",
                 "noTsIgnore": "off",
                 "noUselessEscapeInString": "off",
-                "useIsArray": "off",
                 "useIterableCallbackReturn": "off"
             }
         }

--- a/biome.json
+++ b/biome.json
@@ -31,7 +31,8 @@
                 "useThrowNewError": "on",
                 "useConsistentBuiltinInstantiation": "on",
                 "useObjectSpread": "on",
-                "noYodaExpression": "on"
+                "noYodaExpression": "on",
+                "noSubstr": "on"
             },
             "suspicious": {
                 "noTemplateCurlyInString": "off"

--- a/biome.json
+++ b/biome.json
@@ -24,7 +24,6 @@
             "suspicious": {
                 "noExplicitAny": "off",
                 "noTemplateCurlyInString": "off",
-                "noUselessEscapeInString": "off",
                 "useIterableCallbackReturn": "off"
             }
         }

--- a/biome.json
+++ b/biome.json
@@ -23,7 +23,6 @@
             "preset": "recommended",
             "complexity": {
                 "noBannedTypes": "off",
-                "noExtraBooleanCast": "off",
                 "noUselessConstructor": "off",
                 "noUselessUndefinedInitialization": "off",
                 "useDateNow": "off",

--- a/biome.json
+++ b/biome.json
@@ -44,7 +44,8 @@
                 "useConsistentMethodSignatures": "on",
                 "useUnifiedTypeSignatures": "on",
                 "noNamespace": "on",
-                "useNodeAssertStrict": "on"
+                "useNodeAssertStrict": "on",
+                "useReadonlyClassProperties": "on"
             },
             "suspicious": {
                 "noTemplateCurlyInString": "off"

--- a/biome.json
+++ b/biome.json
@@ -26,7 +26,8 @@
             },
             "style": {
                 "noUselessElse": "on",
-                "useCollapsedElseIf": "on"
+                "useCollapsedElseIf": "on",
+                "useCollapsedIf": "on"
             },
             "suspicious": {
                 "noTemplateCurlyInString": "off"

--- a/biome.json
+++ b/biome.json
@@ -28,7 +28,6 @@
                 "noPrototypeBuiltins": "off",
                 "noShadowRestrictedNames": "off",
                 "noTemplateCurlyInString": "off",
-                "noTsIgnore": "off",
                 "noUselessEscapeInString": "off",
                 "useIterableCallbackReturn": "off"
             }

--- a/biome.json
+++ b/biome.json
@@ -52,12 +52,25 @@
                 "noEqualsToNull": "on",
                 "noUnusedExpressions": "on",
                 "useArraySortCompare": "on",
-                "noMisplacedAssertion": "on"
+                "noMisplacedAssertion": "on",
+                "noShadow": "on"
             }
         }
     },
     "assist": { "actions": { "source": { "organizeImports": "off" } } },
     "overrides": [
+        {
+            "includes": [
+                "packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts"
+            ],
+            "linter": {
+                "rules": {
+                    "suspicious": {
+                        "noShadow": "off"
+                    }
+                }
+            }
+        },
         {
             "includes": ["test/release-version.ts"],
             "linter": {

--- a/biome.json
+++ b/biome.json
@@ -27,7 +27,8 @@
             "style": {
                 "noUselessElse": "on",
                 "useCollapsedElseIf": "on",
-                "useCollapsedIf": "on"
+                "useCollapsedIf": "on",
+                "useThrowNewError": "on"
             },
             "suspicious": {
                 "noTemplateCurlyInString": "off"

--- a/biome.json
+++ b/biome.json
@@ -58,7 +58,14 @@
                 "useUnifiedTypeSignatures": "on",
                 "noNamespace": "on",
                 "useNodeAssertStrict": "on",
-                "useReadonlyClassProperties": "on"
+                "useReadonlyClassProperties": "on",
+                "useThrowOnlyError": "on",
+                "useTrimStartEnd": "on",
+                "useSymbolDescription": "on",
+                "useSpreadOverApply": "on",
+                "useNumberNamespace": "on",
+                "useGlobalThis": "on",
+                "useErrorCause": "on"
             },
             "suspicious": {
                 "noTemplateCurlyInString": "off",

--- a/biome.json
+++ b/biome.json
@@ -23,8 +23,7 @@
             "preset": "recommended",
             "suspicious": {
                 "noExplicitAny": "off",
-                "noTemplateCurlyInString": "off",
-                "useIterableCallbackReturn": "off"
+                "noTemplateCurlyInString": "off"
             }
         }
     },

--- a/biome.json
+++ b/biome.json
@@ -34,7 +34,8 @@
                 "noYodaExpression": "on",
                 "noSubstr": "on",
                 "useExplicitLengthCheck": "on",
-                "noMultiAssign": "on"
+                "noMultiAssign": "on",
+                "useConsistentObjectDefinitions": "on"
             },
             "suspicious": {
                 "noTemplateCurlyInString": "off"

--- a/biome.json
+++ b/biome.json
@@ -25,7 +25,6 @@
                 "noBannedTypes": "off",
                 "noExtraBooleanCast": "off",
                 "noUselessConstructor": "off",
-                "noUselessTernary": "off",
                 "noUselessUndefinedInitialization": "off",
                 "useDateNow": "off",
                 "useOptionalChain": "off"

--- a/biome.json
+++ b/biome.json
@@ -18,7 +18,48 @@
         "indentWidth": 4
     },
     "linter": {
-        "enabled": false
+        "enabled": true,
+        "rules": {
+            "preset": "recommended",
+            "complexity": {
+                "noBannedTypes": "off",
+                "noExtraBooleanCast": "off",
+                "noUselessConstructor": "off",
+                "noUselessContinue": "off",
+                "noUselessSwitchCase": "off",
+                "noUselessTernary": "off",
+                "noUselessUndefinedInitialization": "off",
+                "useDateNow": "off",
+                "useOptionalChain": "off"
+            },
+            "correctness": {
+                "noConstructorReturn": "off",
+                "noSwitchDeclarations": "off",
+                "noUnusedImports": "off",
+                "noUnusedVariables": "off",
+                "noVoidTypeReturn": "off",
+                "useParseIntRadix": "off"
+            },
+            "style": {
+                "noNonNullAssertion": "off",
+                "useConst": "off",
+                "useExponentiationOperator": "off",
+                "useNodejsImportProtocol": "off",
+                "useTemplate": "off"
+            },
+            "suspicious": {
+                "noExplicitAny": "off",
+                "noGlobalIsNan": "off",
+                "noImplicitAnyLet": "off",
+                "noPrototypeBuiltins": "off",
+                "noShadowRestrictedNames": "off",
+                "noTemplateCurlyInString": "off",
+                "noTsIgnore": "off",
+                "noUselessEscapeInString": "off",
+                "useIsArray": "off",
+                "useIterableCallbackReturn": "off"
+            }
+        }
     },
     "assist": { "actions": { "source": { "organizeImports": "off" } } },
     "overrides": [

--- a/biome.json
+++ b/biome.json
@@ -25,7 +25,6 @@
                 "noBannedTypes": "off",
                 "noUselessConstructor": "off",
                 "noUselessUndefinedInitialization": "off",
-                "useDateNow": "off",
                 "useOptionalChain": "off"
             },
             "style": {

--- a/biome.json
+++ b/biome.json
@@ -23,7 +23,6 @@
             "preset": "recommended",
             "complexity": {
                 "noBannedTypes": "off",
-                "noUselessConstructor": "off",
                 "noUselessUndefinedInitialization": "off"
             },
             "style": {

--- a/biome.json
+++ b/biome.json
@@ -22,8 +22,7 @@
         "rules": {
             "preset": "recommended",
             "complexity": {
-                "noBannedTypes": "off",
-                "noUselessUndefinedInitialization": "off"
+                "noBannedTypes": "off"
             },
             "style": {
                 "noNonNullAssertion": "off",

--- a/biome.json
+++ b/biome.json
@@ -23,7 +23,9 @@
             "preset": "recommended",
             "correctness": {
                 "noUndeclaredDependencies": "on",
-                "noGlobalDirnameFilename": "on"
+                "noGlobalDirnameFilename": "on",
+                "noUnusedInstantiation": "on",
+                "useSingleJsDocAsterisk": "on"
             },
             "complexity": {
                 "noUselessReturn": "on"

--- a/biome.json
+++ b/biome.json
@@ -36,7 +36,10 @@
                 "useExplicitLengthCheck": "on",
                 "noMultiAssign": "on",
                 "useConsistentObjectDefinitions": "on",
-                "useForOf": "on"
+                "useForOf": "on",
+                "noUnusedTemplateLiteral": "on",
+                "useShorthandAssign": "on",
+                "noInferrableTypes": "on"
             },
             "suspicious": {
                 "noTemplateCurlyInString": "off"

--- a/biome.json
+++ b/biome.json
@@ -33,7 +33,6 @@
                 "useOptionalChain": "off"
             },
             "correctness": {
-                "noConstructorReturn": "off",
                 "noVoidTypeReturn": "off"
             },
             "style": {

--- a/biome.json
+++ b/biome.json
@@ -29,7 +29,8 @@
                 "useCollapsedElseIf": "on",
                 "useCollapsedIf": "on",
                 "useThrowNewError": "on",
-                "useConsistentBuiltinInstantiation": "on"
+                "useConsistentBuiltinInstantiation": "on",
+                "useObjectSpread": "on"
             },
             "suspicious": {
                 "noTemplateCurlyInString": "off"

--- a/biome.json
+++ b/biome.json
@@ -25,7 +25,6 @@
                 "noBannedTypes": "off",
                 "noExtraBooleanCast": "off",
                 "noUselessConstructor": "off",
-                "noUselessSwitchCase": "off",
                 "noUselessTernary": "off",
                 "noUselessUndefinedInitialization": "off",
                 "useDateNow": "off",

--- a/biome.json
+++ b/biome.json
@@ -28,7 +28,8 @@
                 "noUselessElse": "on",
                 "useCollapsedElseIf": "on",
                 "useCollapsedIf": "on",
-                "useThrowNewError": "on"
+                "useThrowNewError": "on",
+                "useConsistentBuiltinInstantiation": "on"
             },
             "suspicious": {
                 "noTemplateCurlyInString": "off"

--- a/biome.json
+++ b/biome.json
@@ -24,7 +24,6 @@
             "suspicious": {
                 "noExplicitAny": "off",
                 "noGlobalIsNan": "off",
-                "noShadowRestrictedNames": "off",
                 "noTemplateCurlyInString": "off",
                 "noUselessEscapeInString": "off",
                 "useIterableCallbackReturn": "off"

--- a/biome.json
+++ b/biome.json
@@ -25,7 +25,8 @@
                 "noUselessReturn": "on"
             },
             "style": {
-                "noUselessElse": "on"
+                "noUselessElse": "on",
+                "useCollapsedElseIf": "on"
             },
             "suspicious": {
                 "noTemplateCurlyInString": "off"

--- a/biome.json
+++ b/biome.json
@@ -23,7 +23,6 @@
             "preset": "recommended",
             "suspicious": {
                 "noExplicitAny": "off",
-                "noGlobalIsNan": "off",
                 "noTemplateCurlyInString": "off",
                 "noUselessEscapeInString": "off",
                 "useIterableCallbackReturn": "off"

--- a/biome.json
+++ b/biome.json
@@ -22,7 +22,8 @@
         "rules": {
             "preset": "recommended",
             "correctness": {
-                "noUndeclaredDependencies": "on"
+                "noUndeclaredDependencies": "on",
+                "noGlobalDirnameFilename": "on"
             },
             "complexity": {
                 "noUselessReturn": "on"

--- a/biome.json
+++ b/biome.json
@@ -28,7 +28,14 @@
                 "useSingleJsDocAsterisk": "on"
             },
             "complexity": {
-                "noUselessReturn": "on"
+                "noUselessReturn": "on",
+                "noDivRegex": "on",
+                "noUselessCatchBinding": "on",
+                "noUselessStringConcat": "on",
+                "useArrayFind": "on",
+                "useWhile": "on",
+                "noRedundantDefaultExport": "on",
+                "noExcessiveNestedTestSuites": "on"
             },
             "style": {
                 "noUselessElse": "on",

--- a/biome.json
+++ b/biome.json
@@ -23,7 +23,6 @@
             "preset": "recommended",
             "style": {
                 "noNonNullAssertion": "off",
-                "useExponentiationOperator": "off",
                 "useNodejsImportProtocol": "off",
                 "useTemplate": "off"
             },

--- a/biome.json
+++ b/biome.json
@@ -51,12 +51,23 @@
                 "noTemplateCurlyInString": "off",
                 "noEqualsToNull": "on",
                 "noUnusedExpressions": "on",
-                "useArraySortCompare": "on"
+                "useArraySortCompare": "on",
+                "noMisplacedAssertion": "on"
             }
         }
     },
     "assist": { "actions": { "source": { "organizeImports": "off" } } },
     "overrides": [
+        {
+            "includes": ["test/release-version.ts"],
+            "linter": {
+                "rules": {
+                    "suspicious": {
+                        "noMisplacedAssertion": "off"
+                    }
+                }
+            }
+        },
         {
             "includes": ["packages/quicktype-core/src/**"],
             "linter": {

--- a/biome.json
+++ b/biome.json
@@ -21,6 +21,9 @@
         "enabled": true,
         "rules": {
             "preset": "recommended",
+            "correctness": {
+                "noUndeclaredDependencies": "on"
+            },
             "complexity": {
                 "noUselessReturn": "on"
             },

--- a/biome.json
+++ b/biome.json
@@ -21,9 +21,6 @@
         "enabled": true,
         "rules": {
             "preset": "recommended",
-            "complexity": {
-                "noBannedTypes": "off"
-            },
             "style": {
                 "noNonNullAssertion": "off",
                 "useConst": "off",

--- a/biome.json
+++ b/biome.json
@@ -41,7 +41,7 @@
                 "noDelete": "on"
             },
             "style": {
-                "noUselessElse": "on",
+                "noUselessElse": "off",
                 "useCollapsedElseIf": "on",
                 "useCollapsedIf": "on",
                 "useThrowNewError": "on",

--- a/biome.json
+++ b/biome.json
@@ -35,7 +35,8 @@
                 "noSubstr": "on",
                 "useExplicitLengthCheck": "on",
                 "noMultiAssign": "on",
-                "useConsistentObjectDefinitions": "on"
+                "useConsistentObjectDefinitions": "on",
+                "useForOf": "on"
             },
             "suspicious": {
                 "noTemplateCurlyInString": "off"

--- a/biome.json
+++ b/biome.json
@@ -22,7 +22,6 @@
         "rules": {
             "preset": "recommended",
             "suspicious": {
-                "noExplicitAny": "off",
                 "noTemplateCurlyInString": "off"
             }
         }

--- a/biome.json
+++ b/biome.json
@@ -50,7 +50,8 @@
             "suspicious": {
                 "noTemplateCurlyInString": "off",
                 "noEqualsToNull": "on",
-                "noUnusedExpressions": "on"
+                "noUnusedExpressions": "on",
+                "useArraySortCompare": "on"
             }
         }
     },

--- a/biome.json
+++ b/biome.json
@@ -35,8 +35,7 @@
             "correctness": {
                 "noConstructorReturn": "off",
                 "noSwitchDeclarations": "off",
-                "noVoidTypeReturn": "off",
-                "useParseIntRadix": "off"
+                "noVoidTypeReturn": "off"
             },
             "style": {
                 "noNonNullAssertion": "off",

--- a/biome.json
+++ b/biome.json
@@ -30,7 +30,8 @@
                 "useCollapsedIf": "on",
                 "useThrowNewError": "on",
                 "useConsistentBuiltinInstantiation": "on",
-                "useObjectSpread": "on"
+                "useObjectSpread": "on",
+                "noYodaExpression": "on"
             },
             "suspicious": {
                 "noTemplateCurlyInString": "off"

--- a/biome.json
+++ b/biome.json
@@ -66,7 +66,17 @@
                 "noUnusedExpressions": "on",
                 "useArraySortCompare": "on",
                 "noMisplacedAssertion": "on",
-                "noShadow": "on"
+                "noShadow": "on",
+                "noConstantBinaryExpressions": "on",
+                "noVar": "on",
+                "noFocusedTests": "on",
+                "noSkippedTests": "on",
+                "noReturnAssign": "on",
+                "noDuplicateTestHooks": "on",
+                "noDeprecatedImports": "on",
+                "noDuplicateDependencies": "on",
+                "useErrorMessage": "on",
+                "noEmptySource": "on"
             }
         }
     },

--- a/biome.json
+++ b/biome.json
@@ -35,7 +35,6 @@
             "correctness": {
                 "noConstructorReturn": "off",
                 "noSwitchDeclarations": "off",
-                "noUnusedImports": "off",
                 "noUnusedVariables": "off",
                 "noVoidTypeReturn": "off",
                 "useParseIntRadix": "off"

--- a/biome.json
+++ b/biome.json
@@ -41,7 +41,10 @@
                 "useShorthandAssign": "on",
                 "noInferrableTypes": "on",
                 "useDefaultParameterLast": "on",
-                "useConsistentMethodSignatures": "on"
+                "useConsistentMethodSignatures": "on",
+                "useUnifiedTypeSignatures": "on",
+                "noNamespace": "on",
+                "useNodeAssertStrict": "on"
             },
             "suspicious": {
                 "noTemplateCurlyInString": "off"

--- a/biome.json
+++ b/biome.json
@@ -24,7 +24,6 @@
             "suspicious": {
                 "noExplicitAny": "off",
                 "noGlobalIsNan": "off",
-                "noImplicitAnyLet": "off",
                 "noPrototypeBuiltins": "off",
                 "noShadowRestrictedNames": "off",
                 "noTemplateCurlyInString": "off",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,8 @@
                 "quicktype-typescript-input": "24.0.0",
                 "readable-stream": "^4.5.2",
                 "stream-json": "1.8.0",
-                "string-to-stream": "^3.0.1"
+                "string-to-stream": "^3.0.1",
+                "wordwrap": "^1.0.0"
             },
             "bin": {
                 "quicktype": "dist/index.js"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
         "quicktype-typescript-input": "24.0.0",
         "readable-stream": "^4.5.2",
         "stream-json": "1.8.0",
-        "string-to-stream": "^3.0.1"
+        "string-to-stream": "^3.0.1",
+        "wordwrap": "^1.0.0"
     },
     "devDependencies": {
         "@biomejs/biome": "^2.5.3",

--- a/packages/quicktype-core/src/ConvenienceRenderer.ts
+++ b/packages/quicktype-core/src/ConvenienceRenderer.ts
@@ -39,7 +39,6 @@ import {
 import {
     type BlankLineConfig,
     type ForEachPosition,
-    type RenderContext,
     Renderer,
 } from "./Renderer.js";
 import {
@@ -54,7 +53,6 @@ import {
 } from "./support/Comments.js";
 import { trimEnd } from "./support/Strings.js";
 import { assert, defined, nonNull, panic } from "./support/Support.js";
-import type { TargetLanguage } from "./TargetLanguage.js";
 import {
     type Transformation,
     followTargetType,
@@ -176,13 +174,6 @@ export abstract class ConvenienceRenderer extends Renderer {
     private _cycleBreakerTypes?: Set<Type> | undefined;
 
     private _alphabetizeProperties = false;
-
-    public constructor(
-        targetLanguage: TargetLanguage,
-        renderContext: RenderContext,
-    ) {
-        super(targetLanguage, renderContext);
-    }
 
     public get topLevels(): ReadonlyMap<string, Type> {
         return this.typeGraph.topLevels;

--- a/packages/quicktype-core/src/ConvenienceRenderer.ts
+++ b/packages/quicktype-core/src/ConvenienceRenderer.ts
@@ -825,9 +825,9 @@ export abstract class ConvenienceRenderer extends Renderer {
                 (_doubleType) => "double",
                 (_stringType) => "string",
                 (arrayType) =>
-                    typeNameForUnionMember(arrayType.items) + "_array",
+                    `${typeNameForUnionMember(arrayType.items)}_array`,
                 (classType) => lookup(this.nameForNamedType(classType)),
-                (mapType) => typeNameForUnionMember(mapType.values) + "_map",
+                (mapType) => `${typeNameForUnionMember(mapType.values)}_map`,
                 (objectType) => {
                     assert(
                         this.targetLanguage.supportsFullObjectType,

--- a/packages/quicktype-core/src/ConvenienceRenderer.ts
+++ b/packages/quicktype-core/src/ConvenienceRenderer.ts
@@ -1275,7 +1275,7 @@ export abstract class ConvenienceRenderer extends Renderer {
         // A quote at the end of the line would merge with a closing
         // `"""` emitted right after it.  The quote needs escaping iff
         // it's preceded by an even number of backslashes.
-        if (lineEnd !== undefined && lineEnd.startsWith('"')) {
+        if (lineEnd?.startsWith('"')) {
             const trailing = /(\\*)"$/.exec(escaped);
             if (trailing !== null && trailing[1].length % 2 === 0) {
                 escaped = `${escaped.slice(0, -1)}\\"`;

--- a/packages/quicktype-core/src/CycleBreaker.ts
+++ b/packages/quicktype-core/src/CycleBreaker.ts
@@ -107,8 +107,6 @@ export function breakCycles<T>(
             results.push([breakNode, info]);
             break;
         }
-
-        continue;
     }
 
     return results;

--- a/packages/quicktype-core/src/DeclarationIR.ts
+++ b/packages/quicktype-core/src/DeclarationIR.ts
@@ -195,8 +195,6 @@ export function declarationsForGraph(
             for (const t of forwardDeclarable) {
                 declarations.push({ kind: "define", type: t });
             }
-
-            return;
         }
 
         /*

--- a/packages/quicktype-core/src/MakeTransformations.ts
+++ b/packages/quicktype-core/src/MakeTransformations.ts
@@ -175,7 +175,7 @@ function replaceUnion(
         );
     }
 
-    let maybeStringType: TypeRef | undefined = undefined;
+    let maybeStringType: TypeRef | undefined;
     function getStringType(): TypeRef {
         if (maybeStringType === undefined) {
             maybeStringType = builder.getStringType(

--- a/packages/quicktype-core/src/MarkovChain.ts
+++ b/packages/quicktype-core/src/MarkovChain.ts
@@ -119,7 +119,7 @@ export function evaluateFull(
         p = p * cp;
     }
 
-    return [Math.pow(p, 1 / (word.length - depth + 1)), scores];
+    return [p ** (1 / (word.length - depth + 1)), scores];
 }
 
 export function evaluate(mc: MarkovChain, word: string): number {

--- a/packages/quicktype-core/src/MarkovChain.ts
+++ b/packages/quicktype-core/src/MarkovChain.ts
@@ -39,9 +39,8 @@ function lookup(t: Trie, seq: string, i: number): Trie | number | undefined {
 
     if (typeof n === "object") {
         return lookup(n, seq, i + 1);
-    } else {
-        return n / t.count;
     }
+    return n / t.count;
 }
 
 function increment(t: Trie, seq: string, i: number): void {

--- a/packages/quicktype-core/src/MarkovChain.ts
+++ b/packages/quicktype-core/src/MarkovChain.ts
@@ -116,7 +116,7 @@ export function evaluateFull(
         }
 
         scores.push(cp);
-        p = p * cp;
+        p *= cp;
     }
 
     return [p ** (1 / (word.length - depth + 1)), scores];

--- a/packages/quicktype-core/src/MarkovChain.ts
+++ b/packages/quicktype-core/src/MarkovChain.ts
@@ -39,8 +39,9 @@ function lookup(t: Trie, seq: string, i: number): Trie | number | undefined {
 
     if (typeof n === "object") {
         return lookup(n, seq, i + 1);
+    } else {
+        return n / t.count;
     }
-    return n / t.count;
 }
 
 function increment(t: Trie, seq: string, i: number): void {

--- a/packages/quicktype-core/src/MarkovChain.ts
+++ b/packages/quicktype-core/src/MarkovChain.ts
@@ -52,14 +52,14 @@ function increment(t: Trie, seq: string, i: number): void {
 
     if (i >= seq.length - 1) {
         if (typeof t !== "object") {
-            return panic("Malformed trie");
+            panic("Malformed trie");
         }
 
         let n = t.arr[first];
         if (n === null) {
             n = 0;
         } else if (typeof n === "object") {
-            return panic("Malformed trie");
+            panic("Malformed trie");
         }
 
         t.arr[first] = n + 1;
@@ -73,7 +73,7 @@ function increment(t: Trie, seq: string, i: number): void {
     }
 
     if (typeof st !== "object") {
-        return panic("Malformed trie");
+        panic("Malformed trie");
     }
 
     increment(st, seq, i + 1);

--- a/packages/quicktype-core/src/MarkovChain.ts
+++ b/packages/quicktype-core/src/MarkovChain.ts
@@ -52,14 +52,14 @@ function increment(t: Trie, seq: string, i: number): void {
 
     if (i >= seq.length - 1) {
         if (typeof t !== "object") {
-            panic("Malformed trie");
+            return panic("Malformed trie");
         }
 
         let n = t.arr[first];
         if (n === null) {
             n = 0;
         } else if (typeof n === "object") {
-            panic("Malformed trie");
+            return panic("Malformed trie");
         }
 
         t.arr[first] = n + 1;
@@ -74,7 +74,7 @@ function increment(t: Trie, seq: string, i: number): void {
     }
 
     if (typeof st !== "object") {
-        panic("Malformed trie");
+        return panic("Malformed trie");
     }
 
     increment(st, seq, i + 1);

--- a/packages/quicktype-core/src/MarkovChain.ts
+++ b/packages/quicktype-core/src/MarkovChain.ts
@@ -68,7 +68,8 @@ function increment(t: Trie, seq: string, i: number): void {
 
     let st = t.arr[first];
     if (st === null) {
-        t.arr[first] = st = makeTrie();
+        st = makeTrie();
+        t.arr[first] = st;
     }
 
     if (typeof st !== "object") {

--- a/packages/quicktype-core/src/Messages.ts
+++ b/packages/quicktype-core/src/Messages.ts
@@ -297,7 +297,7 @@ export function messageError<Kind extends ErrorKinds>(
             valueString = value;
         }
 
-        userMessage = userMessage.replace("${" + name + "}", valueString);
+        userMessage = userMessage.replace(`\${${name}}`, valueString);
     }
 
     throw new QuickTypeError(

--- a/packages/quicktype-core/src/Messages.ts
+++ b/packages/quicktype-core/src/Messages.ts
@@ -314,5 +314,5 @@ export function messageAssert<Kind extends ErrorKinds>(
     properties: ErrorPropertiesForKind<Kind>,
 ): void {
     if (assertion) return;
-    messageError(kind, properties);
+    return messageError(kind, properties);
 }

--- a/packages/quicktype-core/src/Messages.ts
+++ b/packages/quicktype-core/src/Messages.ts
@@ -14,7 +14,10 @@ export type ErrorProperties =
           kind: "MiscReadError";
           properties: { fileOrURL: string; message: string };
       }
-    | { kind: "MiscUnicodeHighSurrogateWithoutLowSurrogate"; properties: {} }
+    | {
+          kind: "MiscUnicodeHighSurrogateWithoutLowSurrogate";
+          properties: Record<string, never>;
+      }
     | {
           kind: "MiscInvalidMinMaxConstraint";
           properties: { max: number; min: number };
@@ -98,21 +101,24 @@ export type ErrorProperties =
     | { kind: "SchemaFetchErrorAdditional"; properties: { address: string } }
 
     // GraphQL input
-    | { kind: "GraphQLNoQueriesDefined"; properties: {} }
+    | { kind: "GraphQLNoQueriesDefined"; properties: Record<string, never> }
 
     // Driver
     | { kind: "DriverUnknownSourceLanguage"; properties: { lang: string } }
     | { kind: "DriverUnknownOutputLanguage"; properties: { lang: string } }
     | { kind: "DriverMoreThanOneInputGiven"; properties: { topLevel: string } }
     | { kind: "DriverCannotInferNameForSchema"; properties: { uri: string } }
-    | { kind: "DriverNoGraphQLQueryGiven"; properties: {} }
+    | { kind: "DriverNoGraphQLQueryGiven"; properties: Record<string, never> }
     | { kind: "DriverNoGraphQLSchemaInDir"; properties: { dir: string } }
     | {
           kind: "DriverMoreThanOneGraphQLSchemaInDir";
           properties: { dir: string };
       }
-    | { kind: "DriverSourceLangMustBeGraphQL"; properties: {} }
-    | { kind: "DriverGraphQLSchemaNeeded"; properties: {} }
+    | {
+          kind: "DriverSourceLangMustBeGraphQL";
+          properties: Record<string, never>;
+      }
+    | { kind: "DriverGraphQLSchemaNeeded"; properties: Record<string, never> }
     | { kind: "DriverInputFileDoesNotExist"; properties: { filename: string } }
     | {
           kind: "DriverCannotMixJSONWithOtherSamples";
@@ -120,16 +126,19 @@ export type ErrorProperties =
       }
     | { kind: "DriverCannotMixNonJSONInputs"; properties: { dir: string } }
     | { kind: "DriverUnknownDebugOption"; properties: { option: string } }
-    | { kind: "DriverNoLanguageOrExtension"; properties: {} }
+    | { kind: "DriverNoLanguageOrExtension"; properties: Record<string, never> }
     | { kind: "DriverCLIOptionParsingFailed"; properties: { message: string } }
 
     // IR
-    | { kind: "IRNoForwardDeclarableTypeInCycle"; properties: {} }
+    | {
+          kind: "IRNoForwardDeclarableTypeInCycle";
+          properties: Record<string, never>;
+      }
     | {
           kind: "IRTypeAttributesNotPropagated";
           properties: { count: number; indexes: number[] };
       }
-    | { kind: "IRNoEmptyUnions"; properties: {} }
+    | { kind: "IRNoEmptyUnions"; properties: Record<string, never> }
 
     // Rendering
     | {

--- a/packages/quicktype-core/src/Messages.ts
+++ b/packages/quicktype-core/src/Messages.ts
@@ -58,23 +58,23 @@ export type ErrorProperties =
       }
     | {
           kind: "SchemaRequiredMustBeStringOrStringArray";
-          properties: { actual: any; ref: Ref };
+          properties: { actual: unknown; ref: Ref };
       }
     | {
           kind: "SchemaRequiredElementMustBeString";
-          properties: { element: any; ref: Ref };
+          properties: { element: unknown; ref: Ref };
       }
     | {
           kind: "SchemaTypeMustBeStringOrStringArray";
-          properties: { actual: any };
+          properties: { actual: unknown };
       }
     | {
           kind: "SchemaTypeElementMustBeString";
-          properties: { element: any; ref: Ref };
+          properties: { element: unknown; ref: Ref };
       }
     | {
           kind: "SchemaArrayItemsMustBeStringOrArray";
-          properties: { actual: any; ref: Ref };
+          properties: { actual: unknown; ref: Ref };
       }
     | { kind: "SchemaIDMustHaveAddress"; properties: { id: string; ref: Ref } }
     | {
@@ -83,7 +83,7 @@ export type ErrorProperties =
       }
     | {
           kind: "SchemaSetOperationCasesIsNotArray";
-          properties: { cases: any; operation: string; ref: Ref };
+          properties: { cases: unknown; operation: string; ref: Ref };
       }
     | {
           kind: "SchemaMoreThanOneUnionMemberName";

--- a/packages/quicktype-core/src/Messages.ts
+++ b/packages/quicktype-core/src/Messages.ts
@@ -305,5 +305,5 @@ export function messageAssert<Kind extends ErrorKinds>(
     properties: ErrorPropertiesForKind<Kind>,
 ): void {
     if (assertion) return;
-    return messageError(kind, properties);
+    messageError(kind, properties);
 }

--- a/packages/quicktype-core/src/Renderer.ts
+++ b/packages/quicktype-core/src/Renderer.ts
@@ -77,7 +77,8 @@ class EmitContext {
     private _preventBlankLine: boolean;
 
     public constructor() {
-        this._currentEmitTarget = this._emitted = [];
+        this._emitted = [];
+        this._currentEmitTarget = this._emitted;
         this._numBlankLinesNeeded = 0;
         this._preventBlankLine = true; // no blank lines at start of file
     }

--- a/packages/quicktype-core/src/Renderer.ts
+++ b/packages/quicktype-core/src/Renderer.ts
@@ -51,7 +51,7 @@ function lineIndentation(line: string): {
         } else if (c === "\t") {
             indent = (indent / 4 + 1) * 4;
         } else {
-            return { indent, text: line.substring(i) };
+            return { indent, text: line.slice(i) };
         }
     }
 

--- a/packages/quicktype-core/src/RendererOptions/index.ts
+++ b/packages/quicktype-core/src/RendererOptions/index.ts
@@ -87,14 +87,16 @@ export class BooleanOption<Name extends string> extends Option<Name, boolean> {
         actual: Array<OptionDefinition<Name, boolean>>;
         display: Array<OptionDefinition<Name, boolean>>;
     } {
-        const negated = Object.assign({}, this.definition, {
+        const negated = {
+            ...this.definition,
             name: `no-${this.name}`,
             defaultValue: !this.definition.defaultValue,
-        });
-        const display = Object.assign({}, this.definition, {
+        } as OptionDefinition<Name, boolean>;
+        const display = {
+            ...this.definition,
             name: `[no-]${this.name}`,
             description: `${this.definition.description} (${this.definition.defaultValue ? "on" : "off"} by default)`,
-        });
+        } as OptionDefinition<Name, boolean>;
         return {
             display: [display],
             actual: [this.definition, negated],

--- a/packages/quicktype-core/src/Run.ts
+++ b/packages/quicktype-core/src/Run.ts
@@ -162,9 +162,9 @@ class Run implements RunContext {
         // We must not overwrite defaults with undefined values, which
         // we sometimes get.
         this._options = Object.fromEntries(
-            Object.entries(
-                Object.assign({}, defaultOptions, defaultInferenceFlags),
-            ).map(([k, v]) => [k, options[k as keyof typeof options] ?? v]),
+            Object.entries({ ...defaultOptions, ...defaultInferenceFlags }).map(
+                ([k, v]) => [k, options[k as keyof typeof options] ?? v],
+            ),
         ) as Required<typeof options>;
     }
 

--- a/packages/quicktype-core/src/Source.ts
+++ b/packages/quicktype-core/src/Source.ts
@@ -301,7 +301,7 @@ export function serializeRenderResult(
                 break;
             }
             default:
-                assertNever(source);
+                return assertNever(source);
         }
     }
 

--- a/packages/quicktype-core/src/Source.ts
+++ b/packages/quicktype-core/src/Source.ts
@@ -66,7 +66,7 @@ export type Sourcelike = Source | string | Name | SourcelikeArray;
 export type SourcelikeArray = Sourcelike[];
 
 export function sourcelikeToSource(sl: Sourcelike): Source {
-    if (sl instanceof Array) {
+    if (Array.isArray(sl)) {
         return {
             kind: "sequence",
             sequence: sl.map(sourcelikeToSource),

--- a/packages/quicktype-core/src/Source.ts
+++ b/packages/quicktype-core/src/Source.ts
@@ -307,7 +307,7 @@ export function serializeRenderResult(
 
     serializeToStringArray(rootSource);
     finishLine();
-    return { lines, annotations: annotations };
+    return { lines, annotations };
 }
 
 export interface MultiWord {

--- a/packages/quicktype-core/src/Source.ts
+++ b/packages/quicktype-core/src/Source.ts
@@ -301,7 +301,7 @@ export function serializeRenderResult(
                 break;
             }
             default:
-                return assertNever(source);
+                assertNever(source);
         }
     }
 

--- a/packages/quicktype-core/src/Source.ts
+++ b/packages/quicktype-core/src/Source.ts
@@ -224,7 +224,7 @@ export function serializeRenderResult(
                 }
 
                 break;
-            case "table":
+            case "table": {
                 const t = source.table;
                 const numRows = t.length;
                 if (numRows === 0) break;
@@ -270,7 +270,8 @@ export function serializeRenderResult(
                 }
 
                 break;
-            case "annotated":
+            }
+            case "annotated": {
                 const start = currentLocation();
                 serializeToStringArray(source.source);
                 const end = currentLocation();
@@ -279,12 +280,13 @@ export function serializeRenderResult(
                     span: { start, end },
                 });
                 break;
+            }
             case "name":
                 assert(names.has(source.named), "No name for Named");
                 indentIfNeeded();
                 currentLine.push(defined(names.get(source.named)));
                 break;
-            case "modified":
+            case "modified": {
                 indentIfNeeded();
                 const serialized = serializeRenderResult(
                     source.source,
@@ -297,6 +299,7 @@ export function serializeRenderResult(
                 );
                 currentLine.push(source.modifier(serialized[0]));
                 break;
+            }
             default:
                 return assertNever(source);
         }

--- a/packages/quicktype-core/src/Transformers.ts
+++ b/packages/quicktype-core/src/Transformers.ts
@@ -78,9 +78,7 @@ export abstract class Transformer {
         return `${debugStringForType(this.sourceType)} -> ${this.kind}`;
     }
 
-    protected debugPrintContinuations(_indent: number): void {
-        return;
-    }
+    protected debugPrintContinuations(_indent: number): void {}
 
     public debugPrint(indent: number): void {
         console.log(indentationString(indent) + this.debugDescription());

--- a/packages/quicktype-core/src/Type/TransformedStringType.ts
+++ b/packages/quicktype-core/src/Type/TransformedStringType.ts
@@ -1,5 +1,5 @@
 import {
-    // eslint-disable-next-line @typescript-eslint/no-redeclare
+    // biome-ignore lint/suspicious/noShadowRestrictedNames: collection-utils exports this name
     hasOwnProperty,
     mapFromObject,
 } from "collection-utils";

--- a/packages/quicktype-core/src/Type/Type.ts
+++ b/packages/quicktype-core/src/Type/Type.ts
@@ -782,9 +782,7 @@ export function setOperationCasesEqual(
     if (ma.size !== mb.size) return false;
     return iterableEvery(ma, (ta) => {
         const tb = iterableFind(mb, (t) => t.kind === ta.kind);
-        if (tb !== undefined) {
-            if (membersEqual(ta, tb)) return true;
-        }
+        if (tb !== undefined && membersEqual(ta, tb)) return true;
 
         if (conflateNumbers) {
             if (

--- a/packages/quicktype-core/src/Type/TypeBuilder.ts
+++ b/packages/quicktype-core/src/Type/TypeBuilder.ts
@@ -467,7 +467,7 @@ export class TypeBuilder {
 
         const type = derefTypeRef(ref, this.typeGraph);
         if (!(type instanceof ObjectType)) {
-            return panic("Tried to set properties of non-object type");
+            panic("Tried to set properties of non-object type");
         }
 
         type.setProperties(

--- a/packages/quicktype-core/src/Type/TypeBuilder.ts
+++ b/packages/quicktype-core/src/Type/TypeBuilder.ts
@@ -469,7 +469,7 @@ export class TypeBuilder {
 
         const type = derefTypeRef(ref, this.typeGraph);
         if (!(type instanceof ObjectType)) {
-            panic("Tried to set properties of non-object type");
+            return panic("Tried to set properties of non-object type");
         }
 
         type.setProperties(

--- a/packages/quicktype-core/src/Type/TypeBuilder.ts
+++ b/packages/quicktype-core/src/Type/TypeBuilder.ts
@@ -129,7 +129,9 @@ export class TypeBuilder {
         trefs: ReadonlySet<TypeRef> | undefined,
     ): void {
         if (trefs === undefined) return;
-        trefs.forEach((tref) => this.assertTypeRefGraph(tref));
+        trefs.forEach((tref) => {
+            this.assertTypeRefGraph(tref);
+        });
     }
 
     private filterTypeAttributes(
@@ -515,7 +517,9 @@ export class TypeBuilder {
     public modifyPropertiesIfNecessary(
         properties: ReadonlyMap<string, ClassProperty>,
     ): ReadonlyMap<string, ClassProperty> {
-        properties.forEach((p) => this.assertTypeRefGraph(p.typeRef));
+        properties.forEach((p) => {
+            this.assertTypeRefGraph(p.typeRef);
+        });
 
         if (this.canonicalOrder) {
             properties = mapSortByKey(properties);

--- a/packages/quicktype-core/src/Type/TypeBuilder.ts
+++ b/packages/quicktype-core/src/Type/TypeBuilder.ts
@@ -641,7 +641,5 @@ export class TypeBuilder {
         this.registerType(type);
     }
 
-    public setLostTypeAttributes(): void {
-        return;
-    }
+    public setLostTypeAttributes(): void {}
 }

--- a/packages/quicktype-core/src/Type/TypeGraph.ts
+++ b/packages/quicktype-core/src/Type/TypeGraph.ts
@@ -39,7 +39,7 @@ export class TypeAttributeStore {
 
     public constructor(
         private readonly _typeGraph: TypeGraph,
-        private _values: Array<TypeAttributes | undefined>,
+        private readonly _values: Array<TypeAttributes | undefined>,
     ) {}
 
     private getTypeIndex(t: Type): number {

--- a/packages/quicktype-core/src/Type/TypeGraphUtils.ts
+++ b/packages/quicktype-core/src/Type/TypeGraphUtils.ts
@@ -91,13 +91,12 @@ export function optionalToNullable(
                 properties,
                 forwardingRef,
             );
-        } else {
-            return builder.getClassType(
-                c.getAttributes(),
-                properties,
-                forwardingRef,
-            );
         }
+        return builder.getClassType(
+            c.getAttributes(),
+            properties,
+            forwardingRef,
+        );
     }
 
     const classesWithOptional = setFilter(

--- a/packages/quicktype-core/src/Type/TypeGraphUtils.ts
+++ b/packages/quicktype-core/src/Type/TypeGraphUtils.ts
@@ -91,12 +91,13 @@ export function optionalToNullable(
                 properties,
                 forwardingRef,
             );
+        } else {
+            return builder.getClassType(
+                c.getAttributes(),
+                properties,
+                forwardingRef,
+            );
         }
-        return builder.getClassType(
-            c.getAttributes(),
-            properties,
-            forwardingRef,
-        );
     }
 
     const classesWithOptional = setFilter(

--- a/packages/quicktype-core/src/Type/TypeUtils.ts
+++ b/packages/quicktype-core/src/Type/TypeUtils.ts
@@ -109,9 +109,7 @@ export function makeGroupsToFlatten<T extends SetOperationType>(
             setOperationMembersRecursively(u, undefined)[0],
         );
 
-        if (include !== undefined) {
-            if (!include(members)) continue;
-        }
+        if (include !== undefined && !include(members)) continue;
 
         let maybeSet = typeGroups.get(members);
         if (maybeSet === undefined) {

--- a/packages/quicktype-core/src/Type/TypeUtils.ts
+++ b/packages/quicktype-core/src/Type/TypeUtils.ts
@@ -375,9 +375,7 @@ export function matchCompoundType(
     objectType: (objectType: ObjectType) => void,
     unionType: (unionType: UnionType) => void,
 ): void {
-    function ignore<T extends Type>(_: T): void {
-        return;
-    }
+    function ignore<T extends Type>(_: T): void {}
 
     matchTypeExhaustive(
         t,

--- a/packages/quicktype-core/src/Type/TypeUtils.ts
+++ b/packages/quicktype-core/src/Type/TypeUtils.ts
@@ -81,14 +81,12 @@ export function setOperationMembersRecursively<T extends SetOperationType>(
             }
         } else if (includeAny || t.kind !== "any") {
             members.add(t);
-        } else {
-            if (combinationKind !== undefined) {
-                attributes = combineTypeAttributes(
-                    combinationKind,
-                    attributes,
-                    t.getAttributes(),
-                );
-            }
+        } else if (combinationKind !== undefined) {
+            attributes = combineTypeAttributes(
+                combinationKind,
+                attributes,
+                t.getAttributes(),
+            );
         }
     }
 

--- a/packages/quicktype-core/src/UnifyClasses.ts
+++ b/packages/quicktype-core/src/UnifyClasses.ts
@@ -191,36 +191,38 @@ export class UnifyUnionBuilder extends UnionBuilder<
                 this._unifyTypes(Array.from(propertyTypes)),
                 forwardingRef,
             );
-        }
-        const [properties, additionalProperties, lostTypeAttributes] =
-            getCliqueProperties(objectTypes, this.typeBuilder, (types) => {
-                assert(types.size > 0, "Property has no type");
-                return this._unifyTypes(
-                    Array.from(types).map((t) => t.typeRef),
-                );
-            });
-        if (lostTypeAttributes) {
-            this.typeBuilder.setLostTypeAttributes();
-        }
+        } else {
+            const [properties, additionalProperties, lostTypeAttributes] =
+                getCliqueProperties(objectTypes, this.typeBuilder, (types) => {
+                    assert(types.size > 0, "Property has no type");
+                    return this._unifyTypes(
+                        Array.from(types).map((t) => t.typeRef),
+                    );
+                });
+            if (lostTypeAttributes) {
+                this.typeBuilder.setLostTypeAttributes();
+            }
 
-        if (this._makeObjectTypes) {
-            return this.typeBuilder.getUniqueObjectType(
-                typeAttributes,
-                properties,
-                additionalProperties,
-                forwardingRef,
-            );
+            if (this._makeObjectTypes) {
+                return this.typeBuilder.getUniqueObjectType(
+                    typeAttributes,
+                    properties,
+                    additionalProperties,
+                    forwardingRef,
+                );
+            } else {
+                assert(
+                    additionalProperties === undefined,
+                    "We have additional properties but want to make a class",
+                );
+                return this.typeBuilder.getUniqueClassType(
+                    typeAttributes,
+                    this._makeClassesFixed,
+                    properties,
+                    forwardingRef,
+                );
+            }
         }
-        assert(
-            additionalProperties === undefined,
-            "We have additional properties but want to make a class",
-        );
-        return this.typeBuilder.getUniqueClassType(
-            typeAttributes,
-            this._makeClassesFixed,
-            properties,
-            forwardingRef,
-        );
     }
 
     protected makeArray(
@@ -280,8 +282,7 @@ export function unifyTypes<T extends Type>(
     typeAttributes = typeBuilder.reconstituteTypeAttributes(typeAttributes);
     if (types.size === 0) {
         return panic("Cannot unify empty set of types");
-    }
-    if (types.size === 1) {
+    } else if (types.size === 1) {
         const first = defined(iterableFirst(types));
         if (!(first instanceof UnionType)) {
             return typeBuilder.reconstituteTypeRef(

--- a/packages/quicktype-core/src/UnifyClasses.ts
+++ b/packages/quicktype-core/src/UnifyClasses.ts
@@ -49,10 +49,8 @@ function getCliqueProperties(
             }
         }
 
-        // FIXME: refactor this
-        // eslint-disable-next-line @typescript-eslint/prefer-for-of
-        for (let i = 0; i < properties.length; i++) {
-            let [name, types, isOptional] = properties[i];
+        for (const property of properties) {
+            let [name, types, isOptional] = property;
             const maybeProperty = o.getProperties().get(name);
             if (maybeProperty === undefined) {
                 isOptional = true;
@@ -67,7 +65,7 @@ function getCliqueProperties(
                 types.add(maybeProperty.type);
             }
 
-            properties[i][2] = isOptional;
+            property[2] = isOptional;
         }
     }
 

--- a/packages/quicktype-core/src/UnifyClasses.ts
+++ b/packages/quicktype-core/src/UnifyClasses.ts
@@ -193,38 +193,36 @@ export class UnifyUnionBuilder extends UnionBuilder<
                 this._unifyTypes(Array.from(propertyTypes)),
                 forwardingRef,
             );
-        } else {
-            const [properties, additionalProperties, lostTypeAttributes] =
-                getCliqueProperties(objectTypes, this.typeBuilder, (types) => {
-                    assert(types.size > 0, "Property has no type");
-                    return this._unifyTypes(
-                        Array.from(types).map((t) => t.typeRef),
-                    );
-                });
-            if (lostTypeAttributes) {
-                this.typeBuilder.setLostTypeAttributes();
-            }
-
-            if (this._makeObjectTypes) {
-                return this.typeBuilder.getUniqueObjectType(
-                    typeAttributes,
-                    properties,
-                    additionalProperties,
-                    forwardingRef,
-                );
-            } else {
-                assert(
-                    additionalProperties === undefined,
-                    "We have additional properties but want to make a class",
-                );
-                return this.typeBuilder.getUniqueClassType(
-                    typeAttributes,
-                    this._makeClassesFixed,
-                    properties,
-                    forwardingRef,
-                );
-            }
         }
+        const [properties, additionalProperties, lostTypeAttributes] =
+            getCliqueProperties(objectTypes, this.typeBuilder, (types) => {
+                assert(types.size > 0, "Property has no type");
+                return this._unifyTypes(
+                    Array.from(types).map((t) => t.typeRef),
+                );
+            });
+        if (lostTypeAttributes) {
+            this.typeBuilder.setLostTypeAttributes();
+        }
+
+        if (this._makeObjectTypes) {
+            return this.typeBuilder.getUniqueObjectType(
+                typeAttributes,
+                properties,
+                additionalProperties,
+                forwardingRef,
+            );
+        }
+        assert(
+            additionalProperties === undefined,
+            "We have additional properties but want to make a class",
+        );
+        return this.typeBuilder.getUniqueClassType(
+            typeAttributes,
+            this._makeClassesFixed,
+            properties,
+            forwardingRef,
+        );
     }
 
     protected makeArray(
@@ -284,7 +282,8 @@ export function unifyTypes<T extends Type>(
     typeAttributes = typeBuilder.reconstituteTypeAttributes(typeAttributes);
     if (types.size === 0) {
         return panic("Cannot unify empty set of types");
-    } else if (types.size === 1) {
+    }
+    if (types.size === 1) {
         const first = defined(iterableFirst(types));
         if (!(first instanceof UnionType)) {
             return typeBuilder.reconstituteTypeRef(

--- a/packages/quicktype-core/src/UnifyClasses.ts
+++ b/packages/quicktype-core/src/UnifyClasses.ts
@@ -36,7 +36,7 @@ function getCliqueProperties(
     const properties = Array.from(propertyNames).map(
         (name) => [name, new Set(), false] as [string, Set<Type>, boolean],
     );
-    let additionalProperties: Set<Type> | undefined = undefined;
+    let additionalProperties: Set<Type> | undefined;
     for (const o of clique) {
         const additional = o.getAdditionalProperties();
         if (additional !== undefined) {

--- a/packages/quicktype-core/src/UnionBuilder.ts
+++ b/packages/quicktype-core/src/UnionBuilder.ts
@@ -583,12 +583,11 @@ export abstract class UnionBuilder<
         if (union !== undefined) {
             this.typeBuilder.setSetOperationMembers(union, typesSet);
             return union;
-        } else {
-            return this.typeBuilder.getUnionType(
-                typeAttributes,
-                typesSet,
-                forwardingRef,
-            );
         }
+        return this.typeBuilder.getUnionType(
+            typeAttributes,
+            typesSet,
+            forwardingRef,
+        );
     }
 }

--- a/packages/quicktype-core/src/UnionBuilder.ts
+++ b/packages/quicktype-core/src/UnionBuilder.ts
@@ -583,11 +583,12 @@ export abstract class UnionBuilder<
         if (union !== undefined) {
             this.typeBuilder.setSetOperationMembers(union, typesSet);
             return union;
+        } else {
+            return this.typeBuilder.getUnionType(
+                typeAttributes,
+                typesSet,
+                forwardingRef,
+            );
         }
-        return this.typeBuilder.getUnionType(
-            typeAttributes,
-            typesSet,
-            forwardingRef,
-        );
     }
 }

--- a/packages/quicktype-core/src/UnionBuilder.ts
+++ b/packages/quicktype-core/src/UnionBuilder.ts
@@ -153,7 +153,7 @@ export class UnionAccumulator<TArray, TObject>
         attributes: TypeAttributes,
         stringTypes: StringTypes | undefined,
     ): void {
-        let stringTypesAttributes: TypeAttributes | undefined = undefined;
+        let stringTypesAttributes: TypeAttributes | undefined;
         if (stringTypes === undefined) {
             stringTypes =
                 stringTypesTypeAttributeKind.tryGetInAttributes(attributes);

--- a/packages/quicktype-core/src/attributes/AccessorNames.ts
+++ b/packages/quicktype-core/src/attributes/AccessorNames.ts
@@ -260,23 +260,24 @@ export function accessorNamesAttributeProducer(
                 makeAccessorNames(maybeAccessors),
             ),
         };
-    }
-    const identifierAttribute = makeUnionIdentifierAttribute();
+    } else {
+        const identifierAttribute = makeUnionIdentifierAttribute();
 
-    const accessors = checkArray(maybeAccessors, isAccessorEntry);
-    messageAssert(
-        cases.length === accessors.length,
-        "SchemaWrongAccessorEntryArrayLength",
-        {
-            operation: "oneOf",
-            ref: canonicalRef.push("oneOf"),
-        },
-    );
-    const caseAttributes = accessors.map((accessor) =>
-        makeUnionMemberNamesAttribute(
-            identifierAttribute,
-            makeAccessorEntry(accessor),
-        ),
-    );
-    return { forUnion: identifierAttribute, forCases: caseAttributes };
+        const accessors = checkArray(maybeAccessors, isAccessorEntry);
+        messageAssert(
+            cases.length === accessors.length,
+            "SchemaWrongAccessorEntryArrayLength",
+            {
+                operation: "oneOf",
+                ref: canonicalRef.push("oneOf"),
+            },
+        );
+        const caseAttributes = accessors.map((accessor) =>
+            makeUnionMemberNamesAttribute(
+                identifierAttribute,
+                makeAccessorEntry(accessor),
+            ),
+        );
+        return { forUnion: identifierAttribute, forCases: caseAttributes };
+    }
 }

--- a/packages/quicktype-core/src/attributes/AccessorNames.ts
+++ b/packages/quicktype-core/src/attributes/AccessorNames.ts
@@ -260,24 +260,23 @@ export function accessorNamesAttributeProducer(
                 makeAccessorNames(maybeAccessors),
             ),
         };
-    } else {
-        const identifierAttribute = makeUnionIdentifierAttribute();
-
-        const accessors = checkArray(maybeAccessors, isAccessorEntry);
-        messageAssert(
-            cases.length === accessors.length,
-            "SchemaWrongAccessorEntryArrayLength",
-            {
-                operation: "oneOf",
-                ref: canonicalRef.push("oneOf"),
-            },
-        );
-        const caseAttributes = accessors.map((accessor) =>
-            makeUnionMemberNamesAttribute(
-                identifierAttribute,
-                makeAccessorEntry(accessor),
-            ),
-        );
-        return { forUnion: identifierAttribute, forCases: caseAttributes };
     }
+    const identifierAttribute = makeUnionIdentifierAttribute();
+
+    const accessors = checkArray(maybeAccessors, isAccessorEntry);
+    messageAssert(
+        cases.length === accessors.length,
+        "SchemaWrongAccessorEntryArrayLength",
+        {
+            operation: "oneOf",
+            ref: canonicalRef.push("oneOf"),
+        },
+    );
+    const caseAttributes = accessors.map((accessor) =>
+        makeUnionMemberNamesAttribute(
+            identifierAttribute,
+            makeAccessorEntry(accessor),
+        ),
+    );
+    return { forUnion: identifierAttribute, forCases: caseAttributes };
 }

--- a/packages/quicktype-core/src/attributes/Constraints.ts
+++ b/packages/quicktype-core/src/attributes/Constraints.ts
@@ -34,8 +34,8 @@ export class MinMaxConstraintTypeAttributeKind extends TypeAttributeKind<MinMaxC
     public constructor(
         name: string,
         private readonly _typeKinds: Set<TypeKind>,
-        private _minSchemaProperty: string,
-        private _maxSchemaProperty: string,
+        private readonly _minSchemaProperty: string,
+        private readonly _maxSchemaProperty: string,
     ) {
         super(name);
     }

--- a/packages/quicktype-core/src/attributes/Constraints.ts
+++ b/packages/quicktype-core/src/attributes/Constraints.ts
@@ -137,8 +137,8 @@ function producer(
 ): MinMaxConstraint | undefined {
     if (!(typeof schema === "object")) return undefined;
 
-    let min: number | undefined = undefined;
-    let max: number | undefined = undefined;
+    let min: number | undefined;
+    let max: number | undefined;
 
     if (typeof schema[minProperty] === "number") {
         min = schema[minProperty];

--- a/packages/quicktype-core/src/attributes/TypeAttributes.ts
+++ b/packages/quicktype-core/src/attributes/TypeAttributes.ts
@@ -158,9 +158,8 @@ export function combineTypeAttributes(
         if (attrs.length === 1) return attrs[0];
         if (union) {
             return kind.combine(attrs);
-        } else {
-            return kind.intersect(attrs);
         }
+        return kind.intersect(attrs);
     }
 
     return mapFilterMap(attributesByKind, combine);

--- a/packages/quicktype-core/src/attributes/TypeAttributes.ts
+++ b/packages/quicktype-core/src/attributes/TypeAttributes.ts
@@ -36,9 +36,7 @@ export class TypeAttributeKind<T> {
         _schema: { [name: string]: unknown },
         _t: Type,
         _attrs: T,
-    ): void {
-        return;
-    }
+    ): void {}
 
     public children(_: T): ReadonlySet<Type> {
         return new Set();

--- a/packages/quicktype-core/src/attributes/TypeAttributes.ts
+++ b/packages/quicktype-core/src/attributes/TypeAttributes.ts
@@ -158,8 +158,9 @@ export function combineTypeAttributes(
         if (attrs.length === 1) return attrs[0];
         if (union) {
             return kind.combine(attrs);
+        } else {
+            return kind.intersect(attrs);
         }
-        return kind.intersect(attrs);
     }
 
     return mapFilterMap(attributesByKind, combine);

--- a/packages/quicktype-core/src/attributes/TypeAttributes.ts
+++ b/packages/quicktype-core/src/attributes/TypeAttributes.ts
@@ -118,7 +118,7 @@ export class TypeAttributeKind<T> {
 }
 
 // FIXME: strongly type this
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+// biome-ignore lint/suspicious/noExplicitAny: heterogeneous by design; attribute values are typed by their kind
 export type TypeAttributes = ReadonlyMap<TypeAttributeKind<any>, any>;
 
 export const emptyTypeAttributes: TypeAttributes = new Map();
@@ -154,7 +154,7 @@ export function combineTypeAttributes(
     const attributesByKind = mapTranspose(attributeArray);
 
     // FIXME: strongly type this
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    // biome-ignore lint/suspicious/noExplicitAny: heterogeneous by design; attribute values are typed by their kind
     function combine(attrs: any[], kind: TypeAttributeKind<any>): any {
         assert(attrs.length > 0, "Cannot combine zero type attributes");
         if (attrs.length === 1) return attrs[0];

--- a/packages/quicktype-core/src/input/CompressedJSON.ts
+++ b/packages/quicktype-core/src/input/CompressedJSON.ts
@@ -56,15 +56,15 @@ export abstract class CompressedJSON<T> {
 
     private _ctx: Context | undefined;
 
-    private _contextStack: Context[] = [];
+    private readonly _contextStack: Context[] = [];
 
-    private _strings: string[] = [];
+    private readonly _strings: string[] = [];
 
-    private _stringIndexes: { [str: string]: number } = {};
+    private readonly _stringIndexes: { [str: string]: number } = {};
 
-    private _objects: Value[][] = [];
+    private readonly _objects: Value[][] = [];
 
-    private _arrays: Value[][] = [];
+    private readonly _arrays: Value[][] = [];
 
     public constructor(
         public readonly dateTimeRecognizer: DateTimeRecognizer,

--- a/packages/quicktype-core/src/input/CompressedJSON.ts
+++ b/packages/quicktype-core/src/input/CompressedJSON.ts
@@ -182,7 +182,7 @@ export abstract class CompressedJSON<T> {
     }
 
     protected commitString(s: string): void {
-        let value: Value | undefined = undefined;
+        let value: Value | undefined;
         if (this.handleRefs && this.isExpectingRef) {
             value = this.makeString(s);
         } else {

--- a/packages/quicktype-core/src/input/CompressedJSON.ts
+++ b/packages/quicktype-core/src/input/CompressedJSON.ts
@@ -105,6 +105,7 @@ export abstract class CompressedJSON<T> {
     }
 
     protected internString(s: string): number {
+        // biome-ignore lint/suspicious/noPrototypeBuiltins: Object.hasOwn is not in quicktype-core's es6 lib
         if (Object.prototype.hasOwnProperty.call(this._stringIndexes, s)) {
             return this._stringIndexes[s];
         }

--- a/packages/quicktype-core/src/input/CompressedJSON.ts
+++ b/packages/quicktype-core/src/input/CompressedJSON.ts
@@ -154,7 +154,9 @@ export abstract class CompressedJSON<T> {
             this._rootValue = value;
         } else if (this._ctx.currentObject !== undefined) {
             if (this._ctx.currentKey === undefined) {
-                panic("Must have key and can't have string when committing");
+                return panic(
+                    "Must have key and can't have string when committing",
+                );
             }
 
             this._ctx.currentObject.push(
@@ -165,7 +167,7 @@ export abstract class CompressedJSON<T> {
         } else if (this._ctx.currentArray !== undefined) {
             this._ctx.currentArray.push(value);
         } else {
-            panic("Committing value but nowhere to commit to");
+            return panic("Committing value but nowhere to commit to");
         }
     }
 
@@ -256,7 +258,7 @@ export abstract class CompressedJSON<T> {
     protected finishObject(): void {
         const obj = this.context.currentObject;
         if (obj === undefined) {
-            panic("Object ended but not started");
+            return panic("Object ended but not started");
         }
 
         this.popContext();
@@ -271,7 +273,7 @@ export abstract class CompressedJSON<T> {
     protected finishArray(): void {
         const arr = this.context.currentArray;
         if (arr === undefined) {
-            panic("Array ended but not started");
+            return panic("Array ended but not started");
         }
 
         this.popContext();
@@ -359,7 +361,7 @@ export class CompressedJSONFromString extends CompressedJSON<string> {
 
             this.finishObject();
         } else {
-            panic("Invalid JSON object");
+            return panic("Invalid JSON object");
         }
     }
 }

--- a/packages/quicktype-core/src/input/CompressedJSON.ts
+++ b/packages/quicktype-core/src/input/CompressedJSON.ts
@@ -153,9 +153,7 @@ export abstract class CompressedJSON<T> {
             this._rootValue = value;
         } else if (this._ctx.currentObject !== undefined) {
             if (this._ctx.currentKey === undefined) {
-                return panic(
-                    "Must have key and can't have string when committing",
-                );
+                panic("Must have key and can't have string when committing");
             }
 
             this._ctx.currentObject.push(
@@ -166,7 +164,7 @@ export abstract class CompressedJSON<T> {
         } else if (this._ctx.currentArray !== undefined) {
             this._ctx.currentArray.push(value);
         } else {
-            return panic("Committing value but nowhere to commit to");
+            panic("Committing value but nowhere to commit to");
         }
     }
 
@@ -257,7 +255,7 @@ export abstract class CompressedJSON<T> {
     protected finishObject(): void {
         const obj = this.context.currentObject;
         if (obj === undefined) {
-            return panic("Object ended but not started");
+            panic("Object ended but not started");
         }
 
         this.popContext();
@@ -272,7 +270,7 @@ export abstract class CompressedJSON<T> {
     protected finishArray(): void {
         const arr = this.context.currentArray;
         if (arr === undefined) {
-            return panic("Array ended but not started");
+            panic("Array ended but not started");
         }
 
         this.popContext();
@@ -360,7 +358,7 @@ export class CompressedJSONFromString extends CompressedJSON<string> {
 
             this.finishObject();
         } else {
-            return panic("Invalid JSON object");
+            panic("Invalid JSON object");
         }
     }
 }

--- a/packages/quicktype-core/src/input/Inference.ts
+++ b/packages/quicktype-core/src/input/Inference.ts
@@ -363,6 +363,7 @@ export class TypeInference {
                 const key = this._cjson.getStringForValue(arr[i]);
                 const value = arr[i + 1];
                 if (
+                    // biome-ignore lint/suspicious/noPrototypeBuiltins: Object.hasOwn is not in quicktype-core's es6 lib
                     !Object.prototype.hasOwnProperty.call(propertyValues, key)
                 ) {
                     propertyNames.push(key);

--- a/packages/quicktype-core/src/input/Inference.ts
+++ b/packages/quicktype-core/src/input/Inference.ts
@@ -32,7 +32,7 @@ import {
 //   Value[] | NestedValueArray[]
 // but TypeScript doesn't support that.
 // FIXME: reactor this
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+// biome-ignore lint/suspicious/noExplicitAny: TypeScript cannot express this recursive type
 export type NestedValueArray = any;
 
 function forEachArrayInNestedValueArray(

--- a/packages/quicktype-core/src/input/JSONSchemaInput.ts
+++ b/packages/quicktype-core/src/input/JSONSchemaInput.ts
@@ -105,7 +105,7 @@ function withRef<T extends object>(
             : refOrLoc instanceof Ref
               ? refOrLoc
               : refOrLoc.canonicalRef;
-    return Object.assign({ ref }, props ?? {});
+    return { ref, ...(props ?? {}) };
 }
 
 function checkJSONSchemaObject(

--- a/packages/quicktype-core/src/input/JSONSchemaInput.ts
+++ b/packages/quicktype-core/src/input/JSONSchemaInput.ts
@@ -1538,10 +1538,11 @@ export class JSONSchemaInput implements Input<JSONSchemaSourceData> {
                 return panic("Must have a schema store to process JSON Schema");
             }
         } else {
-            maybeSchemaStore = this._schemaStore = new InputJSONSchemaStore(
+            this._schemaStore = new InputJSONSchemaStore(
                 this._schemaInputs,
                 maybeSchemaStore,
             );
+            maybeSchemaStore = this._schemaStore;
         }
 
         const schemaStore = maybeSchemaStore;

--- a/packages/quicktype-core/src/input/JSONSchemaInput.ts
+++ b/packages/quicktype-core/src/input/JSONSchemaInput.ts
@@ -399,13 +399,11 @@ export class Ref {
         if (!(other instanceof Ref)) return false;
         if (this.addressURI !== undefined && other.addressURI !== undefined) {
             if (!this.addressURI.equals(other.addressURI)) return false;
-        } else {
-            if (
-                (this.addressURI === undefined) !==
-                (other.addressURI === undefined)
-            )
-                return false;
-        }
+        } else if (
+            (this.addressURI === undefined) !==
+            (other.addressURI === undefined)
+        )
+            return false;
 
         const l = this.path.length;
         if (l !== other.path.length) return false;

--- a/packages/quicktype-core/src/input/JSONSchemaInput.ts
+++ b/packages/quicktype-core/src/input/JSONSchemaInput.ts
@@ -347,7 +347,7 @@ export class Ref {
         switch (first.kind) {
             case PathElementKind.Root:
                 return this.lookup(root, rest, root);
-            case PathElementKind.KeyOrIndex:
+            case PathElementKind.KeyOrIndex: {
                 const key = first.key;
                 if (Array.isArray(local)) {
                     if (!/^\d+$/.test(key)) {
@@ -380,6 +380,7 @@ export class Ref {
                     rest,
                     root,
                 );
+            }
 
             case PathElementKind.Type:
                 return panic('Cannot look up path that indexes "type"');

--- a/packages/quicktype-core/src/input/JSONSchemaInput.ts
+++ b/packages/quicktype-core/src/input/JSONSchemaInput.ts
@@ -926,8 +926,7 @@ async function addTypesInSchema(
         }
 
         const includedTypes = setFilter(schemaTypes, isTypeIncluded);
-        let producedAttributesForNoCases: JSONSchemaAttributes[] | undefined =
-            undefined;
+        let producedAttributesForNoCases: JSONSchemaAttributes[] | undefined;
 
         function forEachProducedAttribute(
             cases: JSONSchema[] | undefined,

--- a/packages/quicktype-core/src/input/JSONSchemaInput.ts
+++ b/packages/quicktype-core/src/input/JSONSchemaInput.ts
@@ -1496,7 +1496,7 @@ export class JSONSchemaInput implements Input<JSONSchemaSourceData> {
 
     private readonly _schemaInputs: Map<string, string> = new Map();
 
-    private _schemaSources: Array<[URI, JSONSchemaSourceData]> = [];
+    private readonly _schemaSources: Array<[URI, JSONSchemaSourceData]> = [];
 
     private readonly _topLevels: Map<string, Ref> = new Map();
 

--- a/packages/quicktype-core/src/input/JSONSchemaInput.ts
+++ b/packages/quicktype-core/src/input/JSONSchemaInput.ts
@@ -166,9 +166,9 @@ export class Ref {
 
         if (path !== "") {
             const parts = path.split("/");
-            parts.forEach((part) =>
-                elements.push({ kind: PathElementKind.KeyOrIndex, key: part }),
-            );
+            parts.forEach((part) => {
+                elements.push({ kind: PathElementKind.KeyOrIndex, key: part });
+            });
         }
 
         return elements;

--- a/packages/quicktype-core/src/input/JSONSchemaInput.ts
+++ b/packages/quicktype-core/src/input/JSONSchemaInput.ts
@@ -1441,7 +1441,7 @@ async function refsInSchemaForURI(
             });
         }
 
-        return mapMap(mapFromObject(schema), (_, name) => ref.push(name));
+        return mapMap(mapFromObject(schema), (_, key) => ref.push(key));
     }
 
     let name: string;

--- a/packages/quicktype-core/src/input/JSONSchemaStore.ts
+++ b/packages/quicktype-core/src/input/JSONSchemaStore.ts
@@ -31,7 +31,7 @@ export abstract class JSONSchemaStore {
 
         try {
             schema = await this.fetch(address);
-        } catch (e) {
+        } catch {
             // FIXME: handle or log this error
         }
 

--- a/packages/quicktype-core/src/input/PostmanCollection.ts
+++ b/packages/quicktype-core/src/input/PostmanCollection.ts
@@ -96,7 +96,7 @@ export function sourcesFromPostmanCollection(
     );
 
     const joinedDescription = descriptions.join("\n\n").trim();
-    let description: string | undefined = undefined;
+    let description: string | undefined;
     if (joinedDescription !== "") {
         description = joinedDescription;
     }

--- a/packages/quicktype-core/src/input/PostmanCollection.ts
+++ b/packages/quicktype-core/src/input/PostmanCollection.ts
@@ -7,7 +7,7 @@ function isValidJSON(s: string): boolean {
     try {
         JSON.parse(s);
         return true;
-    } catch (error) {
+    } catch {
         return false;
     }
 }

--- a/packages/quicktype-core/src/input/io/get-stream/buffer-stream.ts
+++ b/packages/quicktype-core/src/input/io/get-stream/buffer-stream.ts
@@ -13,7 +13,7 @@ export interface BufferedPassThrough extends PassThrough {
 }
 
 export default function bufferStream(opts: Options) {
-    opts = Object.assign({}, opts);
+    opts = { ...opts };
 
     const array = opts.array;
     let encoding: string | undefined = opts.encoding;

--- a/packages/quicktype-core/src/input/io/get-stream/buffer-stream.ts
+++ b/packages/quicktype-core/src/input/io/get-stream/buffer-stream.ts
@@ -4,6 +4,7 @@ import { PassThrough } from "readable-stream";
 import type { Options } from "./index.js";
 
 export interface BufferedPassThrough extends PassThrough {
+    // biome-ignore lint/suspicious/noExplicitAny: vendored from sindresorhus/get-stream
     getBufferedValue: () => any;
     getBufferedLength: () => number;
 
@@ -30,6 +31,7 @@ export default function bufferStream(opts: Options) {
     }
 
     let len = 0;
+    // biome-ignore lint/suspicious/noExplicitAny: vendored from sindresorhus/get-stream
     const ret: any[] = [];
     const stream = new PassThrough({
         objectMode,
@@ -39,6 +41,7 @@ export default function bufferStream(opts: Options) {
         stream.setEncoding(encoding as BufferEncoding);
     }
 
+    // biome-ignore lint/suspicious/noExplicitAny: vendored from sindresorhus/get-stream
     stream.on("data", (chunk: any) => {
         ret.push(chunk);
 

--- a/packages/quicktype-core/src/input/io/get-stream/index.ts
+++ b/packages/quicktype-core/src/input/io/get-stream/index.ts
@@ -21,6 +21,7 @@ export async function getStream(inputStream: Readable, opts: Options = {}) {
     let clean: (() => void) | undefined;
 
     const p = new Promise((resolve, reject) => {
+        // biome-ignore lint/suspicious/noExplicitAny: vendored from sindresorhus/get-stream
         const error = (err: any) => {
             if (err) {
                 // null check

--- a/packages/quicktype-core/src/input/io/get-stream/index.ts
+++ b/packages/quicktype-core/src/input/io/get-stream/index.ts
@@ -14,7 +14,7 @@ export async function getStream(inputStream: Readable, opts: Options = {}) {
         return await Promise.reject(new Error("Expected a stream"));
     }
 
-    opts = Object.assign({ maxBuffer: Number.POSITIVE_INFINITY }, opts);
+    opts = { maxBuffer: Number.POSITIVE_INFINITY, ...opts };
 
     const maxBuffer = opts.maxBuffer ?? Number.POSITIVE_INFINITY;
     let stream: BufferedPassThrough;
@@ -56,10 +56,10 @@ export async function getStream(inputStream: Readable, opts: Options = {}) {
 
 // FIXME: should these be async ?
 export function buffer(stream: Readable, opts: Options = {}) {
-    void getStream(stream, Object.assign({}, opts, { encoding: "buffer" }));
+    void getStream(stream, { ...opts, encoding: "buffer" });
 }
 
 // FIXME: should these be async ?
 export function array(stream: Readable, opts: Options = {}) {
-    void getStream(stream, Object.assign({}, opts, { array: true }));
+    void getStream(stream, { ...opts, array: true });
 }

--- a/packages/quicktype-core/src/input/io/get-stream/index.ts
+++ b/packages/quicktype-core/src/input/io/get-stream/index.ts
@@ -18,7 +18,7 @@ export async function getStream(inputStream: Readable, opts: Options = {}) {
 
     const maxBuffer = opts.maxBuffer ?? Number.POSITIVE_INFINITY;
     let stream: BufferedPassThrough;
-    let clean;
+    let clean: (() => void) | undefined;
 
     const p = new Promise((resolve, reject) => {
         const error = (err: any) => {

--- a/packages/quicktype-core/src/language/All.ts
+++ b/packages/quicktype-core/src/language/All.ts
@@ -65,6 +65,7 @@ export const all = [
     new TypeScriptZodTargetLanguage(),
 ] as const;
 
+// biome-ignore lint/suspicious/noUnusedExpressions: compile-time type check via satisfies
 all satisfies readonly TargetLanguage[];
 
 /**

--- a/packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts
+++ b/packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts
@@ -1716,39 +1716,35 @@ export class CJSONRenderer extends ConvenienceRenderer {
                                                             "cJSON_NULL"
                                                     ) {
                                                         /* Nothing to do */
-                                                    } else {
-                                                        if (
-                                                            cJSON.items
-                                                                ?.isNullable
-                                                        ) {
-                                                            this.emitBlock(
-                                                                [
-                                                                    "if ((void *)0xDEADBEEF != x",
-                                                                    child_level.toString(),
-                                                                    ")",
-                                                                ],
-                                                                () => {
-                                                                    this.emitLine(
-                                                                        // @ts-expect-error awaiting refactor
-                                                                        cJSON
-                                                                            .items
-                                                                            ?.deleteType,
-                                                                        "(x",
-                                                                        child_level.toString(),
-                                                                        ");",
-                                                                    );
-                                                                },
-                                                            );
-                                                        } else {
-                                                            this.emitLine(
-                                                                // @ts-expect-error awaiting refactor
-                                                                cJSON.items
-                                                                    ?.deleteType,
-                                                                "(x",
+                                                    } else if (
+                                                        cJSON.items?.isNullable
+                                                    ) {
+                                                        this.emitBlock(
+                                                            [
+                                                                "if ((void *)0xDEADBEEF != x",
                                                                 child_level.toString(),
-                                                                ");",
-                                                            );
-                                                        }
+                                                                ")",
+                                                            ],
+                                                            () => {
+                                                                this.emitLine(
+                                                                    // @ts-expect-error awaiting refactor
+                                                                    cJSON.items
+                                                                        ?.deleteType,
+                                                                    "(x",
+                                                                    child_level.toString(),
+                                                                    ");",
+                                                                );
+                                                            },
+                                                        );
+                                                    } else {
+                                                        this.emitLine(
+                                                            // @ts-expect-error awaiting refactor
+                                                            cJSON.items
+                                                                ?.deleteType,
+                                                            "(x",
+                                                            child_level.toString(),
+                                                            ");",
+                                                        );
                                                     }
 
                                                     this.emitLine(
@@ -1894,41 +1890,39 @@ export class CJSONRenderer extends ConvenienceRenderer {
                                                                             "cJSON_NULL"
                                                                     ) {
                                                                         /* Nothing to do */
+                                                                    } else if (
+                                                                        cJSON
+                                                                            .items
+                                                                            ?.isNullable
+                                                                    ) {
+                                                                        this.emitBlock(
+                                                                            [
+                                                                                "if ((void *)0xDEADBEEF != x",
+                                                                                child_level.toString(),
+                                                                                ")",
+                                                                            ],
+                                                                            () => {
+                                                                                this.emitLine(
+                                                                                    // @ts-expect-error awaiting refactor
+                                                                                    cJSON
+                                                                                        .items
+                                                                                        ?.deleteType,
+                                                                                    "(x",
+                                                                                    child_level.toString(),
+                                                                                    ");",
+                                                                                );
+                                                                            },
+                                                                        );
                                                                     } else {
-                                                                        if (
+                                                                        this.emitLine(
+                                                                            // @ts-expect-error awaiting refactor
                                                                             cJSON
                                                                                 .items
-                                                                                ?.isNullable
-                                                                        ) {
-                                                                            this.emitBlock(
-                                                                                [
-                                                                                    "if ((void *)0xDEADBEEF != x",
-                                                                                    child_level.toString(),
-                                                                                    ")",
-                                                                                ],
-                                                                                () => {
-                                                                                    this.emitLine(
-                                                                                        // @ts-expect-error awaiting refactor
-                                                                                        cJSON
-                                                                                            .items
-                                                                                            ?.deleteType,
-                                                                                        "(x",
-                                                                                        child_level.toString(),
-                                                                                        ");",
-                                                                                    );
-                                                                                },
-                                                                            );
-                                                                        } else {
-                                                                            this.emitLine(
-                                                                                // @ts-expect-error awaiting refactor
-                                                                                cJSON
-                                                                                    .items
-                                                                                    ?.deleteType,
-                                                                                "(x",
-                                                                                child_level.toString(),
-                                                                                ");",
-                                                                            );
-                                                                        }
+                                                                                ?.deleteType,
+                                                                            "(x",
+                                                                            child_level.toString(),
+                                                                            ");",
+                                                                        );
                                                                     }
                                                                 },
                                                             );
@@ -2991,64 +2985,60 @@ export class CJSONRenderer extends ConvenienceRenderer {
                                                             jsonName,
                                                             '"));',
                                                         );
-                                                    } else {
-                                                        if (
-                                                            property.isOptional ||
-                                                            cJSON.isNullable
-                                                        ) {
-                                                            this.emitBlock(
-                                                                [
-                                                                    "if (NULL != (x",
-                                                                    level > 0
-                                                                        ? level.toString()
-                                                                        : "",
-                                                                    "->",
-                                                                    name,
-                                                                    " = cJSON_malloc(sizeof(",
-                                                                    cJSON.cType,
-                                                                    "))))",
-                                                                ],
-                                                                () => {
-                                                                    this.emitLine(
-                                                                        "*x",
-                                                                        level >
-                                                                            0
-                                                                            ? level.toString()
-                                                                            : "",
-                                                                        "->",
-                                                                        name,
-                                                                        " = ",
-                                                                        cJSON.getValue,
-                                                                        "(cJSON_GetObjectItemCaseSensitive(j",
-                                                                        level >
-                                                                            0
-                                                                            ? level.toString()
-                                                                            : "",
-                                                                        ', "',
-                                                                        jsonName,
-                                                                        '"));',
-                                                                    );
-                                                                },
-                                                            );
-                                                        } else {
-                                                            this.emitLine(
-                                                                "x",
+                                                    } else if (
+                                                        property.isOptional ||
+                                                        cJSON.isNullable
+                                                    ) {
+                                                        this.emitBlock(
+                                                            [
+                                                                "if (NULL != (x",
                                                                 level > 0
                                                                     ? level.toString()
                                                                     : "",
                                                                 "->",
                                                                 name,
-                                                                " = ",
-                                                                cJSON.getValue,
-                                                                "(cJSON_GetObjectItemCaseSensitive(j",
-                                                                level > 0
-                                                                    ? level.toString()
-                                                                    : "",
-                                                                ', "',
-                                                                jsonName,
-                                                                '"));',
-                                                            );
-                                                        }
+                                                                " = cJSON_malloc(sizeof(",
+                                                                cJSON.cType,
+                                                                "))))",
+                                                            ],
+                                                            () => {
+                                                                this.emitLine(
+                                                                    "*x",
+                                                                    level > 0
+                                                                        ? level.toString()
+                                                                        : "",
+                                                                    "->",
+                                                                    name,
+                                                                    " = ",
+                                                                    cJSON.getValue,
+                                                                    "(cJSON_GetObjectItemCaseSensitive(j",
+                                                                    level > 0
+                                                                        ? level.toString()
+                                                                        : "",
+                                                                    ', "',
+                                                                    jsonName,
+                                                                    '"));',
+                                                                );
+                                                            },
+                                                        );
+                                                    } else {
+                                                        this.emitLine(
+                                                            "x",
+                                                            level > 0
+                                                                ? level.toString()
+                                                                : "",
+                                                            "->",
+                                                            name,
+                                                            " = ",
+                                                            cJSON.getValue,
+                                                            "(cJSON_GetObjectItemCaseSensitive(j",
+                                                            level > 0
+                                                                ? level.toString()
+                                                                : "",
+                                                            ', "',
+                                                            jsonName,
+                                                            '"));',
+                                                        );
                                                     }
                                                 },
                                             );
@@ -4022,58 +4012,56 @@ export class CJSONRenderer extends ConvenienceRenderer {
                                                         "));",
                                                     );
                                                 }
-                                            } else {
-                                                if (
-                                                    property.isOptional ||
-                                                    cJSON.isNullable
-                                                ) {
-                                                    this.emitBlock(
-                                                        [
-                                                            "if (NULL != x",
-                                                            level > 0
-                                                                ? level.toString()
-                                                                : "",
-                                                            "->",
-                                                            name,
-                                                            ")",
-                                                        ],
-                                                        () => {
-                                                            this.emitLine(
-                                                                cJSON.addToObject,
-                                                                "(j",
-                                                                level > 0
-                                                                    ? level.toString()
-                                                                    : "",
-                                                                ', "',
-                                                                jsonName,
-                                                                '", *x',
-                                                                level > 0
-                                                                    ? level.toString()
-                                                                    : "",
-                                                                "->",
-                                                                name,
-                                                                ");",
-                                                            );
-                                                        },
-                                                    );
-                                                } else {
-                                                    this.emitLine(
-                                                        cJSON.addToObject,
-                                                        "(j",
-                                                        level > 0
-                                                            ? level.toString()
-                                                            : "",
-                                                        ', "',
-                                                        jsonName,
-                                                        '", x',
+                                            } else if (
+                                                property.isOptional ||
+                                                cJSON.isNullable
+                                            ) {
+                                                this.emitBlock(
+                                                    [
+                                                        "if (NULL != x",
                                                         level > 0
                                                             ? level.toString()
                                                             : "",
                                                         "->",
                                                         name,
-                                                        ");",
-                                                    );
-                                                }
+                                                        ")",
+                                                    ],
+                                                    () => {
+                                                        this.emitLine(
+                                                            cJSON.addToObject,
+                                                            "(j",
+                                                            level > 0
+                                                                ? level.toString()
+                                                                : "",
+                                                            ', "',
+                                                            jsonName,
+                                                            '", *x',
+                                                            level > 0
+                                                                ? level.toString()
+                                                                : "",
+                                                            "->",
+                                                            name,
+                                                            ");",
+                                                        );
+                                                    },
+                                                );
+                                            } else {
+                                                this.emitLine(
+                                                    cJSON.addToObject,
+                                                    "(j",
+                                                    level > 0
+                                                        ? level.toString()
+                                                        : "",
+                                                    ', "',
+                                                    jsonName,
+                                                    '", x',
+                                                    level > 0
+                                                        ? level.toString()
+                                                        : "",
+                                                    "->",
+                                                    name,
+                                                    ");",
+                                                );
                                             }
 
                                             if (cJSON.isNullable) {
@@ -4283,39 +4271,37 @@ export class CJSONRenderer extends ConvenienceRenderer {
                                                                 "cJSON_NULL"
                                                         ) {
                                                             /* Nothing to do */
-                                                        } else {
-                                                            if (
-                                                                cJSON.items
-                                                                    ?.isNullable
-                                                            ) {
-                                                                this.emitBlock(
-                                                                    [
-                                                                        "if ((void *)0xDEADBEEF != x",
-                                                                        child_level.toString(),
-                                                                        ")",
-                                                                    ],
-                                                                    () => {
-                                                                        this.emitLine(
-                                                                            // @ts-expect-error awaiting refactor
-                                                                            cJSON
-                                                                                .items
-                                                                                ?.deleteType,
-                                                                            "(x",
-                                                                            child_level.toString(),
-                                                                            ");",
-                                                                        );
-                                                                    },
-                                                                );
-                                                            } else {
-                                                                this.emitLine(
-                                                                    // @ts-expect-error awaiting refactor
-                                                                    cJSON.items
-                                                                        ?.deleteType,
-                                                                    "(x",
+                                                        } else if (
+                                                            cJSON.items
+                                                                ?.isNullable
+                                                        ) {
+                                                            this.emitBlock(
+                                                                [
+                                                                    "if ((void *)0xDEADBEEF != x",
                                                                     child_level.toString(),
-                                                                    ");",
-                                                                );
-                                                            }
+                                                                    ")",
+                                                                ],
+                                                                () => {
+                                                                    this.emitLine(
+                                                                        // @ts-expect-error awaiting refactor
+                                                                        cJSON
+                                                                            .items
+                                                                            ?.deleteType,
+                                                                        "(x",
+                                                                        child_level.toString(),
+                                                                        ");",
+                                                                    );
+                                                                },
+                                                            );
+                                                        } else {
+                                                            this.emitLine(
+                                                                // @ts-expect-error awaiting refactor
+                                                                cJSON.items
+                                                                    ?.deleteType,
+                                                                "(x",
+                                                                child_level.toString(),
+                                                                ");",
+                                                            );
                                                         }
 
                                                         this.emitLine(
@@ -4469,41 +4455,39 @@ export class CJSONRenderer extends ConvenienceRenderer {
                                                                                 "cJSON_NULL"
                                                                         ) {
                                                                             /* Nothing to do */
+                                                                        } else if (
+                                                                            cJSON
+                                                                                .items
+                                                                                ?.isNullable
+                                                                        ) {
+                                                                            this.emitBlock(
+                                                                                [
+                                                                                    "if ((void *)0xDEADBEEF != x",
+                                                                                    child_level.toString(),
+                                                                                    ")",
+                                                                                ],
+                                                                                () => {
+                                                                                    this.emitLine(
+                                                                                        // @ts-expect-error awaiting refactor
+                                                                                        cJSON
+                                                                                            .items
+                                                                                            ?.deleteType,
+                                                                                        "(x",
+                                                                                        child_level.toString(),
+                                                                                        ");",
+                                                                                    );
+                                                                                },
+                                                                            );
                                                                         } else {
-                                                                            if (
+                                                                            this.emitLine(
+                                                                                // @ts-expect-error awaiting refactor
                                                                                 cJSON
                                                                                     .items
-                                                                                    ?.isNullable
-                                                                            ) {
-                                                                                this.emitBlock(
-                                                                                    [
-                                                                                        "if ((void *)0xDEADBEEF != x",
-                                                                                        child_level.toString(),
-                                                                                        ")",
-                                                                                    ],
-                                                                                    () => {
-                                                                                        this.emitLine(
-                                                                                            // @ts-expect-error awaiting refactor
-                                                                                            cJSON
-                                                                                                .items
-                                                                                                ?.deleteType,
-                                                                                            "(x",
-                                                                                            child_level.toString(),
-                                                                                            ");",
-                                                                                        );
-                                                                                    },
-                                                                                );
-                                                                            } else {
-                                                                                this.emitLine(
-                                                                                    // @ts-expect-error awaiting refactor
-                                                                                    cJSON
-                                                                                        .items
-                                                                                        ?.deleteType,
-                                                                                    "(x",
-                                                                                    child_level.toString(),
-                                                                                    ");",
-                                                                                );
-                                                                            }
+                                                                                    ?.deleteType,
+                                                                                "(x",
+                                                                                child_level.toString(),
+                                                                                ");",
+                                                                            );
                                                                         }
                                                                     },
                                                                 );
@@ -4561,35 +4545,33 @@ export class CJSONRenderer extends ConvenienceRenderer {
                                                 );
                                             },
                                         );
-                                    } else {
-                                        if (
-                                            property.isOptional ||
-                                            cJSON.isNullable
-                                        ) {
-                                            this.emitBlock(
-                                                [
-                                                    "if (NULL != x",
+                                    } else if (
+                                        property.isOptional ||
+                                        cJSON.isNullable
+                                    ) {
+                                        this.emitBlock(
+                                            [
+                                                "if (NULL != x",
+                                                level > 0
+                                                    ? level.toString()
+                                                    : "",
+                                                "->",
+                                                name,
+                                                ")",
+                                            ],
+                                            () => {
+                                                this.emitLine(
+                                                    cJSON.deleteType,
+                                                    "(x",
                                                     level > 0
                                                         ? level.toString()
                                                         : "",
                                                     "->",
                                                     name,
-                                                    ")",
-                                                ],
-                                                () => {
-                                                    this.emitLine(
-                                                        cJSON.deleteType,
-                                                        "(x",
-                                                        level > 0
-                                                            ? level.toString()
-                                                            : "",
-                                                        "->",
-                                                        name,
-                                                        ");",
-                                                    );
-                                                },
-                                            );
-                                        }
+                                                    ");",
+                                                );
+                                            },
+                                        );
                                     }
                                 },
                             );
@@ -5750,12 +5732,10 @@ export class CJSONRenderer extends ConvenienceRenderer {
             } else {
                 this.emitLine("};");
             }
+        } else if (withName !== "") {
+            this.emitLine("} ", withName);
         } else {
-            if (withName !== "") {
-                this.emitLine("} ", withName);
-            } else {
-                this.emitLine("}");
-            }
+            this.emitLine("}");
         }
     }
 
@@ -5834,12 +5814,10 @@ export class CJSONRenderer extends ConvenienceRenderer {
                 if (maybeNull !== undefined) {
                     /* Houston this is a variant, include it */
                     propRecord.kind = IncludeKind.Include;
+                } else if (t.forceInclude) {
+                    propRecord.kind = IncludeKind.Include;
                 } else {
-                    if (t.forceInclude) {
-                        propRecord.kind = IncludeKind.Include;
-                    } else {
-                        propRecord.kind = IncludeKind.ForwardDeclare;
-                    }
+                    propRecord.kind = IncludeKind.ForwardDeclare;
                 }
             }
 

--- a/packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts
+++ b/packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts
@@ -5763,7 +5763,7 @@ export class CJSONRenderer extends ConvenienceRenderer {
         }
 
         /* Emit includes */
-        if (includes.size !== 0) {
+        if (includes.size > 0) {
             includes.forEach((_rec: IncludeRecord, name: string) => {
                 name = name.concat(".h");
                 if (name !== filename) {

--- a/packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts
+++ b/packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts
@@ -73,7 +73,7 @@ export class CJSONRenderer extends ConvenienceRenderer {
 
     protected readonly enumeratorNamingStyle: NamingStyle; /* Enum naming style */
 
-    private includes: string[];
+    private readonly includes: string[];
 
     /**
      * Constructor

--- a/packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts
+++ b/packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts
@@ -203,9 +203,9 @@ export class CJSONRenderer extends ConvenienceRenderer {
             fieldType,
             lookup,
         );
-        if ("bool" === fieldName) {
+        if (fieldName === "bool") {
             fieldName = "boolean";
-        } else if ("double" === fieldName) {
+        } else if (fieldName === "double") {
             fieldName = "number";
         }
 

--- a/packages/quicktype-core/src/language/CPlusPlus/CPlusPlusRenderer.ts
+++ b/packages/quicktype-core/src/language/CPlusPlus/CPlusPlusRenderer.ts
@@ -656,7 +656,7 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
 
         const typeList: Sourcelike = [];
         for (const t of nonNulls) {
-            if (typeList.length !== 0) {
+            if (typeList.length > 0) {
                 typeList.push(", ");
             }
 
@@ -3086,7 +3086,7 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
             );
         }
 
-        if (includes.size !== 0) {
+        if (includes.size > 0) {
             let numForwards = 0;
             let numIncludes = 0;
             includes.forEach((rec: IncludeRecord, name: string) => {

--- a/packages/quicktype-core/src/language/CPlusPlus/CPlusPlusRenderer.ts
+++ b/packages/quicktype-core/src/language/CPlusPlus/CPlusPlusRenderer.ts
@@ -3039,12 +3039,10 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
                 if (maybeNull !== undefined) {
                     /** Houston this is a variant, include it */
                     propRecord.kind = IncludeKind.Include;
+                } else if (t.forceInclude) {
+                    propRecord.kind = IncludeKind.Include;
                 } else {
-                    if (t.forceInclude) {
-                        propRecord.kind = IncludeKind.Include;
-                    } else {
-                        propRecord.kind = IncludeKind.ForwardDeclare;
-                    }
+                    propRecord.kind = IncludeKind.ForwardDeclare;
                 }
             }
 

--- a/packages/quicktype-core/src/language/CPlusPlus/CPlusPlusRenderer.ts
+++ b/packages/quicktype-core/src/language/CPlusPlus/CPlusPlusRenderer.ts
@@ -3331,9 +3331,7 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
             return inner;
         }
 
-        public emitHelperFunctions(): void {
-            return;
-        }
+        public emitHelperFunctions(): void {}
     })();
 
     public WideString = new (class extends BaseString implements StringType {

--- a/packages/quicktype-core/src/language/CPlusPlus/utils.ts
+++ b/packages/quicktype-core/src/language/CPlusPlus/utils.ts
@@ -182,7 +182,7 @@ export class BaseString {
         smatch: string,
         regex: string,
         stringLiteralPrefix: string,
-        toString: WrappingCode,
+        toStringCode: WrappingCode,
         encodingClass: string,
         encodingFunction: string,
     ) {
@@ -191,7 +191,7 @@ export class BaseString {
         this._smatch = smatch;
         this._regex = regex;
         this._stringLiteralPrefix = stringLiteralPrefix;
-        this._toString = toString;
+        this._toString = toStringCode;
         this._encodingClass = encodingClass;
         this._encodingFunction = encodingFunction;
     }

--- a/packages/quicktype-core/src/language/CSharp/CSharpRenderer.ts
+++ b/packages/quicktype-core/src/language/CSharp/CSharpRenderer.ts
@@ -159,8 +159,9 @@ export class CSharpRenderer extends ConvenienceRenderer {
                 );
                 if (this._csOptions.useList) {
                     return ["List<", itemsType, ">"];
+                } else {
+                    return [itemsType, "[]"];
                 }
-                return [itemsType, "[]"];
             },
             (classType) => this.nameForNamedType(classType),
             (mapType) => [
@@ -189,8 +190,9 @@ export class CSharpRenderer extends ConvenienceRenderer {
         const csType = this.csType(t, follow, withIssues);
         if (isValueType(t)) {
             return [csType, "?"];
+        } else {
+            return csType;
         }
-        return csType;
     }
 
     protected baseclassForType(_t: Type): Sourcelike | undefined {

--- a/packages/quicktype-core/src/language/CSharp/CSharpRenderer.ts
+++ b/packages/quicktype-core/src/language/CSharp/CSharpRenderer.ts
@@ -159,9 +159,8 @@ export class CSharpRenderer extends ConvenienceRenderer {
                 );
                 if (this._csOptions.useList) {
                     return ["List<", itemsType, ">"];
-                } else {
-                    return [itemsType, "[]"];
                 }
+                return [itemsType, "[]"];
             },
             (classType) => this.nameForNamedType(classType),
             (mapType) => [
@@ -190,9 +189,8 @@ export class CSharpRenderer extends ConvenienceRenderer {
         const csType = this.csType(t, follow, withIssues);
         if (isValueType(t)) {
             return [csType, "?"];
-        } else {
-            return csType;
         }
+        return csType;
     }
 
     protected baseclassForType(_t: Type): Sourcelike | undefined {

--- a/packages/quicktype-core/src/language/CSharp/CSharpRenderer.ts
+++ b/packages/quicktype-core/src/language/CSharp/CSharpRenderer.ts
@@ -538,7 +538,7 @@ export class CSharpRenderer extends ConvenienceRenderer {
 
     protected emitDependencyUsings(): void {
         let genericEmited: boolean = false;
-        let ensureGenericOnce = () => {
+        const ensureGenericOnce = () => {
             if (!genericEmited) {
                 this.emitUsing("System.Collections.Generic");
                 genericEmited = true;

--- a/packages/quicktype-core/src/language/CSharp/CSharpRenderer.ts
+++ b/packages/quicktype-core/src/language/CSharp/CSharpRenderer.ts
@@ -529,7 +529,7 @@ export class CSharpRenderer extends ConvenienceRenderer {
     }
 
     protected emitDependencyUsings(): void {
-        let genericEmited: boolean = false;
+        let genericEmited = false;
         const ensureGenericOnce = () => {
             if (!genericEmited) {
                 this.emitUsing("System.Collections.Generic");

--- a/packages/quicktype-core/src/language/CSharp/CSharpRenderer.ts
+++ b/packages/quicktype-core/src/language/CSharp/CSharpRenderer.ts
@@ -484,9 +484,7 @@ export class CSharpRenderer extends ConvenienceRenderer {
         }
     }
 
-    protected emitRequiredHelpers(): void {
-        return;
-    }
+    protected emitRequiredHelpers(): void {}
 
     private emitTypesAndSupport(): void {
         this.forEachObject(
@@ -502,13 +500,9 @@ export class CSharpRenderer extends ConvenienceRenderer {
         this.emitRequiredHelpers();
     }
 
-    protected emitDefaultLeadingComments(): void {
-        return;
-    }
+    protected emitDefaultLeadingComments(): void {}
 
-    protected emitDefaultFollowingComments(): void {
-        return;
-    }
+    protected emitDefaultFollowingComments(): void {}
 
     protected needNamespace(): boolean {
         return true;

--- a/packages/quicktype-core/src/language/CSharp/CSharpRenderer.ts
+++ b/packages/quicktype-core/src/language/CSharp/CSharpRenderer.ts
@@ -294,7 +294,7 @@ export class CSharpRenderer extends ConvenienceRenderer {
                     : "none";
                 const columns: Sourcelike[][] = [];
                 let isFirstProperty = true;
-                let previousDescription: string[] | undefined = undefined;
+                let previousDescription: string[] | undefined;
                 this.forEachClassProperty(
                     c,
                     blankLines,

--- a/packages/quicktype-core/src/language/CSharp/NewtonSoftCSharpRenderer.ts
+++ b/packages/quicktype-core/src/language/CSharp/NewtonSoftCSharpRenderer.ts
@@ -824,9 +824,7 @@ export class NewtonsoftCSharpRenderer extends CSharpRenderer {
                     itemVariable,
                     xfer.itemTransformer,
                     xfer.itemTargetType,
-                    () => {
-                        return;
-                    },
+                    () => {},
                 );
             });
             this.emitLine("writer.WriteEndArray();");

--- a/packages/quicktype-core/src/language/CSharp/SystemTextJsonCSharpRenderer.ts
+++ b/packages/quicktype-core/src/language/CSharp/SystemTextJsonCSharpRenderer.ts
@@ -663,9 +663,10 @@ export class SystemTextJsonCSharpRenderer extends CSharpRenderer {
                 }
 
                 // Handle number (integer/double) union properly
+                const { integerTransformer, doubleTransformer } = xfer;
                 if (
-                    xfer.integerTransformer !== undefined &&
-                    xfer.doubleTransformer !== undefined
+                    integerTransformer !== undefined &&
+                    doubleTransformer !== undefined
                 ) {
                     varGen.counter++;
                     const intTryVar = `intTryValue${varGen.counter}`;
@@ -680,7 +681,7 @@ export class SystemTextJsonCSharpRenderer extends CSharpRenderer {
                         );
                         this.emitBlock(() => {
                             const allHandled = this.emitDecodeTransformer(
-                                xfer.integerTransformer!,
+                                integerTransformer,
                                 targetType,
                                 emitFinish,
                                 intVar,
@@ -693,7 +694,7 @@ export class SystemTextJsonCSharpRenderer extends CSharpRenderer {
                         this.emitLine("else");
                         this.emitBlock(() => {
                             const allHandled = this.emitDecodeTransformer(
-                                xfer.doubleTransformer!,
+                                doubleTransformer,
                                 targetType,
                                 emitFinish,
                                 doubleVar,

--- a/packages/quicktype-core/src/language/CSharp/SystemTextJsonCSharpRenderer.ts
+++ b/packages/quicktype-core/src/language/CSharp/SystemTextJsonCSharpRenderer.ts
@@ -949,9 +949,7 @@ export class SystemTextJsonCSharpRenderer extends CSharpRenderer {
                     itemVariable,
                     xfer.itemTransformer,
                     xfer.itemTargetType,
-                    () => {
-                        return;
-                    },
+                    () => {},
                 );
             });
             this.emitLine("writer.WriteEndArray();");

--- a/packages/quicktype-core/src/language/CSharp/SystemTextJsonCSharpRenderer.ts
+++ b/packages/quicktype-core/src/language/CSharp/SystemTextJsonCSharpRenderer.ts
@@ -705,31 +705,29 @@ export class SystemTextJsonCSharpRenderer extends CSharpRenderer {
                             }
                         });
                     });
-                } else {
+                } else if (xfer.integerTransformer !== undefined) {
                     // Only one present, emit as before
-                    if (xfer.integerTransformer !== undefined) {
-                        varGen.counter++;
-                        const intVar = `intValue${varGen.counter}`;
-                        this.emitDecoderTransformerCase(
-                            ["Number"],
-                            intVar,
-                            xfer.integerTransformer,
-                            targetType,
-                            emitFinish,
-                            varGen,
-                        );
-                    } else if (xfer.doubleTransformer !== undefined) {
-                        varGen.counter++;
-                        const doubleVar = `doubleValue${varGen.counter}`;
-                        this.emitDecoderTransformerCase(
-                            ["Number"],
-                            doubleVar,
-                            xfer.doubleTransformer,
-                            targetType,
-                            emitFinish,
-                            varGen,
-                        );
-                    }
+                    varGen.counter++;
+                    const intVar = `intValue${varGen.counter}`;
+                    this.emitDecoderTransformerCase(
+                        ["Number"],
+                        intVar,
+                        xfer.integerTransformer,
+                        targetType,
+                        emitFinish,
+                        varGen,
+                    );
+                } else if (xfer.doubleTransformer !== undefined) {
+                    varGen.counter++;
+                    const doubleVar = `doubleValue${varGen.counter}`;
+                    this.emitDecoderTransformerCase(
+                        ["Number"],
+                        doubleVar,
+                        xfer.doubleTransformer,
+                        targetType,
+                        emitFinish,
+                        varGen,
+                    );
                 }
 
                 this.emitDecoderTransformerCase(

--- a/packages/quicktype-core/src/language/CSharp/language.ts
+++ b/packages/quicktype-core/src/language/CSharp/language.ts
@@ -139,9 +139,9 @@ export const cSharpOptions = {
     ),
 } as const;
 
-export const newtonsoftCSharpOptions = Object.assign({}, cSharpOptions, {});
+export const newtonsoftCSharpOptions = { ...cSharpOptions };
 
-export const systemTextJsonCSharpOptions = Object.assign({}, cSharpOptions, {});
+export const systemTextJsonCSharpOptions = { ...cSharpOptions };
 
 export const cSharpLanguageConfig = {
     displayName: "C#",

--- a/packages/quicktype-core/src/language/Crystal/CrystalRenderer.ts
+++ b/packages/quicktype-core/src/language/Crystal/CrystalRenderer.ts
@@ -7,9 +7,7 @@ import {
     type ForbiddenWordsInfo,
 } from "../../ConvenienceRenderer.js";
 import type { Name, Namer } from "../../Naming.js";
-import type { RenderContext } from "../../Renderer.js";
 import { type Sourcelike, maybeAnnotated } from "../../Source.js";
-import type { TargetLanguage } from "../../TargetLanguage.js";
 import {
     matchType,
     nullableFromUnion,
@@ -25,13 +23,6 @@ import {
 } from "./utils.js";
 
 export class CrystalRenderer extends ConvenienceRenderer {
-    public constructor(
-        targetLanguage: TargetLanguage,
-        renderContext: RenderContext,
-    ) {
-        super(targetLanguage, renderContext);
-    }
-
     protected makeNamedTypeNamer(): Namer {
         return camelNamingFunction;
     }

--- a/packages/quicktype-core/src/language/Crystal/CrystalRenderer.ts
+++ b/packages/quicktype-core/src/language/Crystal/CrystalRenderer.ts
@@ -202,7 +202,6 @@ export class CrystalRenderer extends ConvenienceRenderer {
     protected emitLeadingComments(): void {
         if (this.leadingComments !== undefined) {
             this.emitComments(this.leadingComments);
-            return;
         }
     }
 

--- a/packages/quicktype-core/src/language/Crystal/language.ts
+++ b/packages/quicktype-core/src/language/Crystal/language.ts
@@ -24,7 +24,7 @@ export class CrystalTargetLanguage extends TargetLanguage<
         return "  ";
     }
 
-    public getOptions(): {} {
+    public getOptions(): Record<string, never> {
         return {};
     }
 }

--- a/packages/quicktype-core/src/language/Crystal/utils.ts
+++ b/packages/quicktype-core/src/language/Crystal/utils.ts
@@ -62,9 +62,8 @@ export const camelNamingFunction = funPrefixNamer("camel", (original: string) =>
 function standardUnicodeCrystalEscape(codePoint: number): string {
     if (codePoint <= 0xffff) {
         return `\\u{${intToHex(codePoint, 4)}}`;
-    } else {
-        return `\\u{${intToHex(codePoint, 6)}}`;
     }
+    return `\\u{${intToHex(codePoint, 6)}}`;
 }
 
 export const crystalStringEscape = utf32ConcatMap(

--- a/packages/quicktype-core/src/language/Crystal/utils.ts
+++ b/packages/quicktype-core/src/language/Crystal/utils.ts
@@ -61,9 +61,9 @@ export const camelNamingFunction = funPrefixNamer("camel", (original: string) =>
 
 function standardUnicodeCrystalEscape(codePoint: number): string {
     if (codePoint <= 0xffff) {
-        return "\\u{" + intToHex(codePoint, 4) + "}";
+        return `\\u{${intToHex(codePoint, 4)}}`;
     } else {
-        return "\\u{" + intToHex(codePoint, 6) + "}";
+        return `\\u{${intToHex(codePoint, 6)}}`;
     }
 }
 

--- a/packages/quicktype-core/src/language/Crystal/utils.ts
+++ b/packages/quicktype-core/src/language/Crystal/utils.ts
@@ -62,8 +62,9 @@ export const camelNamingFunction = funPrefixNamer("camel", (original: string) =>
 function standardUnicodeCrystalEscape(codePoint: number): string {
     if (codePoint <= 0xffff) {
         return `\\u{${intToHex(codePoint, 4)}}`;
+    } else {
+        return `\\u{${intToHex(codePoint, 6)}}`;
     }
-    return `\\u{${intToHex(codePoint, 6)}}`;
 }
 
 export const crystalStringEscape = utf32ConcatMap(

--- a/packages/quicktype-core/src/language/Dart/DartRenderer.ts
+++ b/packages/quicktype-core/src/language/Dart/DartRenderer.ts
@@ -419,9 +419,8 @@ export class DartRenderer extends ConvenienceRenderer {
     // If the first time is the unionType type, after nullableFromUnion conversion,
     // the isNullable property will become false, which is obviously wrong,
     // so add isNullable property
-    // eslint-disable-next-line @typescript-eslint/default-param-last
     protected fromDynamicExpression(
-        isNullable = false,
+        isNullable: boolean,
         t: Type,
         ...dynamic: Sourcelike[]
     ): Sourcelike {
@@ -517,9 +516,8 @@ export class DartRenderer extends ConvenienceRenderer {
     // If the first time is the unionType type, after nullableFromUnion conversion,
     // the isNullable property will become false, which is obviously wrong,
     // so add isNullable property
-    // eslint-disable-next-line @typescript-eslint/default-param-last
     protected toDynamicExpression(
-        isNullable = false,
+        isNullable: boolean,
         t: Type,
         ...dynamic: Sourcelike[]
     ): Sourcelike {

--- a/packages/quicktype-core/src/language/Dart/DartRenderer.ts
+++ b/packages/quicktype-core/src/language/Dart/DartRenderer.ts
@@ -420,7 +420,8 @@ export class DartRenderer extends ConvenienceRenderer {
     // the isNullable property will become false, which is obviously wrong,
     // so add isNullable property
     protected fromDynamicExpression(
-        isNullable: boolean,
+        // biome-ignore lint/style/useDefaultParameterLast: part of the exported DartRenderer API; removing the default would break downstream subclasses
+        isNullable = false,
         t: Type,
         ...dynamic: Sourcelike[]
     ): Sourcelike {
@@ -517,7 +518,8 @@ export class DartRenderer extends ConvenienceRenderer {
     // the isNullable property will become false, which is obviously wrong,
     // so add isNullable property
     protected toDynamicExpression(
-        isNullable: boolean,
+        // biome-ignore lint/style/useDefaultParameterLast: part of the exported DartRenderer API; removing the default would break downstream subclasses
+        isNullable = false,
         t: Type,
         ...dynamic: Sourcelike[]
     ): Sourcelike {

--- a/packages/quicktype-core/src/language/Elixir/ElixirRenderer.ts
+++ b/packages/quicktype-core/src/language/Elixir/ElixirRenderer.ts
@@ -47,7 +47,7 @@ export class ElixirRenderer extends ConvenienceRenderer {
     }
 
     protected canBeForwardDeclared(t: Type): boolean {
-        return "class" === t.kind;
+        return t.kind === "class";
     }
 
     protected forbiddenNamesForGlobalNamespace(): string[] {
@@ -1145,7 +1145,7 @@ end`);
             this.forEachTopLevel(
                 "leading-and-interposing",
                 (topLevel, name) => {
-                    const isTopLevelArray = "array" === topLevel.kind;
+                    const isTopLevelArray = topLevel.kind === "array";
 
                     this.emitBlock(
                         ["defmodule ", this.nameWithNamespace(name), " do"],

--- a/packages/quicktype-core/src/language/Elixir/ElixirRenderer.ts
+++ b/packages/quicktype-core/src/language/Elixir/ElixirRenderer.ts
@@ -1108,9 +1108,7 @@ end`);
         );
     }
 
-    protected emitUnion(_u: UnionType, _unionName: Name): void {
-        return;
-    }
+    protected emitUnion(_u: UnionType, _unionName: Name): void {}
 
     protected emitSourceStructure(): void {
         if (this.leadingComments !== undefined) {

--- a/packages/quicktype-core/src/language/Elixir/ElixirRenderer.ts
+++ b/packages/quicktype-core/src/language/Elixir/ElixirRenderer.ts
@@ -942,7 +942,7 @@ export class ElixirRenderer extends ConvenienceRenderer {
                 this.forEachClassProperty(c, "none", (_name, _jsonName, _p) => {
                     propCount++;
                 });
-                const isEmpty = propCount ? false : true;
+                const isEmpty = !propCount;
                 this.ensureBlankLine();
                 this.emitBlock(
                     [`def from_map(${isEmpty ? "_" : ""}m) do`],

--- a/packages/quicktype-core/src/language/Elixir/ElixirRenderer.ts
+++ b/packages/quicktype-core/src/language/Elixir/ElixirRenderer.ts
@@ -798,7 +798,10 @@ export class ElixirRenderer extends ConvenienceRenderer {
                         ]);
                     }
                 });
-                if (structDescription.length || attributeDescriptions.length) {
+                if (
+                    structDescription.length > 0 ||
+                    attributeDescriptions.length > 0
+                ) {
                     this.emitDescription([
                         ...structDescription,
                         ...attributeDescriptions,
@@ -816,7 +819,7 @@ export class ElixirRenderer extends ConvenienceRenderer {
                         }
                     }
                 });
-                if (requiredAttributes.length) {
+                if (requiredAttributes.length > 0) {
                     this.emitLine(["@enforce_keys [", requiredAttributes, "]"]);
                 }
 
@@ -1152,7 +1155,7 @@ end`);
                         () => {
                             const description =
                                 this.descriptionForType(topLevel) ?? [];
-                            if (description.length) {
+                            if (description.length > 0) {
                                 this.emitDescription([...description]);
                                 this.ensureBlankLine();
                             }

--- a/packages/quicktype-core/src/language/Elm/ElmRenderer.ts
+++ b/packages/quicktype-core/src/language/Elm/ElmRenderer.ts
@@ -564,7 +564,7 @@ export class ElmRenderer extends ConvenienceRenderer {
                 return " xdouble";
             }
             if (t.isPrimitive()) {
-                return " " + t.kind;
+                return ` ${t.kind}`;
             }
 
             return t.kind;

--- a/packages/quicktype-core/src/language/Elm/ElmRenderer.ts
+++ b/packages/quicktype-core/src/language/Elm/ElmRenderer.ts
@@ -75,7 +75,7 @@ export class ElmRenderer extends ConvenienceRenderer {
             topLevelName.order,
             (lookup) => `${lookup(topLevelName)}_to_string`,
         );
-        let decoder: DependencyName | undefined = undefined;
+        let decoder: DependencyName | undefined;
         if (this.namedTypeToNameForTopLevel(t) === undefined) {
             decoder = new DependencyName(
                 lowerNamingFunction,

--- a/packages/quicktype-core/src/language/Golang/GolangRenderer.ts
+++ b/packages/quicktype-core/src/language/Golang/GolangRenderer.ts
@@ -249,7 +249,7 @@ export class GoRenderer extends ConvenienceRenderer {
             const description = this.descriptionForClassProperty(c, jsonName);
             const docStrings =
                 description !== undefined && description.length > 0
-                    ? description.map((d) => "// " + d)
+                    ? description.map((d) => `// ${d}`)
                     : [];
             const goType = this.propertyGoType(p);
             const omitEmpty = canOmitEmpty(p, this._options.omitEmpty)

--- a/packages/quicktype-core/src/language/Golang/GolangRenderer.ts
+++ b/packages/quicktype-core/src/language/Golang/GolangRenderer.ts
@@ -256,7 +256,9 @@ export class GoRenderer extends ConvenienceRenderer {
                 ? ",omitempty"
                 : [];
 
-            docStrings.forEach((doc) => columns.push([doc]));
+            docStrings.forEach((doc) => {
+                columns.push([doc]);
+            });
             const tags = this._options.fieldTags
                 .split(",")
                 .map((tag) => `${tag}:"${stringEscape(jsonName)}${omitEmpty}"`)

--- a/packages/quicktype-core/src/language/JSONSchema/JSONSchemaRenderer.ts
+++ b/packages/quicktype-core/src/language/JSONSchema/JSONSchemaRenderer.ts
@@ -181,10 +181,10 @@ export class JSONSchemaRenderer extends ConvenienceRenderer {
             this.topLevels.size === 1
                 ? this.schemaForType(defined(mapFirst(this.topLevels)))
                 : {};
-        const schema = Object.assign(
-            { $schema: "http://json-schema.org/draft-06/schema#" },
-            topLevelType,
-        );
+        const schema: Schema = {
+            $schema: "http://json-schema.org/draft-06/schema#",
+            ...topLevelType,
+        };
         const definitions: { [name: string]: Schema } = {};
         this.forEachObject("none", (o: ObjectType, name: Name) => {
             const title = defined(this.names.get(name));

--- a/packages/quicktype-core/src/language/JSONSchema/JSONSchemaRenderer.ts
+++ b/packages/quicktype-core/src/language/JSONSchema/JSONSchemaRenderer.ts
@@ -16,7 +16,7 @@ import { matchTypeExhaustive } from "../../Type/TypeUtils.js";
 import { namingFunction } from "./utils.js";
 
 interface Schema {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    // biome-ignore lint/suspicious/noExplicitAny: JSON Schema values are arbitrary JSON
     [name: string]: any;
 }
 

--- a/packages/quicktype-core/src/language/JSONSchema/JSONSchemaRenderer.ts
+++ b/packages/quicktype-core/src/language/JSONSchema/JSONSchemaRenderer.ts
@@ -142,6 +142,7 @@ export class JSONSchemaRenderer extends ConvenienceRenderer {
             }
 
             properties = props;
+            // biome-ignore lint/suspicious/useArraySortCompare: sorting strings; default UTF-16 order is intended
             required = req.sort();
         }
 

--- a/packages/quicktype-core/src/language/JSONSchema/language.ts
+++ b/packages/quicktype-core/src/language/JSONSchema/language.ts
@@ -21,7 +21,7 @@ export class JSONSchemaTargetLanguage extends TargetLanguage<
         super(JSONSchemaLanguageConfig);
     }
 
-    public getOptions(): {} {
+    public getOptions(): Record<string, never> {
         return {};
     }
 

--- a/packages/quicktype-core/src/language/Java/JavaJacksonRenderer.ts
+++ b/packages/quicktype-core/src/language/Java/JavaJacksonRenderer.ts
@@ -61,17 +61,23 @@ export class JacksonRenderer extends JavaRenderer {
         switch (p.type.kind) {
             case "date-time":
                 this._dateTimeProvider.dateTimeJacksonAnnotations.forEach(
-                    (annotation) => annotations.push(annotation),
+                    (annotation) => {
+                        annotations.push(annotation);
+                    },
                 );
                 break;
             case "date":
                 this._dateTimeProvider.dateJacksonAnnotations.forEach(
-                    (annotation) => annotations.push(annotation),
+                    (annotation) => {
+                        annotations.push(annotation);
+                    },
                 );
                 break;
             case "time":
                 this._dateTimeProvider.timeJacksonAnnotations.forEach(
-                    (annotation) => annotations.push(annotation),
+                    (annotation) => {
+                        annotations.push(annotation);
+                    },
                 );
                 break;
             default:

--- a/packages/quicktype-core/src/language/Java/JavaJacksonRenderer.ts
+++ b/packages/quicktype-core/src/language/Java/JavaJacksonRenderer.ts
@@ -1,9 +1,6 @@
 import type { Name } from "../../Naming.js";
-import type { RenderContext } from "../../Renderer.js";
-import type { OptionValues } from "../../RendererOptions/index.js";
 import type { Sourcelike } from "../../Source.js";
 import { assertNever, panic } from "../../support/Support.js";
-import type { TargetLanguage } from "../../TargetLanguage.js";
 import {
     ArrayType,
     type ClassProperty,
@@ -16,18 +13,9 @@ import {
 import { removeNullFromUnion } from "../../Type/TypeUtils.js";
 
 import { JavaRenderer } from "./JavaRenderer.js";
-import type { javaOptions } from "./language.js";
 import { stringEscape } from "./utils.js";
 
 export class JacksonRenderer extends JavaRenderer {
-    public constructor(
-        targetLanguage: TargetLanguage,
-        renderContext: RenderContext,
-        options: OptionValues<typeof javaOptions>,
-    ) {
-        super(targetLanguage, renderContext, options);
-    }
-
     protected readonly _converterKeywords: string[] = [
         "JsonProperty",
         "JsonDeserialize",

--- a/packages/quicktype-core/src/language/Java/JavaRenderer.ts
+++ b/packages/quicktype-core/src/language/Java/JavaRenderer.ts
@@ -390,9 +390,11 @@ export class JavaRenderer extends ConvenienceRenderer {
             (_enumType) => [],
             (unionType) => {
                 const imports: string[] = [];
-                unionType.members.forEach((type) =>
-                    this.javaImport(type).forEach((imp) => imports.push(imp)),
-                );
+                unionType.members.forEach((type) => {
+                    this.javaImport(type).forEach((imp) => {
+                        imports.push(imp);
+                    });
+                });
                 return imports;
             },
             (transformedStringType) => {
@@ -474,7 +476,9 @@ export class JavaRenderer extends ConvenienceRenderer {
     protected importsForClass(c: ClassType): string[] {
         const imports: string[] = [];
         this.forEachClassProperty(c, "none", (_name, _jsonName, p) => {
-            this.javaImport(p.type).forEach((imp) => imports.push(imp));
+            this.javaImport(p.type).forEach((imp) => {
+                imports.push(imp);
+            });
         });
         imports.sort();
         return [...new Set(imports)];
@@ -484,7 +488,9 @@ export class JavaRenderer extends ConvenienceRenderer {
         const imports: string[] = [];
         const [, nonNulls] = removeNullFromUnion(u);
         this.forEachUnionMember(u, nonNulls, "none", null, (_fieldName, t) => {
-            this.javaImport(t).forEach((imp) => imports.push(imp));
+            this.javaImport(t).forEach((imp) => {
+                imports.push(imp);
+            });
         });
         imports.sort();
         return [...new Set(imports)];
@@ -558,7 +564,9 @@ export class JavaRenderer extends ConvenienceRenderer {
                             jsonName,
                             p,
                             false,
-                        ).forEach((annotation) => this.emitLine(annotation));
+                        ).forEach((annotation) => {
+                            this.emitLine(annotation);
+                        });
                         this.emitLine(
                             "public ",
                             rendered,
@@ -575,7 +583,9 @@ export class JavaRenderer extends ConvenienceRenderer {
                             jsonName,
                             p,
                             true,
-                        ).forEach((annotation) => this.emitLine(annotation));
+                        ).forEach((annotation) => {
+                            this.emitLine(annotation);
+                        });
                         this.emitLine(
                             "public void ",
                             setterName,

--- a/packages/quicktype-core/src/language/Java/JavaRenderer.ts
+++ b/packages/quicktype-core/src/language/Java/JavaRenderer.ts
@@ -74,7 +74,6 @@ export class JavaRenderer extends ConvenienceRenderer {
                     this._converterClassname,
                 );
                 break;
-            case "java8":
             default:
                 this._dateTimeProvider = new Java8DateTimeProvider(
                     this,

--- a/packages/quicktype-core/src/language/Java/JavaRenderer.ts
+++ b/packages/quicktype-core/src/language/Java/JavaRenderer.ts
@@ -480,6 +480,7 @@ export class JavaRenderer extends ConvenienceRenderer {
                 imports.push(imp);
             });
         });
+        // biome-ignore lint/suspicious/useArraySortCompare: sorting strings; default UTF-16 order is intended
         imports.sort();
         return [...new Set(imports)];
     }
@@ -492,6 +493,7 @@ export class JavaRenderer extends ConvenienceRenderer {
                 imports.push(imp);
             });
         });
+        // biome-ignore lint/suspicious/useArraySortCompare: sorting strings; default UTF-16 order is intended
         imports.sort();
         return [...new Set(imports)];
     }

--- a/packages/quicktype-core/src/language/Java/JavaRenderer.ts
+++ b/packages/quicktype-core/src/language/Java/JavaRenderer.ts
@@ -524,13 +524,13 @@ export class JavaRenderer extends ConvenienceRenderer {
                         p,
                         true,
                     );
-                    if (getter.length !== 0) {
+                    if (getter.length > 0) {
                         this.emitLine(
                             `@lombok.Getter(onMethod_ = {${getter.join(", ")}})`,
                         );
                     }
 
-                    if (setter.length !== 0) {
+                    if (setter.length > 0) {
                         this.emitLine(
                             `@lombok.Setter(onMethod_ = {${setter.join(", ")}})`,
                         );

--- a/packages/quicktype-core/src/language/JavaScript/JavaScriptRenderer.ts
+++ b/packages/quicktype-core/src/language/JavaScript/JavaScriptRenderer.ts
@@ -279,16 +279,10 @@ export class JavaScriptRenderer extends ConvenienceRenderer {
                                 "), null, 2);",
                             );
                         }
+                    } else if (!this._jsOptions.runtimeTypecheck) {
+                        this.emitLine("return value;");
                     } else {
-                        if (!this._jsOptions.runtimeTypecheck) {
-                            this.emitLine("return value;");
-                        } else {
-                            this.emitLine(
-                                "return uncast(value, ",
-                                typeMap,
-                                ");",
-                            );
-                        }
+                        this.emitLine("return uncast(value, ", typeMap, ");");
                     }
                 },
             );

--- a/packages/quicktype-core/src/language/JavaScript/JavaScriptRenderer.ts
+++ b/packages/quicktype-core/src/language/JavaScript/JavaScriptRenderer.ts
@@ -497,9 +497,7 @@ function r(name${stringAnnotation}) {
         }
     }
 
-    protected emitTypes(): void {
-        return;
-    }
+    protected emitTypes(): void {}
 
     protected emitUsageImportComment(): void {
         this.emitLine('//   const Convert = require("./file");');

--- a/packages/quicktype-core/src/language/JavaScriptPropTypes/JavaScriptPropTypesRenderer.ts
+++ b/packages/quicktype-core/src/language/JavaScriptPropTypes/JavaScriptPropTypesRenderer.ts
@@ -265,7 +265,9 @@ export class JavaScriptPropTypesRenderer extends ConvenienceRenderer {
         });
 
         // now emit ordered source
-        order.forEach((i) => this.emitGatheredSource(mapValue[i]));
+        order.forEach((i) => {
+            this.emitGatheredSource(mapValue[i]);
+        });
 
         // now emit top levels
         this.forEachTopLevel("none", (type, name) => {

--- a/packages/quicktype-core/src/language/JavaScriptPropTypes/JavaScriptPropTypesRenderer.ts
+++ b/packages/quicktype-core/src/language/JavaScriptPropTypes/JavaScriptPropTypesRenderer.ts
@@ -274,18 +274,16 @@ export class JavaScriptPropTypesRenderer extends ConvenienceRenderer {
             if (type instanceof PrimitiveType) {
                 this.ensureBlankLine();
                 this.emitExport(name, this.typeMapTypeFor(type));
+            } else if (type.kind === "array") {
+                this.ensureBlankLine();
+                this.emitExport(name, [
+                    "PropTypes.arrayOf(",
+                    this.typeMapTypeFor((type as ArrayType).items),
+                    ")",
+                ]);
             } else {
-                if (type.kind === "array") {
-                    this.ensureBlankLine();
-                    this.emitExport(name, [
-                        "PropTypes.arrayOf(",
-                        this.typeMapTypeFor((type as ArrayType).items),
-                        ")",
-                    ]);
-                } else {
-                    this.ensureBlankLine();
-                    this.emitExport(name, ["_", name]);
-                }
+                this.ensureBlankLine();
+                this.emitExport(name, ["_", name]);
             }
         });
     }

--- a/packages/quicktype-core/src/language/Kotlin/KotlinJacksonRenderer.ts
+++ b/packages/quicktype-core/src/language/Kotlin/KotlinJacksonRenderer.ts
@@ -1,12 +1,9 @@
 import { arrayIntercalate, iterableSome } from "collection-utils";
 
 import type { Name } from "../../Naming.js";
-import type { RenderContext } from "../../Renderer.js";
-import type { OptionValues } from "../../RendererOptions/index.js";
 import { type Sourcelike, modifySource } from "../../Source.js";
 import { camelCase } from "../../support/Strings.js";
 import { mustNotHappen } from "../../support/Support.js";
-import type { TargetLanguage } from "../../TargetLanguage.js";
 import {
     type ArrayType,
     ClassType,
@@ -19,18 +16,9 @@ import {
 import { matchType, nullableFromUnion } from "../../Type/TypeUtils.js";
 
 import { KotlinRenderer } from "./KotlinRenderer.js";
-import type { kotlinOptions } from "./language.js";
 import { stringEscape } from "./utils.js";
 
 export class KotlinJacksonRenderer extends KotlinRenderer {
-    public constructor(
-        targetLanguage: TargetLanguage,
-        renderContext: RenderContext,
-        _kotlinOptions: OptionValues<typeof kotlinOptions>,
-    ) {
-        super(targetLanguage, renderContext, _kotlinOptions);
-    }
-
     private unionMemberJsonValueGuard(t: Type, _e: Sourcelike): Sourcelike {
         return matchType<Sourcelike>(
             t,

--- a/packages/quicktype-core/src/language/Kotlin/KotlinKlaxonRenderer.ts
+++ b/packages/quicktype-core/src/language/Kotlin/KotlinKlaxonRenderer.ts
@@ -1,12 +1,9 @@
 import { arrayIntercalate, iterableSome } from "collection-utils";
 
 import type { Name } from "../../Naming.js";
-import type { RenderContext } from "../../Renderer.js";
-import type { OptionValues } from "../../RendererOptions/index.js";
 import { type Sourcelike, modifySource } from "../../Source.js";
 import { camelCase } from "../../support/Strings.js";
 import { mustNotHappen } from "../../support/Support.js";
-import type { TargetLanguage } from "../../TargetLanguage.js";
 import {
     type ArrayType,
     ClassType,
@@ -19,18 +16,9 @@ import {
 import { matchType, nullableFromUnion } from "../../Type/TypeUtils.js";
 
 import { KotlinRenderer } from "./KotlinRenderer.js";
-import type { kotlinOptions } from "./language.js";
 import { stringEscape } from "./utils.js";
 
 export class KotlinKlaxonRenderer extends KotlinRenderer {
-    public constructor(
-        targetLanguage: TargetLanguage,
-        renderContext: RenderContext,
-        _kotlinOptions: OptionValues<typeof kotlinOptions>,
-    ) {
-        super(targetLanguage, renderContext, _kotlinOptions);
-    }
-
     private unionMemberFromJsonValue(t: Type, e: Sourcelike): Sourcelike {
         return matchType<Sourcelike>(
             t,

--- a/packages/quicktype-core/src/language/Kotlin/KotlinXRenderer.ts
+++ b/packages/quicktype-core/src/language/Kotlin/KotlinXRenderer.ts
@@ -1,13 +1,9 @@
 import type { Name } from "../../Naming.js";
-import type { RenderContext } from "../../Renderer.js";
-import type { OptionValues } from "../../RendererOptions/index.js";
 import { type Sourcelike, modifySource } from "../../Source.js";
 import { camelCase } from "../../support/Strings.js";
-import type { TargetLanguage } from "../../TargetLanguage.js";
 import type { ArrayType, EnumType, MapType, Type } from "../../Type/index.js";
 
 import { KotlinRenderer } from "./KotlinRenderer.js";
-import type { kotlinOptions } from "./language.js";
 import { stringEscape } from "./utils.js";
 
 /**
@@ -15,14 +11,6 @@ import { stringEscape } from "./utils.js";
  * TODO: Union, Any, Top Level Array, Top Level Map
  */
 export class KotlinXRenderer extends KotlinRenderer {
-    public constructor(
-        targetLanguage: TargetLanguage,
-        renderContext: RenderContext,
-        _kotlinOptions: OptionValues<typeof kotlinOptions>,
-    ) {
-        super(targetLanguage, renderContext, _kotlinOptions);
-    }
-
     protected anySourceType(optional: string): Sourcelike {
         return ["JsonElement", optional];
     }

--- a/packages/quicktype-core/src/language/Kotlin/utils.ts
+++ b/packages/quicktype-core/src/language/Kotlin/utils.ts
@@ -43,7 +43,7 @@ export function kotlinNameStyle(
 }
 
 function unicodeEscape(codePoint: number): string {
-    return "\\u" + intToHex(codePoint, 4);
+    return `\\u${intToHex(codePoint, 4)}`;
 }
 
 // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/packages/quicktype-core/src/language/Objective-C/ObjectiveCRenderer.ts
+++ b/packages/quicktype-core/src/language/Objective-C/ObjectiveCRenderer.ts
@@ -408,7 +408,7 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
     }
 
     protected implicitlyConvertsToJSON(t: Type): boolean {
-        return this.implicitlyConvertsFromJSON(t) && "bool" !== t.kind;
+        return this.implicitlyConvertsFromJSON(t) && t.kind !== "bool";
     }
 
     protected emitPropertyAssignment(

--- a/packages/quicktype-core/src/language/Php/PhpRenderer.ts
+++ b/packages/quicktype-core/src/language/Php/PhpRenderer.ts
@@ -588,11 +588,11 @@ export class PhpRenderer extends ConvenienceRenderer {
                     className,
                     "::",
                     args,
-                    "::" + idx,
+                    `::${idx}`,
                     "'",
                     suffix,
                     "/*",
-                    "" + idx,
+                    `${idx}`,
                     ":",
                     args,
                     "*/",
@@ -603,7 +603,7 @@ export class PhpRenderer extends ConvenienceRenderer {
                     "null",
                     suffix,
                     " /*",
-                    "" + idx,
+                    `${idx}`,
                     ":",
                     args,
                     "*/",
@@ -614,7 +614,7 @@ export class PhpRenderer extends ConvenienceRenderer {
                     "true",
                     suffix,
                     " /*",
-                    "" + idx,
+                    `${idx}`,
                     ":",
                     args,
                     "*/",
@@ -622,10 +622,10 @@ export class PhpRenderer extends ConvenienceRenderer {
             (_integerType) =>
                 this.emitLine(
                     ...lhs,
-                    "" + idx,
+                    `${idx}`,
                     suffix,
                     " /*",
-                    "" + idx,
+                    `${idx}`,
                     ":",
                     args,
                     "*/",
@@ -633,10 +633,10 @@ export class PhpRenderer extends ConvenienceRenderer {
             (_doubleType) =>
                 this.emitLine(
                     ...lhs,
-                    "" + (idx + idx / 1000),
+                    `${idx + idx / 1000}`,
                     suffix,
                     " /*",
-                    "" + idx,
+                    `${idx}`,
                     ":",
                     args,
                     "*/",
@@ -648,11 +648,11 @@ export class PhpRenderer extends ConvenienceRenderer {
                     className,
                     "::",
                     args,
-                    "::" + idx,
+                    `::${idx}`,
                     "'",
                     suffix,
                     " /*",
-                    "" + idx,
+                    `${idx}`,
                     ":",
                     args,
                     "*/",
@@ -669,7 +669,7 @@ export class PhpRenderer extends ConvenienceRenderer {
                         "",
                     );
                 });
-                this.emitLine("); /* ", "" + idx, ":", args, "*/");
+                this.emitLine("); /* ", `${idx}`, ":", args, "*/");
             },
             (classType) =>
                 this.emitLine(
@@ -678,7 +678,7 @@ export class PhpRenderer extends ConvenienceRenderer {
                     "::sample()",
                     suffix,
                     " /*",
-                    "" + idx,
+                    `${idx}`,
                     ":",
                     args,
                     "*/",
@@ -721,7 +721,7 @@ export class PhpRenderer extends ConvenienceRenderer {
             },
             (transformedStringType) => {
                 if (transformedStringType.kind === "date-time") {
-                    const x = _.pad("" + (1 + (idx % 31)), 2, "0");
+                    const x = _.pad(`${1 + (idx % 31)}`, 2, "0");
                     this.emitLine(
                         ...lhs,
                         "DateTime::createFromFormat(DateTimeInterface::ISO8601, '",

--- a/packages/quicktype-core/src/language/Php/PhpRenderer.ts
+++ b/packages/quicktype-core/src/language/Php/PhpRenderer.ts
@@ -280,11 +280,11 @@ export class PhpRenderer extends ConvenienceRenderer {
             },
             (transformedStringType) => {
                 if (transformedStringType.kind === "time") {
-                    throw Error('transformedStringType.kind === "time"');
+                    throw new Error('transformedStringType.kind === "time"');
                 }
 
                 if (transformedStringType.kind === "date") {
-                    throw Error('transformedStringType.kind === "date"');
+                    throw new Error('transformedStringType.kind === "date"');
                 }
 
                 if (transformedStringType.kind === "date-time") {
@@ -321,7 +321,7 @@ export class PhpRenderer extends ConvenienceRenderer {
                     ];
                 }
 
-                throw Error("union are not supported");
+                throw new Error("union are not supported");
             },
             (transformedStringType) => {
                 if (transformedStringType.kind === "date-time") {
@@ -332,7 +332,7 @@ export class PhpRenderer extends ConvenienceRenderer {
                     return "string";
                 }
 
-                throw Error('transformedStringType.kind === "unknown"');
+                throw new Error('transformedStringType.kind === "unknown"');
             },
         );
     }
@@ -356,7 +356,7 @@ export class PhpRenderer extends ConvenienceRenderer {
                     return ["?", this.phpConvertType(className, nullable)];
                 }
 
-                throw Error("union are not supported");
+                throw new Error("union are not supported");
             },
             (transformedStringType) => {
                 if (transformedStringType.kind === "date-time") {
@@ -367,7 +367,7 @@ export class PhpRenderer extends ConvenienceRenderer {
                     return "string";
                 }
 
-                throw Error('transformedStringType.kind === "unknown"');
+                throw new Error('transformedStringType.kind === "unknown"');
             },
         );
     }
@@ -435,7 +435,7 @@ export class PhpRenderer extends ConvenienceRenderer {
                     return;
                 }
 
-                throw Error("union are not supported");
+                throw new Error("union are not supported");
             },
             (transformedStringType) => {
                 if (transformedStringType.kind === "date-time") {
@@ -452,7 +452,7 @@ export class PhpRenderer extends ConvenienceRenderer {
                     return;
                 }
 
-                throw Error('transformedStringType.kind === "unknown"');
+                throw new Error('transformedStringType.kind === "unknown"');
             },
         );
     }
@@ -546,7 +546,7 @@ export class PhpRenderer extends ConvenienceRenderer {
                     return;
                 }
 
-                throw Error("union are not supported");
+                throw new Error("union are not supported");
             },
             (transformedStringType) => {
                 if (transformedStringType.kind === "date-time") {
@@ -566,7 +566,7 @@ export class PhpRenderer extends ConvenienceRenderer {
                     return;
                 }
 
-                throw Error('transformedStringType.kind === "unknown"');
+                throw new Error('transformedStringType.kind === "unknown"');
             },
         );
     }
@@ -717,7 +717,7 @@ export class PhpRenderer extends ConvenienceRenderer {
                     return;
                 }
 
-                throw Error(`union are not supported:${unionType}`);
+                throw new Error(`union are not supported:${unionType}`);
             },
             (transformedStringType) => {
                 if (transformedStringType.kind === "date-time") {
@@ -747,7 +747,7 @@ export class PhpRenderer extends ConvenienceRenderer {
                     return;
                 }
 
-                throw Error('transformedStringType.kind === "unknown"');
+                throw new Error('transformedStringType.kind === "unknown"');
             },
         );
     }
@@ -832,7 +832,7 @@ export class PhpRenderer extends ConvenienceRenderer {
                     return;
                 }
 
-                throw Error("not implemented");
+                throw new Error("not implemented");
             },
             (transformedStringType) => {
                 if (transformedStringType.kind === "date-time") {
@@ -862,7 +862,7 @@ export class PhpRenderer extends ConvenienceRenderer {
                     return;
                 }
 
-                throw Error(
+                throw new Error(
                     `transformedStringType.kind === ${transformedStringType.kind}`,
                 );
             },
@@ -1351,7 +1351,7 @@ export class PhpRenderer extends ConvenienceRenderer {
     }
 
     protected emitUnionDefinition(_u: UnionType, _unionName: Name): void {
-        throw Error("emitUnionDefinition not implemented");
+        throw new Error("emitUnionDefinition not implemented");
     }
 
     protected emitEnumSerializationAttributes(_e: EnumType): void {

--- a/packages/quicktype-core/src/language/Php/utils.ts
+++ b/packages/quicktype-core/src/language/Php/utils.ts
@@ -1,5 +1,3 @@
-import _ from "lodash";
-
 import {
     allLowerWordStyle,
     allUpperWordStyle,

--- a/packages/quicktype-core/src/language/Pike/language.ts
+++ b/packages/quicktype-core/src/language/Pike/language.ts
@@ -18,7 +18,7 @@ export class PikeTargetLanguage extends TargetLanguage<
         super(pikeLanguageConfig);
     }
 
-    public getOptions(): {} {
+    public getOptions(): Record<string, never> {
         return {};
     }
 

--- a/packages/quicktype-core/src/language/Python/JSONPythonRenderer.ts
+++ b/packages/quicktype-core/src/language/Python/JSONPythonRenderer.ts
@@ -68,13 +68,6 @@ export interface ValueOrLambda {
 // * If `input` is a lambda, the result is `lambda x: f(input(x))`
 function compose(
     input: ValueOrLambda,
-    f: (arg: Sourcelike) => Sourcelike,
-): ValueOrLambda;
-// FIXME: refactor this
-// eslint-disable-next-line @typescript-eslint/unified-signatures
-function compose(input: ValueOrLambda, f: ValueOrLambda): ValueOrLambda;
-function compose(
-    input: ValueOrLambda,
     f: ValueOrLambda | ((arg: Sourcelike) => Sourcelike),
 ): ValueOrLambda {
     if (typeof f === "function") {

--- a/packages/quicktype-core/src/language/Python/PythonRenderer.ts
+++ b/packages/quicktype-core/src/language/Python/PythonRenderer.ts
@@ -390,13 +390,9 @@ export class PythonRenderer extends ConvenienceRenderer {
         });
     }
 
-    protected emitSupportCode(): void {
-        return;
-    }
+    protected emitSupportCode(): void {}
 
-    protected emitClosingCode(): void {
-        return;
-    }
+    protected emitClosingCode(): void {}
 
     protected emitSourceStructure(_givenOutputFilename: string): void {
         const declarationLines = this.gatherSource(() => {
@@ -404,9 +400,7 @@ export class PythonRenderer extends ConvenienceRenderer {
                 ["interposing", 2],
                 (c: ClassType) => this.emitClass(c),
                 (e) => this.emitEnum(e),
-                (_u) => {
-                    return;
-                },
+                (_u) => {},
             );
         });
 

--- a/packages/quicktype-core/src/language/Python/PythonRenderer.ts
+++ b/packages/quicktype-core/src/language/Python/PythonRenderer.ts
@@ -323,7 +323,7 @@ export class PythonRenderer extends ConvenienceRenderer {
         ) {
             return mapSortBy(properties, (p: ClassProperty) => {
                 return (p.type instanceof UnionType &&
-                    nullableFromUnion(p.type) != null) ||
+                    nullableFromUnion(p.type) !== null) ||
                     p.isOptional
                     ? 1
                     : 0;

--- a/packages/quicktype-core/src/language/Ruby/RubyRenderer.ts
+++ b/packages/quicktype-core/src/language/Ruby/RubyRenderer.ts
@@ -51,7 +51,7 @@ export class RubyRenderer extends ConvenienceRenderer {
     }
 
     protected canBeForwardDeclared(t: Type): boolean {
-        return "class" === t.kind;
+        return t.kind === "class";
     }
 
     protected forbiddenNamesForGlobalNamespace(): readonly string[] {
@@ -861,7 +861,7 @@ export class RubyRenderer extends ConvenienceRenderer {
 
                         // The json gem defines to_json on maps and primitives, so we only need to supply
                         // it for arrays.
-                        const needsToJsonDefined = "array" === topLevel.kind;
+                        const needsToJsonDefined = topLevel.kind === "array";
 
                         const classDeclaration = (): void => {
                             this.emitBlock(["class ", name], () => {

--- a/packages/quicktype-core/src/language/Ruby/RubyRenderer.ts
+++ b/packages/quicktype-core/src/language/Ruby/RubyRenderer.ts
@@ -732,13 +732,11 @@ export class RubyRenderer extends ConvenienceRenderer {
                         ["Integer"],
                         [` = ${this._options.strictness}Integer`],
                     ]);
-                if (this._options.strictness === Strictness.Strict) {
-                    if (has.nil)
-                        declarations.push([
-                            ["Nil"],
-                            [` = ${this._options.strictness}Nil`],
-                        ]);
-                }
+                if (this._options.strictness === Strictness.Strict && has.nil)
+                    declarations.push([
+                        ["Nil"],
+                        [` = ${this._options.strictness}Nil`],
+                    ]);
 
                 if (has.bool)
                     declarations.push([

--- a/packages/quicktype-core/src/language/Ruby/utils.ts
+++ b/packages/quicktype-core/src/language/Ruby/utils.ts
@@ -26,7 +26,7 @@ export const forbiddenForObjectProperties = Array.from(
     new Set([...keywords.keywords, ...keywords.reservedProperties]),
 );
 function unicodeEscape(codePoint: number): string {
-    return "\\u{" + intToHex(codePoint, 0) + "}";
+    return `\\u{${intToHex(codePoint, 0)}}`;
 }
 
 export const stringEscape = utf32ConcatMap(
@@ -47,7 +47,7 @@ const legalizeName = legalizeCharacters(isPartCharacter);
 
 export function simpleNameStyle(original: string, uppercase: boolean): string {
     if (/^[0-9]+$/.test(original)) {
-        original = original + "N";
+        original = `${original}N`;
     }
 
     const words = splitIntoWords(original);

--- a/packages/quicktype-core/src/language/Rust/utils.ts
+++ b/packages/quicktype-core/src/language/Rust/utils.ts
@@ -171,7 +171,9 @@ export function getPreferredNamingStyle(
     const occurrences = Object.fromEntries(
         Object.keys(namingStyles).map((key) => [key, 0]),
     );
-    namingStyleOccurences.forEach((style) => ++occurrences[style]);
+    namingStyleOccurences.forEach((style) => {
+        ++occurrences[style];
+    });
     const max = Math.max(...Object.values(occurrences));
     const preferedStyles = Object.entries(occurrences).flatMap(
         ([style, num]) => (num === max ? [style] : []),

--- a/packages/quicktype-core/src/language/Rust/utils.ts
+++ b/packages/quicktype-core/src/language/Rust/utils.ts
@@ -102,6 +102,7 @@ export const namingStyles = {
     },
 } as const;
 
+// biome-ignore lint/suspicious/noUnusedExpressions: compile-time type check via satisfies
 namingStyles satisfies Record<string, NamingStyle>;
 
 export type NamingStyleKey = keyof typeof namingStyles;

--- a/packages/quicktype-core/src/language/Rust/utils.ts
+++ b/packages/quicktype-core/src/language/Rust/utils.ts
@@ -155,9 +155,8 @@ export const camelNamingFunction = funPrefixNamer("camel", (original: string) =>
 const standardUnicodeRustEscape = (codePoint: number): string => {
     if (codePoint <= 0xffff) {
         return `\\u{${intToHex(codePoint, 4)}}`;
-    } else {
-        return `\\u{${intToHex(codePoint, 6)}}`;
     }
+    return `\\u{${intToHex(codePoint, 6)}}`;
 };
 
 export const rustStringEscape = utf32ConcatMap(

--- a/packages/quicktype-core/src/language/Rust/utils.ts
+++ b/packages/quicktype-core/src/language/Rust/utils.ts
@@ -155,8 +155,9 @@ export const camelNamingFunction = funPrefixNamer("camel", (original: string) =>
 const standardUnicodeRustEscape = (codePoint: number): string => {
     if (codePoint <= 0xffff) {
         return `\\u{${intToHex(codePoint, 4)}}`;
+    } else {
+        return `\\u{${intToHex(codePoint, 6)}}`;
     }
-    return `\\u{${intToHex(codePoint, 6)}}`;
 };
 
 export const rustStringEscape = utf32ConcatMap(

--- a/packages/quicktype-core/src/language/Rust/utils.ts
+++ b/packages/quicktype-core/src/language/Rust/utils.ts
@@ -154,9 +154,9 @@ export const camelNamingFunction = funPrefixNamer("camel", (original: string) =>
 
 const standardUnicodeRustEscape = (codePoint: number): string => {
     if (codePoint <= 0xffff) {
-        return "\\u{" + intToHex(codePoint, 4) + "}";
+        return `\\u{${intToHex(codePoint, 4)}}`;
     } else {
-        return "\\u{" + intToHex(codePoint, 6) + "}";
+        return `\\u{${intToHex(codePoint, 6)}}`;
     }
 };
 

--- a/packages/quicktype-core/src/language/Rust/utils.ts
+++ b/packages/quicktype-core/src/language/Rust/utils.ts
@@ -57,8 +57,8 @@ export const namingStyles = {
                 .map((p, i) =>
                     i === 0
                         ? p.toLowerCase()
-                        : p.substring(0, 1).toUpperCase() +
-                          p.substring(1).toLowerCase(),
+                        : p.slice(0, 1).toUpperCase() +
+                          p.slice(1).toLowerCase(),
                 )
                 .join(""),
     },
@@ -72,8 +72,7 @@ export const namingStyles = {
             parts
                 .map(
                     (p) =>
-                        p.substring(0, 1).toUpperCase() +
-                        p.substring(1).toLowerCase(),
+                        p.slice(0, 1).toUpperCase() + p.slice(1).toLowerCase(),
                 )
                 .join(""),
     },

--- a/packages/quicktype-core/src/language/Scala3/CirceRenderer.ts
+++ b/packages/quicktype-core/src/language/Scala3/CirceRenderer.ts
@@ -180,7 +180,7 @@ export class CirceRenderer extends Scala3Renderer {
         function sortBy(t: Type): string {
             const kind = t.kind;
             if (kind === "class") return kind;
-            return "_" + kind;
+            return `_${kind}`;
         }
 
         this.emitDescription(this.descriptionForType(u));

--- a/packages/quicktype-core/src/language/Scala3/CirceRenderer.ts
+++ b/packages/quicktype-core/src/language/Scala3/CirceRenderer.ts
@@ -18,7 +18,7 @@ import { Scala3Renderer } from "./Scala3Renderer.js";
 import { wrapOption } from "./utils.js";
 
 export class CirceRenderer extends Scala3Renderer {
-    private seenUnionTypes: string[] = [];
+    private readonly seenUnionTypes: string[] = [];
 
     protected circeEncoderForType(
         t: Type,

--- a/packages/quicktype-core/src/language/Scala3/Scala3Renderer.ts
+++ b/packages/quicktype-core/src/language/Scala3/Scala3Renderer.ts
@@ -265,7 +265,7 @@ export class Scala3Renderer extends ConvenienceRenderer {
                 const nameNeedsBackticks =
                     jsonName.endsWith("_") || shouldAddBacktick(jsonName);
                 const nameWithBackticks = nameNeedsBackticks
-                    ? "`" + jsonName + "`"
+                    ? `\`${jsonName}\``
                     : jsonName;
                 this.emitLine(
                     "val ",

--- a/packages/quicktype-core/src/language/Scala3/Scala3Renderer.ts
+++ b/packages/quicktype-core/src/language/Scala3/Scala3Renderer.ts
@@ -311,7 +311,9 @@ export class Scala3Renderer extends ConvenienceRenderer {
                         const backticks =
                             shouldAddBacktick(jsonName) ||
                             jsonName.includes(" ") ||
-                            !Number.isNaN(Number.parseInt(jsonName.charAt(0)));
+                            !Number.isNaN(
+                                Number.parseInt(jsonName.charAt(0), 10),
+                            );
                         if (backticks) {
                             this.emitItem("`");
                         }

--- a/packages/quicktype-core/src/language/Scala3/utils.ts
+++ b/packages/quicktype-core/src/language/Scala3/utils.ts
@@ -29,8 +29,9 @@ export const shouldAddBacktick = (paramName: string): boolean => {
 export const wrapOption = (s: string, optional: boolean): string => {
     if (optional) {
         return `Option[${s}]`;
+    } else {
+        return s;
     }
-    return s;
 };
 
 function isPartCharacter(codePoint: number): boolean {

--- a/packages/quicktype-core/src/language/Scala3/utils.ts
+++ b/packages/quicktype-core/src/language/Scala3/utils.ts
@@ -28,7 +28,7 @@ export const shouldAddBacktick = (paramName: string): boolean => {
 
 export const wrapOption = (s: string, optional: boolean): string => {
     if (optional) {
-        return "Option[" + s + "]";
+        return `Option[${s}]`;
     } else {
         return s;
     }

--- a/packages/quicktype-core/src/language/Scala3/utils.ts
+++ b/packages/quicktype-core/src/language/Scala3/utils.ts
@@ -22,7 +22,7 @@ export const shouldAddBacktick = (paramName: string): boolean => {
         keywords.some((s) => paramName === s) ||
         invalidSymbols.some((s) => paramName.includes(s)) ||
         !isNaN(+Number.parseFloat(paramName)) ||
-        !isNaN(Number.parseInt(paramName.charAt(0)))
+        !isNaN(Number.parseInt(paramName.charAt(0), 10))
     );
 };
 

--- a/packages/quicktype-core/src/language/Scala3/utils.ts
+++ b/packages/quicktype-core/src/language/Scala3/utils.ts
@@ -21,8 +21,8 @@ export const shouldAddBacktick = (paramName: string): boolean => {
     return (
         keywords.some((s) => paramName === s) ||
         invalidSymbols.some((s) => paramName.includes(s)) ||
-        !isNaN(+Number.parseFloat(paramName)) ||
-        !isNaN(Number.parseInt(paramName.charAt(0), 10))
+        !Number.isNaN(+Number.parseFloat(paramName)) ||
+        !Number.isNaN(Number.parseInt(paramName.charAt(0), 10))
     );
 };
 

--- a/packages/quicktype-core/src/language/Scala3/utils.ts
+++ b/packages/quicktype-core/src/language/Scala3/utils.ts
@@ -29,9 +29,8 @@ export const shouldAddBacktick = (paramName: string): boolean => {
 export const wrapOption = (s: string, optional: boolean): string => {
     if (optional) {
         return `Option[${s}]`;
-    } else {
-        return s;
     }
+    return s;
 };
 
 function isPartCharacter(codePoint: number): boolean {

--- a/packages/quicktype-core/src/language/Smithy4s/Smithy4sRenderer.ts
+++ b/packages/quicktype-core/src/language/Smithy4s/Smithy4sRenderer.ts
@@ -128,7 +128,7 @@ export class Smithy4sRenderer extends ConvenienceRenderer {
     // because some renderers, such as kotlinx, can cope with `any`, while some get mad.
     protected arrayType(arrayType: ArrayType, _ = false): Sourcelike {
         // this.emitTopLevelArray(arrayType, new Name(arrayType.getCombinedName().toString() + "List"))
-        return arrayType.getCombinedName().toString() + "List";
+        return `${arrayType.getCombinedName().toString()}List`;
     }
 
     protected emitArrayType(_: ArrayType, smithyType: Sourcelike): void {
@@ -136,7 +136,7 @@ export class Smithy4sRenderer extends ConvenienceRenderer {
     }
 
     protected mapType(mapType: MapType, _ = false): Sourcelike {
-        return mapType.getCombinedName().toString() + "Map";
+        return `${mapType.getCombinedName().toString()}Map`;
         // return [this.scalaType(mapType.values, withIssues), "Map"];
     }
 
@@ -278,7 +278,7 @@ export class Smithy4sRenderer extends ConvenienceRenderer {
                 const nameNeedsBackticks =
                     jsonName.endsWith("_") || shouldAddBacktick(jsonName);
                 const nameWithBackticks = nameNeedsBackticks
-                    ? "`" + jsonName + "`"
+                    ? `\`${jsonName}\``
                     : jsonName;
                 this.emitLine(
                     p.isOptional ? "" : nullableOrOptional ? "" : "@required ",

--- a/packages/quicktype-core/src/language/Smithy4s/Smithy4sRenderer.ts
+++ b/packages/quicktype-core/src/language/Smithy4s/Smithy4sRenderer.ts
@@ -302,9 +302,7 @@ export class Smithy4sRenderer extends ConvenienceRenderer {
     protected emitClassDefinitionMethods(arrayTypes: ClassProperty[]): void {
         this.emitLine("}");
         arrayTypes.forEach((p) => {
-            function ignore<T extends Type>(_: T): void {
-                return;
-            }
+            function ignore<T extends Type>(_: T): void {}
 
             matchCompoundType(
                 p.type,
@@ -397,9 +395,7 @@ export class Smithy4sRenderer extends ConvenienceRenderer {
         this.ensureBlankLine();
 
         emitLater.forEach((p) => {
-            function ignore<T extends Type>(_: T): void {
-                return;
-            }
+            function ignore<T extends Type>(_: T): void {}
 
             matchCompoundType(
                 p,

--- a/packages/quicktype-core/src/language/Smithy4s/utils.ts
+++ b/packages/quicktype-core/src/language/Smithy4s/utils.ts
@@ -22,8 +22,8 @@ export const shouldAddBacktick = (paramName: string): boolean => {
     return (
         keywords.some((s) => paramName === s) ||
         invalidSymbols.some((s) => paramName.includes(s)) ||
-        !isNaN(Number.parseFloat(paramName)) ||
-        !isNaN(Number.parseInt(paramName.charAt(0), 10))
+        !Number.isNaN(Number.parseFloat(paramName)) ||
+        !Number.isNaN(Number.parseInt(paramName.charAt(0), 10))
     );
 };
 

--- a/packages/quicktype-core/src/language/Smithy4s/utils.ts
+++ b/packages/quicktype-core/src/language/Smithy4s/utils.ts
@@ -23,7 +23,7 @@ export const shouldAddBacktick = (paramName: string): boolean => {
         keywords.some((s) => paramName === s) ||
         invalidSymbols.some((s) => paramName.includes(s)) ||
         !isNaN(Number.parseFloat(paramName)) ||
-        !isNaN(Number.parseInt(paramName.charAt(0)))
+        !isNaN(Number.parseInt(paramName.charAt(0), 10))
     );
 };
 

--- a/packages/quicktype-core/src/language/Swift/SwiftRenderer.ts
+++ b/packages/quicktype-core/src/language/Swift/SwiftRenderer.ts
@@ -684,18 +684,16 @@ export class SwiftRenderer extends ConvenienceRenderer {
             },
         );
 
-        if (!this._options.justTypes) {
-            // FIXME: We emit only the MARK line for top-level-enum.schema
-            if (this._options.convenienceInitializers) {
-                this.ensureBlankLine();
-                this.emitMark(
-                    this.sourcelikeToString(className) +
-                        " convenience initializers and mutators",
-                );
-                this.ensureBlankLine();
-                this.emitConvenienceInitializersExtension(c, className);
-                this.ensureBlankLine();
-            }
+        // FIXME: We emit only the MARK line for top-level-enum.schema
+        if (!this._options.justTypes && this._options.convenienceInitializers) {
+            this.ensureBlankLine();
+            this.emitMark(
+                this.sourcelikeToString(className) +
+                    " convenience initializers and mutators",
+            );
+            this.ensureBlankLine();
+            this.emitConvenienceInitializersExtension(c, className);
+            this.ensureBlankLine();
         }
 
         this.endFile();

--- a/packages/quicktype-core/src/language/Swift/SwiftRenderer.ts
+++ b/packages/quicktype-core/src/language/Swift/SwiftRenderer.ts
@@ -515,7 +515,7 @@ export class SwiftRenderer extends ConvenienceRenderer {
             ],
             () => {
                 if (this._options.dense) {
-                    let lastProperty: ClassProperty | undefined = undefined;
+                    let lastProperty: ClassProperty | undefined;
                     let lastNames: Name[] = [];
 
                     const emitLastProperty = (): void => {

--- a/packages/quicktype-core/src/language/Swift/SwiftRenderer.ts
+++ b/packages/quicktype-core/src/language/Swift/SwiftRenderer.ts
@@ -440,7 +440,7 @@ export class SwiftRenderer extends ConvenienceRenderer {
     private get accessLevel(): string {
         return this._options.accessLevel === "internal"
             ? "" // internal is default, so we don't have to emit it
-            : this._options.accessLevel + " ";
+            : `${this._options.accessLevel} `;
     }
 
     private get objcMembersDeclaration(): string {

--- a/packages/quicktype-core/src/language/Swift/utils.ts
+++ b/packages/quicktype-core/src/language/Swift/utils.ts
@@ -78,7 +78,7 @@ export function swiftNameStyle(
 }
 
 function unicodeEscape(codePoint: number): string {
-    return "\\u{" + intToHex(codePoint, 0) + "}";
+    return `\\u{${intToHex(codePoint, 0)}}`;
 }
 
 export const stringEscape = utf32ConcatMap(

--- a/packages/quicktype-core/src/language/TypeScriptEffectSchema/TypeScriptEffectSchemaRenderer.ts
+++ b/packages/quicktype-core/src/language/TypeScriptEffectSchema/TypeScriptEffectSchemaRenderer.ts
@@ -32,7 +32,7 @@ import { legalizeName } from "../JavaScript/utils.js";
 import type { typeScriptEffectSchemaOptions } from "./language.js";
 
 export class TypeScriptEffectSchemaRenderer extends ConvenienceRenderer {
-    private emittedObjects = new Set<Name>();
+    private readonly emittedObjects = new Set<Name>();
 
     public constructor(
         targetLanguage: TargetLanguage,

--- a/packages/quicktype-core/src/language/TypeScriptEffectSchema/TypeScriptEffectSchemaRenderer.ts
+++ b/packages/quicktype-core/src/language/TypeScriptEffectSchema/TypeScriptEffectSchemaRenderer.ts
@@ -286,13 +286,13 @@ export class TypeScriptEffectSchemaRenderer extends ConvenienceRenderer {
         });
 
         // now emit ordered source
-        order.forEach((i) =>
+        order.forEach((i) => {
             this.emitGatheredSource(
-                this.gatherSource(() =>
-                    this.emitObject(mapKey[i], mapValue[i]),
-                ),
-            ),
-        );
+                this.gatherSource(() => {
+                    this.emitObject(mapKey[i], mapValue[i]);
+                }),
+            );
+        });
     }
 
     protected emitSourceStructure(): void {

--- a/packages/quicktype-core/src/language/TypeScriptEffectSchema/language.ts
+++ b/packages/quicktype-core/src/language/TypeScriptEffectSchema/language.ts
@@ -22,7 +22,7 @@ export class TypeScriptEffectSchemaTargetLanguage extends TargetLanguage<
         super(typeScriptEffectSchemaLanguageConfig);
     }
 
-    public getOptions(): {} {
+    public getOptions(): Record<string, never> {
         return {};
     }
 

--- a/packages/quicktype-core/src/language/TypeScriptFlow/FlowRenderer.ts
+++ b/packages/quicktype-core/src/language/TypeScriptFlow/FlowRenderer.ts
@@ -13,7 +13,7 @@ export class FlowRenderer extends TypeScriptFlowBaseRenderer {
     }
 
     protected get typeAnnotations(): JavaScriptTypeAnnotations {
-        return Object.assign({ never: "" }, tsFlowTypeAnnotations);
+        return { never: "", ...tsFlowTypeAnnotations };
     }
 
     protected emitEnum(e: EnumType, enumName: Name): void {

--- a/packages/quicktype-core/src/language/TypeScriptFlow/TypeScriptFlowBaseRenderer.ts
+++ b/packages/quicktype-core/src/language/TypeScriptFlow/TypeScriptFlowBaseRenderer.ts
@@ -250,7 +250,6 @@ export abstract class TypeScriptFlowBaseRenderer extends JavaScriptRenderer {
 
     protected emitModuleExports(): void {
         if (this._tsFlowOptions.justTypes) {
-            return;
         } else {
             super.emitModuleExports();
         }

--- a/packages/quicktype-core/src/language/TypeScriptFlow/TypeScriptRenderer.ts
+++ b/packages/quicktype-core/src/language/TypeScriptFlow/TypeScriptRenderer.ts
@@ -45,7 +45,7 @@ export class TypeScriptRenderer extends TypeScriptFlowBaseRenderer {
     }
 
     protected get typeAnnotations(): JavaScriptTypeAnnotations {
-        return Object.assign({ never: ": never" }, tsFlowTypeAnnotations);
+        return { never: ": never", ...tsFlowTypeAnnotations };
     }
 
     protected emitModuleExports(): void {}

--- a/packages/quicktype-core/src/language/TypeScriptFlow/TypeScriptRenderer.ts
+++ b/packages/quicktype-core/src/language/TypeScriptFlow/TypeScriptRenderer.ts
@@ -48,9 +48,7 @@ export class TypeScriptRenderer extends TypeScriptFlowBaseRenderer {
         return Object.assign({ never: ": never" }, tsFlowTypeAnnotations);
     }
 
-    protected emitModuleExports(): void {
-        return;
-    }
+    protected emitModuleExports(): void {}
 
     protected emitUsageImportComment(): void {
         const topLevelNames: Sourcelike[] = [];

--- a/packages/quicktype-core/src/language/TypeScriptFlow/language.ts
+++ b/packages/quicktype-core/src/language/TypeScriptFlow/language.ts
@@ -12,7 +12,8 @@ import { javaScriptOptions } from "../JavaScript/index.js";
 import { FlowRenderer } from "./FlowRenderer.js";
 import { TypeScriptRenderer } from "./TypeScriptRenderer.js";
 
-export const tsFlowOptions = Object.assign({}, javaScriptOptions, {
+export const tsFlowOptions = {
+    ...javaScriptOptions,
     justTypes: new BooleanOption("just-types", "Interfaces only", false),
     nicePropertyNames: new BooleanOption(
         "nice-property-names",
@@ -40,7 +41,7 @@ export const tsFlowOptions = Object.assign({}, javaScriptOptions, {
         false,
     ),
     readonly: new BooleanOption("readonly", "Use readonly type members", false),
-});
+};
 
 export const typeScriptLanguageConfig = {
     displayName: "TypeScript",

--- a/packages/quicktype-core/src/language/TypeScriptFlow/utils.ts
+++ b/packages/quicktype-core/src/language/TypeScriptFlow/utils.ts
@@ -17,13 +17,15 @@ export function quotePropertyName(original: string): string {
 
     if (original.length === 0) {
         return quoted;
-    } else if (!isES3IdentifierStart(original.codePointAt(0) as number)) {
-        return quoted;
-    } else if (escaped !== original) {
-        return quoted;
-    } else if (legalizeName(original) !== original) {
-        return quoted;
-    } else {
-        return original;
     }
+    if (!isES3IdentifierStart(original.codePointAt(0) as number)) {
+        return quoted;
+    }
+    if (escaped !== original) {
+        return quoted;
+    }
+    if (legalizeName(original) !== original) {
+        return quoted;
+    }
+    return original;
 }

--- a/packages/quicktype-core/src/language/TypeScriptFlow/utils.ts
+++ b/packages/quicktype-core/src/language/TypeScriptFlow/utils.ts
@@ -17,15 +17,13 @@ export function quotePropertyName(original: string): string {
 
     if (original.length === 0) {
         return quoted;
-    }
-    if (!isES3IdentifierStart(original.codePointAt(0) as number)) {
+    } else if (!isES3IdentifierStart(original.codePointAt(0) as number)) {
         return quoted;
-    }
-    if (escaped !== original) {
+    } else if (escaped !== original) {
         return quoted;
-    }
-    if (legalizeName(original) !== original) {
+    } else if (legalizeName(original) !== original) {
         return quoted;
+    } else {
+        return original;
     }
-    return original;
 }

--- a/packages/quicktype-core/src/language/TypeScriptZod/TypeScriptZodRenderer.ts
+++ b/packages/quicktype-core/src/language/TypeScriptZod/TypeScriptZodRenderer.ts
@@ -413,9 +413,9 @@ export class TypeScriptZodRenderer extends ConvenienceRenderer {
         // which we can get back to the same type by following child type
         // references. Those can never be topologically ordered.
         const indexForTypeRef = new Map<number, number>();
-        mapTypeRef.forEach((typeRef, index) =>
-            indexForTypeRef.set(typeRef, index),
-        );
+        mapTypeRef.forEach((typeRef, index) => {
+            indexForTypeRef.set(typeRef, index);
+        });
         this._recursiveTypeRefs = new Set();
         mapType.forEach((_, startIndex) => {
             const visited = new Set<number>();
@@ -510,13 +510,13 @@ export class TypeScriptZodRenderer extends ConvenienceRenderer {
         } while (indices.length > 0 && passNum <= MAX_PASSES);
 
         // now emit ordered source
-        order.forEach((i) =>
+        order.forEach((i) => {
             this.emitGatheredSource(
-                this.gatherSource(() =>
-                    this.emitObject(mapName[i], mapType[i]),
-                ),
-            ),
-        );
+                this.gatherSource(() => {
+                    this.emitObject(mapName[i], mapType[i]);
+                }),
+            );
+        });
     }
 
     protected emitSourceStructure(): void {

--- a/packages/quicktype-core/src/language/TypeScriptZod/TypeScriptZodRenderer.ts
+++ b/packages/quicktype-core/src/language/TypeScriptZod/TypeScriptZodRenderer.ts
@@ -468,10 +468,7 @@ export class TypeScriptZodRenderer extends ConvenienceRenderer {
                         // find this childs's ordinal, if it has already been added
                         // faster to go through what we've defined so far than all definitions
 
-                        // FIXME: refactor this
-                        // eslint-disable-next-line @typescript-eslint/prefer-for-of
-                        for (let j = 0; j < order.length; j++) {
-                            const childIndex = order[j];
+                        for (const childIndex of order) {
                             if (mapTypeRef[childIndex] === childRef) {
                                 found = true;
                                 break;

--- a/packages/quicktype-core/src/language/TypeScriptZod/language.ts
+++ b/packages/quicktype-core/src/language/TypeScriptZod/language.ts
@@ -27,7 +27,7 @@ export class TypeScriptZodTargetLanguage extends TargetLanguage<
         super(typeScriptZodLanguageConfig);
     }
 
-    public getOptions(): {} {
+    public getOptions(): Record<string, never> {
         return {};
     }
 

--- a/packages/quicktype-core/src/rewrites/CombineClasses.ts
+++ b/packages/quicktype-core/src/rewrites/CombineClasses.ts
@@ -45,13 +45,11 @@ function canBeCombined(
         if (p1.size !== p2.size) {
             return false;
         }
-    } else {
-        if (
-            p1.size < p2.size * REQUIRED_OVERLAP ||
-            p2.size < p1.size * REQUIRED_OVERLAP
-        ) {
-            return false;
-        }
+    } else if (
+        p1.size < p2.size * REQUIRED_OVERLAP ||
+        p2.size < p1.size * REQUIRED_OVERLAP
+    ) {
+        return false;
     }
 
     let larger: ReadonlyMap<string, ClassProperty>;

--- a/packages/quicktype-core/src/rewrites/CombineClasses.ts
+++ b/packages/quicktype-core/src/rewrites/CombineClasses.ts
@@ -142,7 +142,7 @@ function findSimilarityCliques(
     const cliques: Clique[] = [];
 
     for (const c of classCandidates) {
-        let cliqueIndex: number | undefined = undefined;
+        let cliqueIndex: number | undefined;
         for (let i = 0; i < cliques.length; i++) {
             if (tryAddToClique(c, cliques[i], onlyWithSameProperties)) {
                 cliqueIndex = i;

--- a/packages/quicktype-core/src/rewrites/InferMaps.ts
+++ b/packages/quicktype-core/src/rewrites/InferMaps.ts
@@ -19,7 +19,7 @@ import { unifyTypes, unionBuilderForUnification } from "../UnifyClasses.js";
 const mapSizeThreshold = 20;
 const stringMapSizeThreshold = 50;
 
-let markovChain: MarkovChain | undefined = undefined;
+let markovChain: MarkovChain | undefined;
 
 function nameProbability(name: string): number {
     if (markovChain === undefined) {
@@ -92,7 +92,7 @@ function shouldBeMap(
     // 1. All property types are null.
     // 2. Some property types are null or nullable.
     // 3. No property types are null or nullable.
-    let firstNonNullCases: ReadonlySet<Type> | undefined = undefined;
+    let firstNonNullCases: ReadonlySet<Type> | undefined;
     const allCases = new Set<Type>();
     let canBeMap = true;
     // Check that all the property types are the same, modulo nullability.

--- a/packages/quicktype-core/src/rewrites/InferMaps.ts
+++ b/packages/quicktype-core/src/rewrites/InferMaps.ts
@@ -61,7 +61,7 @@ function shouldBeMap(
         const names = Array.from(properties.keys());
         const probabilities = names.map(nameProbability);
         const product = probabilities.reduce((a, b) => a * b, 1);
-        const probability = Math.pow(product, 1 / numProperties);
+        const probability = product ** (1 / numProperties);
         // The idea behind this is to have a probability around 0.0025 for
         // n=1, up to around 1.0 for n=20.  I.e. when we only have a few
         // properties, they need to look really weird to infer a map, but
@@ -76,10 +76,10 @@ function shouldBeMap(
         // we want maybe 0.004 and 5, or maybe something even more
         // trigger-happy.
         const exponent = 5;
-        const scale = Math.pow(22, exponent);
+        const scale = 22 ** exponent;
         const limit =
-            Math.pow(numProperties + 2, exponent) / scale +
-            (0.0025 - Math.pow(3, exponent) / scale);
+            (numProperties + 2) ** exponent / scale +
+            (0.0025 - 3 ** exponent / scale);
         if (probability > limit) return undefined;
     }
 

--- a/packages/quicktype-core/src/support/Chance.ts
+++ b/packages/quicktype-core/src/support/Chance.ts
@@ -88,13 +88,13 @@ class MersenneTwister {
 
     /* generates a random number on [0,0xffffffff]-interval */
     private genrand_int32() {
-        let y;
+        let y: number;
         const mag01 = [0x0, this.MATRIX_A];
         /* mag01[x] = x * MATRIX_A  for x=0,1 */
 
         if (this.mti >= this.N) {
             /* generate N words at one time */
-            let kk;
+            let kk: number;
 
             if (this.mti === this.N + 1) {
                 /* if init_genrand() has not been called, */

--- a/packages/quicktype-core/src/support/Chance.ts
+++ b/packages/quicktype-core/src/support/Chance.ts
@@ -45,7 +45,7 @@ class MersenneTwister {
 
     private readonly LOWER_MASK: number;
 
-    private mt: number[];
+    private readonly mt: number[];
 
     private mti: number;
 

--- a/packages/quicktype-core/src/support/Chance.ts
+++ b/packages/quicktype-core/src/support/Chance.ts
@@ -52,7 +52,7 @@ class MersenneTwister {
     public constructor(seed: number) {
         if (seed === undefined) {
             // kept random number same size as time used previously to ensure no unexpected results downstream
-            seed = Math.floor(Math.random() * Math.pow(10, 13));
+            seed = Math.floor(Math.random() * 10 ** 13);
         }
 
         /* Period parameters */

--- a/packages/quicktype-core/src/support/Strings.ts
+++ b/packages/quicktype-core/src/support/Strings.ts
@@ -63,7 +63,7 @@ export function utf16ConcatMap(
             const cc = s.charCodeAt(i);
             if (charNoEscapeMap[cc] !== 1) {
                 if (cs === null) cs = [];
-                cs.push(s.substring(start, i));
+                cs.push(s.slice(start, i));
 
                 const str = charStringMap[cc];
                 if (str === undefined) {
@@ -80,7 +80,7 @@ export function utf16ConcatMap(
 
         if (cs === null) return s;
 
-        cs.push(s.substring(start, i));
+        cs.push(s.slice(start, i));
 
         return cs.join("");
     };
@@ -108,7 +108,7 @@ export function utf32ConcatMap(
             let cc = s.charCodeAt(i);
             if (charNoEscapeMap[cc] !== 1) {
                 if (cs === null) cs = [];
-                cs.push(s.substring(start, i));
+                cs.push(s.slice(start, i));
 
                 if (isHighSurrogate(cc)) {
                     const highSurrogate = cc;
@@ -139,7 +139,7 @@ export function utf32ConcatMap(
 
         if (cs === null) return s;
 
-        cs.push(s.substring(start, i));
+        cs.push(s.slice(start, i));
 
         return cs.join("");
     };

--- a/packages/quicktype-core/src/support/Strings.ts
+++ b/packages/quicktype-core/src/support/Strings.ts
@@ -190,9 +190,8 @@ export function intToHex(i: number, width: number): string {
 export function standardUnicodeHexEscape(codePoint: number): string {
     if (codePoint <= 0xffff) {
         return `\\u${intToHex(codePoint, 4)}`;
-    } else {
-        return `\\U${intToHex(codePoint, 8)}`;
     }
+    return `\\U${intToHex(codePoint, 8)}`;
 }
 
 export function escapeNonPrintableMapper(
@@ -672,8 +671,7 @@ export function makeNameStyle(
 
         if (prefix !== undefined) {
             return addPrefixIfNecessary(prefix, styledName);
-        } else {
-            return styledName;
         }
+        return styledName;
     };
 }

--- a/packages/quicktype-core/src/support/Strings.ts
+++ b/packages/quicktype-core/src/support/Strings.ts
@@ -371,10 +371,10 @@ const fastIsDigit = precomputedCodePointPredicate(isDigit);
 export function splitIntoWords(s: string): WordInName[] {
     // [start, end, allUpper]
     const intervals: Array<[number, number, boolean]> = [];
-    let intervalStart: number | undefined = undefined;
+    let intervalStart: number | undefined;
     const len = s.length;
     let i = 0;
-    let lastLowerCaseIndex: number | undefined = undefined;
+    let lastLowerCaseIndex: number | undefined;
 
     function atEnd(): boolean {
         return i >= len;

--- a/packages/quicktype-core/src/support/Strings.ts
+++ b/packages/quicktype-core/src/support/Strings.ts
@@ -609,7 +609,8 @@ export function makeNameStyle(
             restWordStyle = firstUpperWordStyle;
             restAcronymStyle = allUpperWordStyle;
         } else {
-            restWordStyle = restAcronymStyle = firstUpperWordStyle;
+            restAcronymStyle = firstUpperWordStyle;
+            restWordStyle = restAcronymStyle;
         }
     } else {
         separator = "_";
@@ -618,32 +619,31 @@ export function makeNameStyle(
     switch (namingStyle) {
         case "pascal":
         case "pascal-upper-acronyms":
-            firstWordStyle = firstWordAcronymStyle = firstUpperWordStyle;
+            firstWordAcronymStyle = firstUpperWordStyle;
+            firstWordStyle = firstWordAcronymStyle;
             break;
         case "camel":
         case "camel-upper-acronyms":
-            firstWordStyle = firstWordAcronymStyle = allLowerWordStyle;
+            firstWordAcronymStyle = allLowerWordStyle;
+            firstWordStyle = firstWordAcronymStyle;
             break;
         case "underscore":
-            firstWordStyle =
-                restWordStyle =
-                firstWordAcronymStyle =
-                restAcronymStyle =
-                    allLowerWordStyle;
+            firstWordStyle = allLowerWordStyle;
+            restWordStyle = allLowerWordStyle;
+            firstWordAcronymStyle = allLowerWordStyle;
+            restAcronymStyle = allLowerWordStyle;
             break;
         case "upper-underscore":
-            firstWordStyle =
-                restWordStyle =
-                firstWordAcronymStyle =
-                restAcronymStyle =
-                    allUpperWordStyle;
+            firstWordStyle = allUpperWordStyle;
+            restWordStyle = allUpperWordStyle;
+            firstWordAcronymStyle = allUpperWordStyle;
+            restAcronymStyle = allUpperWordStyle;
             break;
         case "original":
-            firstWordStyle =
-                restWordStyle =
-                firstWordAcronymStyle =
-                restAcronymStyle =
-                    originalWord;
+            firstWordStyle = originalWord;
+            restWordStyle = originalWord;
+            firstWordAcronymStyle = originalWord;
+            restAcronymStyle = originalWord;
             break;
         default:
             return assertNever(namingStyle);

--- a/packages/quicktype-core/src/support/Strings.ts
+++ b/packages/quicktype-core/src/support/Strings.ts
@@ -423,7 +423,7 @@ export function splitIntoWords(s: string): WordInName[] {
 
     function commitInterval(): void {
         if (intervalStart === undefined) {
-            panic("Tried to commit interval without starting one");
+            return panic("Tried to commit interval without starting one");
         }
 
         assert(i > intervalStart, "Interval must be non-empty");

--- a/packages/quicktype-core/src/support/Strings.ts
+++ b/packages/quicktype-core/src/support/Strings.ts
@@ -189,9 +189,9 @@ export function intToHex(i: number, width: number): string {
 
 export function standardUnicodeHexEscape(codePoint: number): string {
     if (codePoint <= 0xffff) {
-        return "\\u" + intToHex(codePoint, 4);
+        return `\\u${intToHex(codePoint, 4)}`;
     } else {
-        return "\\U" + intToHex(codePoint, 8);
+        return `\\U${intToHex(codePoint, 8)}`;
     }
 }
 
@@ -343,7 +343,7 @@ export function startWithLetter(
     const modify = upper ? capitalize : decapitalize;
     if (str === "") return modify("empty");
     if (isAllowedStart(str.charCodeAt(0))) return modify(str);
-    return modify("the" + str);
+    return modify(`the${str}`);
 }
 
 const knownAcronyms = new Set(acronyms);

--- a/packages/quicktype-core/src/support/Strings.ts
+++ b/packages/quicktype-core/src/support/Strings.ts
@@ -423,7 +423,7 @@ export function splitIntoWords(s: string): WordInName[] {
 
     function commitInterval(): void {
         if (intervalStart === undefined) {
-            return panic("Tried to commit interval without starting one");
+            panic("Tried to commit interval without starting one");
         }
 
         assert(i > intervalStart, "Interval must be non-empty");

--- a/packages/quicktype-core/src/support/Strings.ts
+++ b/packages/quicktype-core/src/support/Strings.ts
@@ -190,8 +190,9 @@ export function intToHex(i: number, width: number): string {
 export function standardUnicodeHexEscape(codePoint: number): string {
     if (codePoint <= 0xffff) {
         return `\\u${intToHex(codePoint, 4)}`;
+    } else {
+        return `\\U${intToHex(codePoint, 8)}`;
     }
-    return `\\U${intToHex(codePoint, 8)}`;
 }
 
 export function escapeNonPrintableMapper(
@@ -671,7 +672,8 @@ export function makeNameStyle(
 
         if (prefix !== undefined) {
             return addPrefixIfNecessary(prefix, styledName);
+        } else {
+            return styledName;
         }
-        return styledName;
     };
 }

--- a/packages/quicktype-core/src/support/Support.ts
+++ b/packages/quicktype-core/src/support/Support.ts
@@ -98,7 +98,7 @@ export function assertNever(x: never): never {
 
 export function assert(condition: boolean, message = "Assertion failed"): void {
     if (!condition) {
-        return messageError("InternalError", { message });
+        messageError("InternalError", { message });
     }
 }
 

--- a/packages/quicktype-core/src/support/Support.ts
+++ b/packages/quicktype-core/src/support/Support.ts
@@ -99,7 +99,7 @@ export function assertNever(x: never): never {
 
 export function assert(condition: boolean, message = "Assertion failed"): void {
     if (!condition) {
-        messageError("InternalError", { message });
+        return messageError("InternalError", { message });
     }
 }
 

--- a/packages/quicktype-core/src/support/Support.ts
+++ b/packages/quicktype-core/src/support/Support.ts
@@ -6,6 +6,7 @@ import type { JSONSchema } from "../input/JSONSchemaStore.js";
 import { messageError } from "../Messages.js";
 
 export interface StringMap {
+    // biome-ignore lint/suspicious/noExplicitAny: heterogeneous by design; holds arbitrary JSON values
     [name: string]: any;
 }
 

--- a/packages/quicktype-graphql-input/src/index.ts
+++ b/packages/quicktype-graphql-input/src/index.ts
@@ -254,7 +254,7 @@ class GQLQuery {
                     null,
                     containingTypeName,
                 );
-            case TypeKind.ENUM:
+            case TypeKind.ENUM: {
                 if (!fieldType.enumValues) {
                     return panic("Enum type doesn't have values");
                 }
@@ -276,6 +276,7 @@ class GQLQuery {
                     new Set(values),
                 );
                 break;
+            }
             case TypeKind.INPUT_OBJECT:
                 // FIXME: Support input objects
                 return panic("Input objects not supported");
@@ -365,7 +366,7 @@ class GQLQuery {
             if (!nextItem) break;
             const { selection, optional, inType } = nextItem;
             switch (selection.kind) {
-                case Kind.FIELD:
+                case Kind.FIELD: {
                     const fieldName = selection.name.value;
                     const givenName = selection.alias
                         ? selection.alias.value
@@ -382,6 +383,7 @@ class GQLQuery {
                         builder.makeClassProperty(fieldType, optional),
                     );
                     break;
+                }
                 case Kind.FRAGMENT_SPREAD: {
                     const fragment = this.getFragment(selection.name.value);
                     const fragmentType =

--- a/packages/quicktype-graphql-input/src/index.ts
+++ b/packages/quicktype-graphql-input/src/index.ts
@@ -648,13 +648,13 @@ function makeGraphQLQueryTypes(
 export interface GraphQLSourceData {
     name: string;
     query: string;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    // biome-ignore lint/suspicious/noExplicitAny: raw GraphQL introspection JSON
     schema: any;
 }
 
 interface GraphQLTopLevel {
     query: string;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    // biome-ignore lint/suspicious/noExplicitAny: raw GraphQL introspection JSON
     schema: any;
 }
 

--- a/packages/quicktype-graphql-input/src/index.ts
+++ b/packages/quicktype-graphql-input/src/index.ts
@@ -217,7 +217,7 @@ class GQLQuery {
             }
         }
 
-        messageAssert(queries.length >= 1, "GraphQLNoQueriesDefined", {});
+        messageAssert(queries.length > 0, "GraphQLNoQueriesDefined", {});
         this.queries = queries;
     }
 

--- a/packages/quicktype-graphql-input/src/index.ts
+++ b/packages/quicktype-graphql-input/src/index.ts
@@ -466,7 +466,6 @@ class GQLQuery {
 class GQLSchemaFromJSON implements GQLSchema {
     public readonly types: { [name: string]: GQLType } = {};
 
-    // @ts-expect-error: The constructor can return early, but only by throwing.
     public readonly queryType: GQLType;
 
     public readonly mutationType?: GQLType;
@@ -475,11 +474,11 @@ class GQLSchemaFromJSON implements GQLSchema {
         const schema: GraphQLSchema = json.data;
 
         if (schema.__schema.queryType.name === null) {
-            return panic("Query type doesn't have a name.");
+            panic("Query type doesn't have a name.");
         }
 
         for (const t of schema.__schema.types as GQLType[]) {
-            if (!t.name) return panic("No top-level type name given");
+            if (!t.name) panic("No top-level type name given");
             this.types[t.name] = {
                 kind: t.kind,
                 name: t.name,
@@ -488,7 +487,7 @@ class GQLSchemaFromJSON implements GQLSchema {
         }
 
         for (const t of schema.__schema.types) {
-            if (!t.name) return panic("This cannot happen");
+            if (!t.name) panic("This cannot happen");
             const type = this.types[t.name];
             this.addTypeFields(type, t as GQLType);
             // console.log(`type ${type.name} is ${type.kind}`);
@@ -496,7 +495,7 @@ class GQLSchemaFromJSON implements GQLSchema {
 
         const queryType = this.types[schema.__schema.queryType.name];
         if (queryType === undefined) {
-            return panic("Query type not found.");
+            panic("Query type not found.");
         }
 
         // console.log(`query type ${queryType.name} is ${queryType.kind}`);
@@ -507,12 +506,12 @@ class GQLSchemaFromJSON implements GQLSchema {
         }
 
         if (schema.__schema.mutationType.name === null) {
-            return panic("Mutation type doesn't have a name.");
+            panic("Mutation type doesn't have a name.");
         }
 
         const mutationType = this.types[schema.__schema.mutationType.name];
         if (mutationType === undefined) {
-            return panic("Mutation type not found.");
+            panic("Mutation type not found.");
         }
 
         this.mutationType = mutationType;

--- a/packages/quicktype-graphql-input/src/index.ts
+++ b/packages/quicktype-graphql-input/src/index.ts
@@ -466,6 +466,7 @@ class GQLQuery {
 class GQLSchemaFromJSON implements GQLSchema {
     public readonly types: { [name: string]: GQLType } = {};
 
+    // @ts-expect-error: The constructor can return early, but only by throwing.
     public readonly queryType: GQLType;
 
     public readonly mutationType?: GQLType;
@@ -474,11 +475,11 @@ class GQLSchemaFromJSON implements GQLSchema {
         const schema: GraphQLSchema = json.data;
 
         if (schema.__schema.queryType.name === null) {
-            panic("Query type doesn't have a name.");
+            return panic("Query type doesn't have a name.");
         }
 
         for (const t of schema.__schema.types as GQLType[]) {
-            if (!t.name) panic("No top-level type name given");
+            if (!t.name) return panic("No top-level type name given");
             this.types[t.name] = {
                 kind: t.kind,
                 name: t.name,
@@ -487,7 +488,7 @@ class GQLSchemaFromJSON implements GQLSchema {
         }
 
         for (const t of schema.__schema.types) {
-            if (!t.name) panic("This cannot happen");
+            if (!t.name) return panic("This cannot happen");
             const type = this.types[t.name];
             this.addTypeFields(type, t as GQLType);
             // console.log(`type ${type.name} is ${type.kind}`);
@@ -495,7 +496,7 @@ class GQLSchemaFromJSON implements GQLSchema {
 
         const queryType = this.types[schema.__schema.queryType.name];
         if (queryType === undefined) {
-            panic("Query type not found.");
+            return panic("Query type not found.");
         }
 
         // console.log(`query type ${queryType.name} is ${queryType.kind}`);
@@ -506,12 +507,12 @@ class GQLSchemaFromJSON implements GQLSchema {
         }
 
         if (schema.__schema.mutationType.name === null) {
-            panic("Mutation type doesn't have a name.");
+            return panic("Mutation type doesn't have a name.");
         }
 
         const mutationType = this.types[schema.__schema.mutationType.name];
         if (mutationType === undefined) {
-            panic("Mutation type not found.");
+            return panic("Mutation type not found.");
         }
 
         this.mutationType = mutationType;

--- a/packages/quicktype-vscode/src/extension.ts
+++ b/packages/quicktype-vscode/src/extension.ts
@@ -411,12 +411,12 @@ function deduceTargetLanguage(): TargetLanguage {
 
 const lastTargetLanguageUsedKey = "lastTargetLanguageUsed";
 
-let extensionContext: vscode.ExtensionContext | undefined = undefined;
+let extensionContext: vscode.ExtensionContext | undefined;
 
 const codeProviders: Map<string, CodeProvider> = new Map();
 
-let lastCodeProvider: CodeProvider | undefined = undefined;
-let explicitlySetTargetLanguage: TargetLanguage | undefined = undefined;
+let lastCodeProvider: CodeProvider | undefined;
+let explicitlySetTargetLanguage: TargetLanguage | undefined;
 
 async function openQuicktype(
     inputKind: InputKind,

--- a/packages/quicktype-vscode/src/extension.ts
+++ b/packages/quicktype-vscode/src/extension.ts
@@ -15,6 +15,7 @@ import {
     quicktype,
 } from "quicktype-core";
 import { schemaForTypeScriptSources } from "quicktype-typescript-input";
+// biome-ignore lint/correctness/noUndeclaredDependencies: the vscode module is provided by the VS Code host at runtime
 import * as vscode from "vscode";
 
 const configurationSection = "quicktype";

--- a/packages/quicktype-vscode/src/extension.ts
+++ b/packages/quicktype-vscode/src/extension.ts
@@ -310,7 +310,7 @@ class CodeProvider implements vscode.TextDocumentContentProvider {
     public get documentName(): string {
         const basename = path.basename(this.document.fileName);
         const extIndex = basename.lastIndexOf(".");
-        return extIndex === -1 ? basename : basename.substring(0, extIndex);
+        return extIndex === -1 ? basename : basename.slice(0, extIndex);
     }
 
     public setDocument(document: vscode.TextDocument): void {

--- a/packages/quicktype-vscode/src/extension.ts
+++ b/packages/quicktype-vscode/src/extension.ts
@@ -546,6 +546,4 @@ export async function activate(
     }
 }
 
-export function deactivate(): void {
-    return;
-}
+export function deactivate(): void {}

--- a/packages/quicktype-vscode/src/extension.ts
+++ b/packages/quicktype-vscode/src/extension.ts
@@ -34,7 +34,7 @@ enum Command {
 function jsonIsValid(json: string): boolean {
     try {
         JSON.parse(json);
-    } catch (e) {
+    } catch {
         return false;
     }
 
@@ -186,7 +186,7 @@ async function pasteAsTypes(
     let content: string;
     try {
         content = await vscode.env.clipboard.readText();
-    } catch (e) {
+    } catch {
         return await vscode.window.showErrorMessage(
             "Could not get clipboard contents",
         );
@@ -370,7 +370,7 @@ class CodeProvider implements vscode.TextDocumentContentProvider {
             if (!this._isOpen) return;
 
             this._onDidChange.fire(this.uri);
-        } catch (e) {
+        } catch {
             // FIXME
         }
     }

--- a/packages/quicktype-vscode/src/extension.ts
+++ b/packages/quicktype-vscode/src/extension.ts
@@ -147,7 +147,7 @@ async function runQuicktype(
     }
 
     const options: Partial<Options> = {
-        lang: lang,
+        lang,
         inputData,
         rendererOptions,
         indentation,

--- a/packages/quicktype-vscode/src/extension.ts
+++ b/packages/quicktype-vscode/src/extension.ts
@@ -1,4 +1,4 @@
-import * as path from "path";
+import * as path from "node:path";
 
 import {
     InputData,

--- a/src/GraphQLIntrospection.ts
+++ b/src/GraphQLIntrospection.ts
@@ -40,7 +40,7 @@ export async function introspectServer(
     try {
         const response = await globalThis.fetch(url, {
             method,
-            headers: headers,
+            headers,
             body: JSON.stringify({ query: getIntrospectionQuery() }),
         });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -137,8 +137,8 @@ async function samplesFromDirectory(
         // Each file is a (Name, JSON | URL)
         const sourcesInDir: TypeSource[] = [];
         const graphQLSources: GraphQLTypeSource[] = [];
-        let graphQLSchema: Readable | undefined = undefined;
-        let graphQLSchemaFileName: string | undefined = undefined;
+        let graphQLSchema: Readable | undefined;
+        let graphQLSchemaFileName: string | undefined;
         for (let file of files) {
             const name = typeNameFromFilename(file);
 
@@ -987,11 +987,11 @@ export async function makeQuicktypeOptions(
     }
 
     let sources: TypeSource[] = [];
-    let leadingComments: string[] | undefined = undefined;
+    let leadingComments: string[] | undefined;
     let fixedTopLevels = false;
     switch (options.srcLang) {
         case "graphql": {
-            let schemaString: string | undefined = undefined;
+            let schemaString: string | undefined;
             let wroteSchemaToFile = false;
             if (options.graphqlIntrospect !== undefined) {
                 schemaString = await introspectServer(
@@ -1024,7 +1024,7 @@ export async function makeQuicktypeOptions(
 
             const gqlSources: GraphQLTypeSource[] = [];
             for (const queryFile of options.src) {
-                let schemaFileName: string | undefined = undefined;
+                let schemaFileName: string | undefined;
                 if (schemaString === undefined) {
                     schemaFileName = defined(options.graphqlSchema);
                     schemaString = fs.readFileSync(schemaFileName, "utf8");

--- a/src/index.ts
+++ b/src/index.ts
@@ -242,7 +242,7 @@ async function samplesFromDirectory(
             schemaSources.length + graphQLSources.length > 0
         ) {
             return messageError("DriverCannotMixJSONWithOtherSamples", {
-                dir: dir,
+                dir,
             });
         }
 
@@ -253,7 +253,7 @@ async function samplesFromDirectory(
             oneUnlessEmpty(schemaSources) + oneUnlessEmpty(graphQLSources) >
             1
         ) {
-            return messageError("DriverCannotMixNonJSONInputs", { dir: dir });
+            return messageError("DriverCannotMixNonJSONInputs", { dir });
         }
 
         if (jsonSamples.length > 0) {
@@ -352,7 +352,7 @@ function inferCLIOptions(
     const options: CLIOptions = {
         src: opts.src ?? [],
         srcUrls: opts.srcUrls,
-        srcLang: srcLang,
+        srcLang,
         lang: language.name as LanguageName,
         topLevel: opts.topLevel ?? inferTopLevel(opts),
         noRender: !!opts.noRender,

--- a/src/index.ts
+++ b/src/index.ts
@@ -990,7 +990,7 @@ export async function makeQuicktypeOptions(
     let leadingComments: string[] | undefined = undefined;
     let fixedTopLevels = false;
     switch (options.srcLang) {
-        case "graphql":
+        case "graphql": {
             let schemaString: string | undefined = undefined;
             let wroteSchemaToFile = false;
             if (options.graphqlIntrospect !== undefined) {
@@ -1047,6 +1047,7 @@ export async function makeQuicktypeOptions(
 
             sources = gqlSources;
             break;
+        }
         case "json":
         case "schema":
             sources = await getSources(options);

--- a/src/index.ts
+++ b/src/index.ts
@@ -120,7 +120,8 @@ async function sourceFromFileOrUrlArray(
 
 function typeNameFromFilename(filename: string): string {
     const name = path.basename(filename);
-    return name.substring(0, name.lastIndexOf("."));
+    const extIndex = name.lastIndexOf(".");
+    return extIndex === -1 ? "" : name.slice(0, extIndex);
 }
 
 async function samplesFromDirectory(

--- a/src/index.ts
+++ b/src/index.ts
@@ -879,10 +879,10 @@ async function getSources(options: CLIOptions): Promise<TypeSource[]> {
 }
 
 function makeTypeScriptSource(fileNames: string[]): SchemaTypeSource {
-    return Object.assign(
-        { kind: "schema" },
-        schemaForTypeScriptSources(fileNames),
-    ) as SchemaTypeSource;
+    return {
+        kind: "schema",
+        ...schemaForTypeScriptSources(fileNames),
+    } as SchemaTypeSource;
 }
 
 export function jsonInputForTargetLanguage(
@@ -1064,12 +1064,10 @@ export async function makeQuicktypeOptions(
                         collectionFile,
                     );
                 for (const src of postmanSources) {
-                    sources.push(
-                        Object.assign(
-                            { kind: "json" },
-                            stringSourceDataToStreamSourceData(src),
-                        ) as JSONTypeSource,
-                    );
+                    sources.push({
+                        kind: "json",
+                        ...stringSourceDataToStreamSourceData(src),
+                    } as JSONTypeSource);
                 }
 
                 if (postmanSources.length > 1) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -395,7 +395,7 @@ function negatedInferenceFlagName(name: string): string {
         name = name.slice(prefix.length);
     }
 
-    return "no" + capitalize(name);
+    return `no${capitalize(name)}`;
 }
 
 function dashedFromCamelCase(name: string): string {
@@ -470,7 +470,7 @@ function makeOptionDefinitions(
             return {
                 name: dashedFromCamelCase(negatedInferenceFlagName(name)),
                 optionType: "boolean" as const,
-                description: flag.negationDescription + ".",
+                description: `${flag.negationDescription}.`,
                 kind: "cli" as const,
             };
         }).values(),

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -159,9 +159,7 @@ export abstract class Fixture {
         return this.name === name;
     }
 
-    async setup(): Promise<void> {
-        return;
-    }
+    async setup(): Promise<void> {}
 
     abstract getSamples(sources: string[]): {
         priority: Sample[];
@@ -1110,9 +1108,7 @@ class CommentInjectionTreeSitterFixture extends Fixture {
         return this.name === name;
     }
 
-    async setup(): Promise<void> {
-        return;
-    }
+    async setup(): Promise<void> {}
 
     getSamples(sources: string[]): { priority: Sample[]; others: Sample[] } {
         const commentInjectionSamples = [

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -216,10 +216,6 @@ export abstract class Fixture {
 }
 
 abstract class LanguageFixture extends Fixture {
-    constructor(language: languages.Language) {
-        super(language);
-    }
-
     async setup() {
         const setupCommand = this.language.setupCommand;
         if (!setupCommand || ONLY_OUTPUT) {

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -103,7 +103,7 @@ function runEnvForLanguage(
     const newEnv = Object.assign({}, process.env);
 
     for (const option of Object.keys(additionalRendererOptions)) {
-        newEnv["QUICKTYPE_" + option.toUpperCase().replace("-", "_")] = (
+        newEnv[`QUICKTYPE_${option.toUpperCase().replace("-", "_")}`] = (
             additionalRendererOptions[
                 option as keyof typeof additionalRendererOptions
             ] as Option<string, unknown>

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -100,7 +100,7 @@ function additionalTestFiles(
 function runEnvForLanguage(
     additionalRendererOptions: RendererOptions,
 ): NodeJS.ProcessEnv {
-    const newEnv = Object.assign({}, process.env);
+    const newEnv = { ...process.env };
 
     for (const option of Object.keys(additionalRendererOptions)) {
         newEnv[`QUICKTYPE_${option.toUpperCase().replace("-", "_")}`] = (

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -867,6 +867,7 @@ const commentInjectionNestedCommentSchema =
 const commentInjectionEnumNestedCommentSchema =
     "test/inputs/schema/comment-injection-enum-nested-comment.schema";
 const treeSitterWasm = (filename: string): string =>
+    // biome-ignore lint/correctness/noGlobalDirnameFilename: the test harness runs as CommonJS
     path.join(__dirname, "tree-sitter-wasms", filename);
 
 const commentInjectionTreeSitterTargets: TreeSitterTarget[] = [

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -1147,6 +1147,7 @@ class CommentInjectionTreeSitterFixture extends Fixture {
     private readonly _treeSitterLanguages = new Map<string, unknown>();
 
     private async loadTreeSitterLanguage(
+        // biome-ignore lint/suspicious/noExplicitAny: web-tree-sitter is loaded dynamically without types
         TreeSitter: any,
         wasmModule: string,
     ): Promise<unknown> {
@@ -1161,6 +1162,7 @@ class CommentInjectionTreeSitterFixture extends Fixture {
     }
 
     private async parseGeneratedFiles(
+        // biome-ignore lint/suspicious/noExplicitAny: web-tree-sitter is loaded dynamically without types
         TreeSitter: any,
         target: TreeSitterTarget,
         generatedFiles: string[],
@@ -1183,6 +1185,7 @@ class CommentInjectionTreeSitterFixture extends Fixture {
             const tree = parser.parse(source);
             const problems: TreeSitterParseProblem[] = [];
 
+            // biome-ignore lint/suspicious/noExplicitAny: web-tree-sitter is loaded dynamically without types
             function visit(node: any): void {
                 if (
                     node.type === "ERROR" ||

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1,6 +1,6 @@
 import type { LanguageName } from "quicktype-core";
 
-import * as process from "process";
+import * as process from "node:process";
 // @ts-ignore
 import type { RendererOptions } from "../dist/quicktype-core/Run";
 

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -700,7 +700,7 @@ export const ElmLanguage: Language = {
 export const SwiftLanguage: Language = {
     name: "swift",
     base: "test/fixtures/swift",
-    compileCommand: `swiftc -o quicktype main.swift quicktype.swift`,
+    compileCommand: "swiftc -o quicktype main.swift quicktype.swift",
     runCommand(sample: string) {
         return `./quicktype "${sample}"`;
     },
@@ -779,7 +779,7 @@ export const SwiftLanguage: Language = {
 export const ObjectiveCLanguage: Language = {
     name: "objective-c",
     base: "test/fixtures/objective-c",
-    compileCommand: `clang -Werror -framework Foundation *.m -o test`,
+    compileCommand: "clang -Werror -framework Foundation *.m -o test",
     runCommand(sample: string) {
         return `cp "${sample}" sample.json && ./test sample.json`;
     },

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -821,7 +821,7 @@ export const TypeScriptLanguage: Language = {
     // in the generated code
     compileCommand: "tsc -p .",
     runCommand(sample: string) {
-        return `tsx main.ts \"${sample}\"`;
+        return `tsx main.ts "${sample}"`;
     },
     diffViaSchema: true,
     skipDiffViaSchema: [
@@ -865,7 +865,7 @@ export const JavaScriptLanguage: Language = {
     name: "javascript",
     base: "test/fixtures/javascript",
     runCommand(sample: string) {
-        return `node main.js \"${sample}\"`;
+        return `node main.js "${sample}"`;
     },
     // FIXME: enable once TypeScript supports unions
     diffViaSchema: false,
@@ -891,7 +891,7 @@ export const JavaScriptPropTypesLanguage: Language = {
     base: "test/fixtures/javascript-prop-types",
     setupCommand: "npm install",
     runCommand(sample: string) {
-        return `node main.js \"${sample}\"`;
+        return `node main.js "${sample}"`;
     },
     copyInput: true,
     diffViaSchema: false,
@@ -922,7 +922,7 @@ export const FlowLanguage: Language = {
     name: "flow",
     base: "test/fixtures/flow",
     runCommand(sample: string) {
-        return `flow check 1>&2 && flow-node main.js \"${sample}\"`;
+        return `flow check 1>&2 && flow-node main.js "${sample}"`;
     },
     diffViaSchema: false,
     skipDiffViaSchema: [],
@@ -1272,7 +1272,7 @@ export const DartLanguage: Language = {
     name: "dart",
     base: "test/fixtures/dart",
     runCommand(sample: string) {
-        return `dart --enable-experiment=non-nullable parser.dart \"${sample}\"`;
+        return `dart --enable-experiment=non-nullable parser.dart "${sample}"`;
     },
     diffViaSchema: false,
     skipDiffViaSchema: [],
@@ -1330,7 +1330,7 @@ export const PikeLanguage: Language = {
     name: "pike",
     base: "test/fixtures/pike",
     runCommand(sample: string) {
-        return `pike main.pike \"${sample}\"`;
+        return `pike main.pike "${sample}"`;
     },
     diffViaSchema: false,
     skipDiffViaSchema: [],
@@ -1469,7 +1469,7 @@ export const HaskellLanguage: Language = {
 export const PHPLanguage: Language = {
     name: "php",
     base: "test/fixtures/php",
-    runCommand: (sample) => `php main.php \"${sample}\"`,
+    runCommand: (sample) => `php main.php "${sample}"`,
     diffViaSchema: false,
     skipDiffViaSchema: [],
     allowMissingNull: true,

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1,7 +1,7 @@
 import type { LanguageName } from "quicktype-core";
 
 import * as process from "node:process";
-// @ts-ignore
+// @ts-expect-error: ../dist only exists after the root package is built
 import type { RendererOptions } from "../dist/quicktype-core/Run";
 
 const easySampleJSONs = [

--- a/test/lib/deepEquals.ts
+++ b/test/lib/deepEquals.ts
@@ -145,13 +145,11 @@ export default function deepEquals(
     for (const p of yKeys) {
         // We allow properties in y that aren't present in x
         // so long as they're null.
-        if (xKeys.indexOf(p) < 0) {
-            if (y[p] !== null) {
-                console.error(
-                    `Non-null property ${p} is not expected at path ${pathToString(path)}.`,
-                );
-                return false;
-            }
+        if (xKeys.indexOf(p) < 0 && y[p] !== null) {
+            console.error(
+                `Non-null property ${p} is not expected at path ${pathToString(path)}.`,
+            );
+            return false;
         }
     }
 

--- a/test/lib/deepEquals.ts
+++ b/test/lib/deepEquals.ts
@@ -33,7 +33,9 @@ function momentsEqual(x: Moment, y: Moment, isTime: boolean): boolean {
 
 // https://stackoverflow.com/questions/1068834/object-comparison-in-javascript
 export default function deepEquals(
+    // biome-ignore lint/suspicious/noExplicitAny: compares arbitrary parsed JSON values
     x: any,
+    // biome-ignore lint/suspicious/noExplicitAny: compares arbitrary parsed JSON values
     y: any,
     assumeStringsEqual: boolean,
     relax: ComparisonRelaxations,

--- a/test/lib/deepEquals.ts
+++ b/test/lib/deepEquals.ts
@@ -6,11 +6,6 @@ function pathToString(path: string[]): string {
     return `.${path.join(".")}`;
 }
 
-declare namespace Math {
-    // TypeScript cannot find this function
-    function fround(n: number): number;
-}
-
 function tryParseMoment(s: string): [Moment | undefined, boolean] {
     let m = moment(s);
     if (m.isValid()) return [m, false];

--- a/test/lib/deepEquals.ts
+++ b/test/lib/deepEquals.ts
@@ -3,7 +3,7 @@ import type { Moment } from "moment";
 import type { ComparisonRelaxations } from "../utils";
 
 function pathToString(path: string[]): string {
-    return "." + path.join(".");
+    return `.${path.join(".")}`;
 }
 
 declare namespace Math {

--- a/test/lib/deepEquals.ts
+++ b/test/lib/deepEquals.ts
@@ -77,7 +77,7 @@ export default function deepEquals(
         return false;
     }
     if (
-        !!relax.allowStringifiedIntegers &&
+        relax.allowStringifiedIntegers &&
         typeof x === "string" &&
         typeof y === "number"
     ) {
@@ -155,7 +155,7 @@ export default function deepEquals(
 
     for (const p of xKeys) {
         if (yKeys.indexOf(p) < 0) {
-            if (!!relax.allowMissingNull && x[p] === null) {
+            if (relax.allowMissingNull && x[p] === null) {
                 continue;
             }
             console.error(

--- a/test/lib/deepEquals.ts
+++ b/test/lib/deepEquals.ts
@@ -42,7 +42,7 @@ export default function deepEquals(
     // remember that NaN === NaN returns false
     // and isNaN(undefined) returns true
     if (typeof x === "number" && typeof y === "number") {
-        if (isNaN(x) && isNaN(y)) {
+        if (Number.isNaN(x) && Number.isNaN(y)) {
             return true;
         }
         // because sometimes Newtonsoft.JSON is not exact

--- a/test/lib/multicore.ts
+++ b/test/lib/multicore.ts
@@ -61,11 +61,11 @@ export async function inParallel<Item, Result, Acc>(
                 await map(item, i);
             }
         } else {
-            _.range(workers).forEach((i) =>
+            _.range(workers).forEach((i) => {
                 cluster.fork({
                     worker: i,
-                }),
-            );
+                });
+            });
         }
     } else {
         // Setup a worker

--- a/test/lib/multicore.ts
+++ b/test/lib/multicore.ts
@@ -7,8 +7,8 @@ const WORKERS = ["👷🏻", "👷🏼", "👷🏽", "👷🏾", "👷🏿"];
 export interface ParallelArgs<Item, Result, Acc> {
     queue: Item[];
     workers: number;
-    setup(): Promise<Acc>;
-    map(item: Item, index: number): Promise<Result>;
+    setup: () => Promise<Acc>;
+    map: (item: Item, index: number) => Promise<Result>;
 }
 
 function randomPick<T>(arr: T[]): T {

--- a/test/lib/multicore.ts
+++ b/test/lib/multicore.ts
@@ -1,5 +1,5 @@
-import cluster from "cluster";
-import process from "process";
+import cluster from "node:cluster";
+import process from "node:process";
 import * as _ from "lodash";
 
 const WORKERS = ["👷🏻", "👷🏼", "👷🏽", "👷🏾", "👷🏿"];

--- a/test/release-version.ts
+++ b/test/release-version.ts
@@ -1,4 +1,4 @@
-import { strict as assert } from "node:assert";
+import { strict as assert } from "node:assert/strict";
 import {
     mkdirSync,
     mkdtempSync,

--- a/test/test.ts
+++ b/test/test.ts
@@ -6,6 +6,7 @@ import { type Fixture, allFixtures } from "./fixtures";
 import { inParallel } from "./lib/multicore";
 import { type Sample, execAsync } from "./utils";
 
+// biome-ignore lint/style/useExplicitLengthCheck: length is used as a value here, not a boolean
 const CPUs = Number.parseInt(process.env.CPUs || "0", 10) || os.cpus().length;
 
 //////////////////////////////////////

--- a/test/unit/java-acronym-names.test.ts
+++ b/test/unit/java-acronym-names.test.ts
@@ -54,6 +54,7 @@ async function javaEnumConstantIdentifier(
         new RegExp(`case (\\w+): return "${enumValue}";`),
     );
 
+    // biome-ignore lint/suspicious/noMisplacedAssertion: helper is only called from within tests
     expect(match, `generated Java output:\n${output}`).not.toBeNull();
     return match?.[1] ?? "";
 }

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -96,9 +96,9 @@ export function execAsync(
 }
 
 async function time<T>(work: () => Promise<T>): Promise<[T, number]> {
-    const start = +new Date();
+    const start = Date.now();
     const result = await work();
-    const end = +new Date();
+    const end = Date.now();
     return [result, end - start];
 }
 


### PR DESCRIPTION
# Adopt Biome lint rules

This PR turns Biome's linter on for real, on top of the formatter-only setup from #2923, and adopts rules deliberately:

1. **First commit** enables the linter with the `recommended` preset. Of the 218 recommended rules, 30 reported diagnostics on the codebase; those were temporarily set to `"off"` so the commit lands with lint green and zero code changes.
2. **One commit per rule** then re-enables each of those 30 and fixes all of its violations — except three that misfit the codebase (see the rejected table).
3. The **non-recommended rules** of Biome 2.5 were then evaluated group by group (correctness, complexity, performance, security, style, suspicious): 29 more rules were adopted with fixes, and 27 already-clean guard rules were enabled in per-group batches. The `nursery` group was skipped as unstable, and `a11y` plus the framework-specific rules (React/Vue/Qwik/Solid/Next/DOM/CSS/GraphQL) don't apply to this library/CLI.

Every commit keeps `npm run lint`, `npm run build`, and the Vitest unit suite green. Lint fixes are behavior-preserving; where a fix would have been risky or wrong, a targeted `biome-ignore` suppression with a real explanation (or a scoped config override) is used instead. Notably, `noUndeclaredDependencies` caught a genuine issue: the CLI imported `wordwrap` without declaring it, relying on hoisting from quicktype-core — it is now a declared dependency.

**Result: 270 rules active** (215 recommended + 55 opted-in), 3 recommended rules off, 3 scoped overrides.

## Adopted rules (with violations fixed)

### Recommended preset (re-enabled one by one)

| Rule | Violations fixed | Notes |
|---|---|---|
| correctness/noUnusedImports | 1 | unused lodash import |
| correctness/noUnusedVariables | 5 | unused catch bindings → optional catch |
| correctness/useParseIntRadix | 3 | single-char parses, radix 10 |
| correctness/noSwitchDeclarations | 20 | case blocks scoped |
| complexity/noBannedTypes | 13 | `{}` → `Record<string, never>` |
| complexity/noExtraBooleanCast | 2 | redundant `!!` |
| complexity/noUselessConstructor | 7 | super-forwarding constructors removed |
| complexity/noUselessContinue | 1 | |
| complexity/noUselessSwitchCase | 1 | case adjacent to identical default |
| complexity/noUselessTernary | 1 | `x ? false : true` → `!x` |
| complexity/noUselessUndefinedInitialization | 24 | `= undefined` initializers |
| complexity/useDateNow | 2 | `+new Date()` → `Date.now()` |
| complexity/useOptionalChain | 1 | |
| style/noNonNullAssertion | 2 | replaced `!` with narrowing via destructured consts |
| style/useConst | 1 | |
| style/useExponentiationOperator | 6 | `Math.pow` → `**` |
| style/useNodejsImportProtocol | 6 | `node:` prefix; quicktype-core exempted via override (its `browser` field only remaps bare specifiers — enforced by `core-package.test.ts`) |
| style/useTemplate | 40 | concatenation → template literals, escapes hand-verified |
| suspicious/noExplicitAny | 25 | 6 became `unknown`; deliberate anys (heterogeneous maps, vendored get-stream, untyped tree-sitter) suppressed with reasons |
| suspicious/noGlobalIsNan | 6 | all call sites already number-typed |
| suspicious/noImplicitAnyLet | 3 | explicit annotations |
| suspicious/noPrototypeBuiltins | 2 | already-safe `.call` sites suppressed; `Object.hasOwn` unavailable under core's es6 lib |
| suspicious/noShadowRestrictedNames | 2 | `toString` param renamed; collection-utils `hasOwnProperty` import suppressed |
| suspicious/noTsIgnore | 1 | → `@ts-expect-error` with explanation |
| suspicious/noUselessEscapeInString | 7 | `\"` in template literals |
| suspicious/useIsArray | 1 | `instanceof Array` → `Array.isArray` |
| suspicious/useIterableCallbackReturn | 19 | forEach expression arrows → statement bodies |

### Non-recommended rules (opted in, violations fixed)

| Rule | Violations fixed | Notes |
|---|---|---|
| correctness/noUndeclaredDependencies | 2 | **real catch**: `wordwrap` now declared for the CLI; `vscode` host module suppressed |
| correctness/noGlobalDirnameFilename | 1 | protects the ESM dual build; CJS test harness suppressed |
| complexity/noUselessReturn | 24 | trailing `return;` |
| style/useCollapsedElseIf | 16 | one site hand-collapsed to keep a comment |
| style/useCollapsedIf | 5 | one site hand-collapsed to keep a comment |
| style/useThrowNewError | 15 | `throw Error(...)` → `throw new Error(...)` |
| style/useConsistentBuiltinInstantiation | 0 | overlapped entirely with useThrowNewError |
| style/useObjectSpread | 17 | `Object.assign({}, ...)` → spread; 3 sites needed type annotations |
| style/noYodaExpression | 7 | |
| style/noSubstr | 11 | `substring` → `slice`; one site got an explicit guard to preserve edge-case behavior |
| style/useExplicitLengthCheck | 11 | one numeric-fallback site suppressed (autofix would have produced a boolean) |
| style/noMultiAssign | 9 | chains split |
| style/useConsistentObjectDefinitions | 6 | shorthand |
| style/useForOf | 2 | replaced eslint-disabled index loops |
| style/noUnusedTemplateLiteral | 2 | |
| style/useShorthandAssign | 1 | |
| style/noInferrableTypes | 1 | |
| style/useDefaultParameterLast | 2 | both sites are exported API (`DartRenderer`'s protected dynamic-expression methods), so per review the defaults are kept with targeted suppressions — the rule now only guards new code |
| style/useConsistentMethodSignatures | 2 | property-style interface signatures |
| style/useUnifiedTypeSignatures | 1 | compose() overloads unified |
| style/noNamespace | 1 | obsolete `declare namespace Math` (fround is in ES2015 lib) |
| style/useNodeAssertStrict | 1 | same strict assert object |
| style/useReadonlyClassProperties | 13 | type-level only |
| suspicious/noEqualsToNull | 1 | value is `Type \| null`, never undefined |
| suspicious/noUnusedExpressions | 2 | deliberate `satisfies` checks suppressed |
| suspicious/useArraySortCompare | 3 | string sorts where UTF-16 order is intended, suppressed |
| suspicious/noMisplacedAssertion | 10 | script-style `test/release-version.ts` exempted via override; one test helper suppressed |
| suspicious/noShadow | 29 | one real shadow renamed; CJSONRenderer.ts exempted (28 same-named nested emit-lambda params; bulk rename too risky) |

### Already-clean guard rules enabled (no violations)

correctness: `noUnusedInstantiation`, `useSingleJsDocAsterisk` · complexity: `noDivRegex`, `noUselessCatchBinding`, `noUselessStringConcat`, `useArrayFind`, `useWhile`, `noRedundantDefaultExport`, `noExcessiveNestedTestSuites` · performance: `noDelete` · style: `useThrowOnlyError`, `useTrimStartEnd`, `useSymbolDescription`, `useSpreadOverApply`, `useNumberNamespace`, `useGlobalThis`, `useErrorCause` · suspicious: `noConstantBinaryExpressions`, `noVar`, `noFocusedTests`, `noSkippedTests`, `noReturnAssign`, `noDuplicateTestHooks`, `noDeprecatedImports`, `noDuplicateDependencies`, `useErrorMessage`, `noEmptySource`

## Rejected / skipped rules

### Recommended rules kept off

| Rule | Violations | Rationale |
|---|---|---|
| suspicious/noTemplateCurlyInString | 48 | quicktype's error messages use `${placeholder}` templates in plain strings by design (`Messages.ts`, substituted at runtime by `messageError`), and the Kotlin renderers emit Kotlin's own `${}` interpolation syntax. The rule flags the codebase's intended core patterns wholesale. |
| correctness/noVoidTypeReturn | 13 | rejected in review: the owner prefers `return panic(...)` in void functions — the `return` makes the control-flow termination explicit at the call site. Initially adopted, then reverted. |
| correctness/noConstructorReturn | 6 | rejected in review, same idiom objection as noVoidTypeReturn: all six violations were `return panic(...)` in a constructor. Reverting restored the `@ts-expect-error` on `queryType` that the fix had made obsolete. |

### Non-recommended rules not adopted (off by default; rationale)

| Rule | Violations | Rationale |
|---|---|---|
| style/noUselessElse | 20 | rejected in review: the owner prefers explicit else blocks after returning branches over flattened straight-line code. Initially adopted, then reverted; kept explicitly `"off"`. |
| suspicious/noEmptyBlockStatements | 25 | empty method bodies are deliberate no-op default hooks throughout the renderer class hierarchy |
| suspicious/useAwait | 7 | async methods implement async-by-contract interfaces (`Input.addSource` etc.) with sync bodies |
| suspicious/noParametersOnlyUsedInRecursion | 5 | the fix removes parameters from protected renderer API signatures |
| suspicious/noUnnecessaryConditions | 97 | flags defensive checks; high false-positive rate |
| suspicious/noConsole | 71 | the CLI writes to the console by design |
| suspicious/noBitwiseOperators | 56 | hashing/Markov/Mersenne-Twister code uses bitwise math deliberately |
| suspicious/noUndeclaredEnvVars | — | CLI/test harness read arbitrary env vars by design |
| complexity/noVoid | 5 | `void promise` deliberately marks fire-and-forget calls |
| complexity/noImplicitCoercions | 11 | `+str` / `!!x` are deliberate idioms |
| complexity/noForEach | 41 | forEach is used pervasively; useIterableCallbackReturn guards actual misuse |
| complexity/noExcessiveCognitiveComplexity, noExcessiveLinesPerFunction, useMaxParams | 105/273/70 | arbitrary size thresholds; language renderers are legitimately large |
| complexity/useSimplifiedLogicExpression | 20 | its De Morgan rewrites reduce readability |
| correctness/noUndeclaredVariables, noUnresolvedImports | 0/12 | redundant with the TypeScript compiler |
| correctness/useImportExtensions | 1189 | extension policy is owned by TS NodeNext resolution |
| correctness/noNodejsModules | 38 | it's a Node CLI; core's browser-compat is guarded by its own test |
| performance/noAwaitInLoops | 14 | sequential awaits are intentional (ordering, IO) |
| performance/noNamespaceImport, noBarrelFile, noReExportAll | 39/31/35 | `import *` and barrel index files are the package structure |
| performance/useTopLevelRegex | 20 | hoisting regexes risks shared `lastIndex` state and hurts locality |
| security/noSecrets | 121 | entropy heuristic false-positives on code-generation strings and fixtures |
| security/noDangerouslySetInnerHtml* | — | DOM/JSX only, N/A |
| style/noMagicNumbers | 1328 | absurd churn for a code generator full of structural constants |
| style/useConsistentMemberAccessibility | 949 | repo convention is explicit `public`; the rule's default demands the opposite |
| style/noTernary, useBlockStatements, noContinue, noNestedTernary, noEnum, noIncrementDecrement, noNegationElse | 484/437/46/18/18/97/76 | ban or churn idioms the codebase uses deliberately |
| style/useNamingConvention | 424 | underscore-prefixed privates and renderer naming clash with the rule |
| style/useNumericSeparators | 195 | churn incl. vendored PRNG constants |
| style/noParameterProperties | 154 | constructor parameter properties are a core idiom here |
| style/useDestructuring, useConsistentArrowReturn | 99/41 | mechanical churn, marginal benefit |
| style/noParameterAssign | 75 | parameter normalization (opts defaulting) is deliberate |
| style/useExportsLast, useFilenamingConvention, noExcessiveLinesPerFile, noExcessiveClassesPerFile | 61/47/64/26 | structural churn / arbitrary thresholds |
| style/noProcessEnv, correctness/noProcessGlobal | 16/43 | CLI and test harness use process/env by design |
| style/useConsistentArrayType, useConsistentTypeDefinitions | 33/10 | both forms used deliberately; pure churn |
| style/useAtIndex | 3 | `.at()` is not in quicktype-core's es6 lib |
| style/noCommonJs | 5 | build/test scripts legitimately use require |
| style/noDefaultExport | 3 | existing default exports are module API |
| style/noUselessUndefined | 109 | explicit `undefined` returns/arguments are used deliberately with strict optional typing |
| nursery group | — | skipped as unstable |
| a11y group + React/Vue/Qwik/Solid/Next/GraphQL/CSS rules | — | no DOM/JSX/framework code in this repo |

## Verification

- `npm run lint` exits 0 with zero diagnostics
- `npm run build` (all workspaces + CLI) succeeds
- `npm run test:unit` — 70/70 Vitest tests pass
- after every one of the 68 commits, all three of the above were green

🤖 Generated with [Claude Code](https://claude.com/claude-code)


