### PR TITLE
fix(cli): don't render a 'string' placeholder for boolean flags in --help

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -581,6 +581,20 @@ function makeOptionDefinitions(
     return beforeLang.concat(lang, afterLang, inference, afterInference);
 }
 
+// command-line-usage defaults to a "string" type placeholder for any option
+// definition that has neither a `type` function nor a `typeLabel`.  Map our
+// `optionType` to a `type` function (like `parseOptions` does for
+// command-line-args) so boolean flags are rendered without a bogus value
+// placeholder, while options that take values keep their explicit `typeLabel`.
+function optionDefinitionsForUsage(
+    definitions: OptionDefinition[],
+): OptionDefinition[] {
+    return definitions.map((def) => ({
+        ...def,
+        type: def.optionType === "boolean" ? Boolean : String,
+    }));
+}
+
 interface ColumnDefinition {
     name: string;
     padding?: { left: string; right: string };
@@ -638,7 +652,9 @@ function makeSectionsBeforeRenderers(
         },
         {
             header: "Options",
-            optionList: makeOptionDefinitions(targetLanguages),
+            optionList: optionDefinitionsForUsage(
+                makeOptionDefinitions(targetLanguages),
+            ),
             hide: ["no-render", "build-markov-chain"],
             tableOptions: tableOptionsForOptions,
         },
@@ -786,7 +802,7 @@ function usage(targetLanguages: readonly TargetLanguage[]): void {
 
         rendererSections.push({
             header: `Options for ${language.displayName}`,
-            optionList: definitions,
+            optionList: optionDefinitionsForUsage(definitions),
             tableOptions: tableOptionsForOptions,
         });
     }


### PR DESCRIPTION
## Problem

Every boolean flag in `quicktype --help` was displayed with a bogus `string` type placeholder, as if it took a string argument:

```
 --no-maps string                Don't infer maps, always use classes.
 --quiet string                  Don't show issues in the generated code.
 -h, --help string               Get some help.
 --[no-]just-types string        Classes only (off by default)
```

## Cause

command-line-usage derives an option's type label as `definition.type ? definition.type.name.toLowerCase() : 'string'`, and only suppresses the label when the type is `Boolean`. Our `OptionDefinition`s carry an `optionType` field instead of a `type` function; `parseOptions` maps `optionType` to `Boolean`/`String` before calling command-line-args, but the `usage()` path passed the raw definitions straight to command-line-usage, so every option without an explicit `typeLabel` fell back to `string`.

## Fix

Add `optionDefinitionsForUsage()` in `src/index.ts`, which applies the same `optionType` → `type` mapping for the help sections (both the global options list and the per-language renderer option lists). Boolean flags now render with no placeholder; options that take values keep their explicit `typeLabel` (`FILE`, `NewtonSoft|SystemTextJson`, ...), since command-line-usage prefers `typeLabel` when set.

## After

```
 -o, --out FILE                  The output file. Determines --lang and --top-level.
 --no-maps                       Don't infer maps, always use classes.
 --quiet                         Don't show issues in the generated code.
 -h, --help                      Get some help.
```

and for `--lang cs --help`:

```
 --framework NewtonSoft|SystemTextJson   Serialization framework
 --[no-]virtual                          Generate virtual properties (off by default)
 --[no-]just-types                       Classes only (off by default)
```

## Verification

- `npm run build` passes; `vitest run` — 71 tests, all passing; biome clean.
- Manually inspected `node dist/index.js --help` and `--lang cs --help`: no boolean flag shows a placeholder, all valued flags keep theirs.
- Option parsing is untouched (it already did this mapping): `--quiet`, `--just-types`, and `--no-maps` still work.

Fixes #2932

🤖 Generated with [Claude Code](https://claude.com/claude-code)