### PR TITLE
fix(core): throw a clear error when addSource gets an empty samples array

### DIFF
--- a/packages/quicktype-core/src/Messages.ts
+++ b/packages/quicktype-core/src/Messages.ts
@@ -125,6 +125,7 @@ export type ErrorProperties =
           properties: { dir: string };
       }
     | { kind: "DriverCannotMixNonJSONInputs"; properties: { dir: string } }
+    | { kind: "DriverNoSamplesForTopLevel"; properties: { name: string } }
     | { kind: "DriverUnknownDebugOption"; properties: { option: string } }
     | { kind: "DriverNoLanguageOrExtension"; properties: Record<string, never> }
     | { kind: "DriverCLIOptionParsingFailed"; properties: { message: string } }
@@ -239,6 +240,7 @@ const errorMessages: ErrorMessages = {
         "Cannot mix JSON samples with JSON Schems, GraphQL, or TypeScript in input subdirectory ${dir}",
     DriverCannotMixNonJSONInputs:
         "Cannot mix JSON Schema, GraphQL, and TypeScript in an input subdirectory ${dir}",
+    DriverNoSamplesForTopLevel: "No JSON samples given for top-level ${name}",
     DriverUnknownDebugOption: "Unknown debug option ${option}",
     DriverNoLanguageOrExtension:
         "Please specify a language (--lang) or an output file extension",

--- a/packages/quicktype-core/src/input/Inputs.ts
+++ b/packages/quicktype-core/src/input/Inputs.ts
@@ -120,6 +120,10 @@ export class JSONInput<T> implements Input<JSONSourceData<T>> {
 
     public async addSource(source: JSONSourceData<T>): Promise<void> {
         const { name, samples, description } = source;
+        if (samples.length === 0) {
+            return messageError("DriverNoSamplesForTopLevel", { name });
+        }
+
         try {
             const values = await arrayMapSync(
                 samples,
@@ -133,6 +137,10 @@ export class JSONInput<T> implements Input<JSONSourceData<T>> {
 
     public addSourceSync(source: JSONSourceData<T>): void {
         const { name, samples, description } = source;
+        if (samples.length === 0) {
+            return messageError("DriverNoSamplesForTopLevel", { name });
+        }
+
         try {
             const values = samples.map((s) =>
                 this._compressedJSON.parseSync(s),

--- a/test/unit/empty-json-samples.test.ts
+++ b/test/unit/empty-json-samples.test.ts
@@ -1,0 +1,44 @@
+// addSource with an empty samples array used to succeed silently and
+// quicktype would render full converter boilerplate for a type with no
+// evidence whatsoever. An empty samples array is almost always a caller bug
+// (a glob that matched nothing, a filtered list that came up empty), so it
+// must fail loudly instead — see
+// https://github.com/glideapps/quicktype/issues/2934.
+
+import { describe, expect, test } from "vitest";
+
+import {
+    InputData,
+    jsonInputForTargetLanguage,
+    quicktype,
+} from "../../packages/quicktype-core/src/index.js";
+
+describe("JSON input with empty samples", () => {
+    test("addSource throws a clear error", async () => {
+        const jsonInput = jsonInputForTargetLanguage("typescript");
+        await expect(
+            jsonInput.addSource({ name: "X", samples: [] }),
+        ).rejects.toThrow("No JSON samples given for top-level X");
+    });
+
+    test("addSourceSync throws a clear error", () => {
+        const jsonInput = jsonInputForTargetLanguage("typescript");
+        expect(() =>
+            jsonInput.addSourceSync({ name: "X", samples: [] }),
+        ).toThrow("No JSON samples given for top-level X");
+    });
+
+    test("non-empty samples still generate code", async () => {
+        const jsonInput = jsonInputForTargetLanguage("typescript");
+        await jsonInput.addSource({
+            name: "Person",
+            samples: ['{"name":"Alice","age":30}'],
+        });
+
+        const inputData = new InputData();
+        inputData.addInput(jsonInput);
+        const result = await quicktype({ inputData, lang: "typescript" });
+
+        expect(result.lines.join("\n")).toContain("Person");
+    });
+});


### PR DESCRIPTION
## Problem

Calling `addSource({ name: "X", samples: [] })` on a JSON input neither threw nor errored later — `quicktype()` happily rendered full converter boilerplate (168 lines of TypeScript in the issue's repro) for a type with no evidence whatsoever. An empty samples array is almost certainly a caller bug (a glob that matched nothing, a filtered list that came up empty), and the old behavior masked it.

## Fix

`JSONInput.addSource` and `JSONInput.addSourceSync` now reject an empty `samples` array via the repo's user-facing error mechanism (`messageError`) with a new `DriverNoSamplesForTopLevel` message kind:

```
No JSON samples given for top-level X
```

This mirrors how malformed JSON in a sample already fails (`MiscJSONParseError`).

I verified that no existing caller can legitimately hit this: the CLI only pushes a `json` source when it has at least one sample (`src/index.ts` guards with `jsonSamples.length > 0`, and per-file sources always contain exactly one sample), and the Postman-collection input only emits a source when `samples.length > 0`.

## Tests

New unit test `test/unit/empty-json-samples.test.ts`:

- `addSource` with empty samples rejects with the clear message
- `addSourceSync` with empty samples throws with the clear message
- non-empty samples still generate code

Full unit suite passes (10 files, 74 tests).

Fixes #2934

🤖 Generated with [Claude Code](https://claude.com/claude-code)