### PR TITLE
CI: run once-only extras on Node 24; add Node 22 support leg

### DIFF
--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -11,14 +11,14 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                node-version: ["20", "24"]
+                node-version: ["20", "22", "24"]
         steps:
             - uses: actions/checkout@v3
             - uses: ./.github/workflows/setup
               with:
                   node-version: ${{ matrix.node-version }}
             - name: Check formatting (Biome)
-              if: ${{ matrix.node-version == '20' }}
+              if: ${{ matrix.node-version == '24' }}
               run: npm run lint
             - run: npm run test:unit
             - run: node dist/index.js --version


### PR DESCRIPTION
## Principle

The Node 20 and 22 legs of the `build` matrix should exist for one reason only: verifying that quicktype supports those Node versions. Anything that isn't a version-support check — one-time repo hygiene like linting — belongs on Node 24, the current/primary version we build and publish with (`.nvmrc` is v24.6.0).

## Changes

- **New Node 22 leg**: the matrix is now `["20", "22", "24"]`, so Node 22 support is actually verified. Every leg runs build, `npm run test:unit`, and `node dist/index.js --version` — those are the support checks.
- **Biome lint moved to Node 24** (`if: matrix.node-version == '24'`): lint results don't depend on the Node version, so running it once on the primary version is enough.
- **Representative fixtures stay on Node 20**: running fixtures on the minimum supported version *is* a version-support check, so it keeps its gate.

No other workflow has Node-20-gated steps (checked `.github/workflows/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)