### PR TITLE
fix(swift): emit JSONNull hash(into:) by default

### DIFF
--- a/packages/quicktype-core/src/language/Swift/SwiftRenderer.ts
+++ b/packages/quicktype-core/src/language/Swift/SwiftRenderer.ts
@@ -1185,12 +1185,10 @@ encoder.dateEncodingStrategy = .formatted(formatter)`);
 			return 0
 	}`);
 
-                if (this._options.swift5Support) {
-                    this.ensureBlankLine();
-                    this.emitMultiline(`    public func hash(into hasher: inout Hasher) {
+                this.ensureBlankLine();
+                this.emitMultiline(`    public func hash(into hasher: inout Hasher) {
 			// No-op
 	}`);
-                }
             }
 
             this.ensureBlankLine();

--- a/test/unit/swift-json-null-hashable.test.ts
+++ b/test/unit/swift-json-null-hashable.test.ts
@@ -1,0 +1,27 @@
+import {
+    InputData,
+    JSONSchemaInput,
+    quicktype,
+} from "../../packages/quicktype-core/src/index.js";
+import { expect, test } from "vitest";
+
+const schema = JSON.stringify({
+    type: "object",
+    properties: {
+        value: {},
+    },
+    required: ["value"],
+});
+
+test("emits hash(into:) for JSONNull by default", async () => {
+    const schemaInput = new JSONSchemaInput(undefined);
+    await schemaInput.addSource({ name: "TopLevel", schema });
+
+    const inputData = new InputData();
+    inputData.addInput(schemaInput);
+
+    const result = await quicktype({ inputData, lang: "swift" });
+    const output = result.lines.join("\n");
+
+    expect(output).toContain("public func hash(into hasher: inout Hasher)");
+});


### PR DESCRIPTION
## Description

Emit JSONNull.hash(into:) in default Swift output and add a focused generated-output regression for the Swift 5.9 deprecation warning.

## Related Issue

Fixes #2423

## Motivation and Context

Default Swift output emitted only the deprecated `hashValue` protocol implementation unless `--swift-5-support` was enabled.

## Previous Behaviour / Output

Default JSONNull output omitted `hash(into:)`, which produced the reported Swift 5.9 Hashable deprecation warning.

## New Behaviour / Output

Default JSONNull output includes `hash(into:)` without requiring a renderer option. The Objective-C-support branch is unchanged.

## How Has This Been Tested?

- `npm run test:unit -- test/unit/swift-json-null-hashable.test.ts` — passed in a network-isolated container.

## Screenshots (if appropriate)

Not applicable.

---
AI assistance was used; I reviewed and own this change.

Northset self-run record for commit `7a233c5bc4d1`: [M-019 receipt](https://northset-oss.github.io/verification-pilot/#M-019).
It records the declared checks and published bundle provenance.
Contributor self-run; not maintainer verification.
