### PR TITLE
fix(core): enforce rendererOptions keys in the type system

### DIFF
--- a/packages/quicktype-core/src/RendererOptions/types.ts
+++ b/packages/quicktype-core/src/RendererOptions/types.ts
@@ -54,7 +54,13 @@ export type OptionValue<O> =
 export type OptionKey<O> =
     O extends EnumOption<string, Record<string, unknown>, infer EnumKey>
         ? EnumKey
-        : O;
+        : O extends Option<string, infer Value>
+          ? Value extends boolean
+              ? // `BooleanOption.getValue` also accepts the strings
+                // "true" and "false", which is what the CLI passes.
+                boolean | `${boolean}`
+              : Value
+          : never;
 
 // FIXME: Merge these and use camelCase user-facing keys (v24)
 export type OptionMap<T> = {

--- a/packages/quicktype-core/src/Run.ts
+++ b/packages/quicktype-core/src/Run.ts
@@ -113,10 +113,11 @@ export interface NonInferenceOptions<Lang extends LanguageName = LanguageName> {
      */
     outputFilename: string;
     /** Options for the target language's renderer */
-    rendererOptions: RendererOptions<Lang>;
+    rendererOptions: Partial<RendererOptions<Lang>>;
 }
 
-export type Options = NonInferenceOptions & InferenceFlags;
+export type Options<Lang extends LanguageName = LanguageName> =
+    NonInferenceOptions<Lang> & InferenceFlags;
 
 const defaultOptions: NonInferenceOptions = {
     lang: "ts",
@@ -600,15 +601,15 @@ class Run implements RunContext {
  * @param options Partial options.  For options that are not defined, the
  * defaults will be used.
  */
-export async function quicktypeMultiFile(
-    options: Partial<Options>,
-): Promise<MultiFileRenderResult> {
+export async function quicktypeMultiFile<
+    Lang extends LanguageName = LanguageName,
+>(options: Partial<Options<Lang>>): Promise<MultiFileRenderResult> {
     return await new Run(options).run();
 }
 
-export function quicktypeMultiFileSync(
-    options: Partial<Options>,
-): MultiFileRenderResult {
+export function quicktypeMultiFileSync<
+    Lang extends LanguageName = LanguageName,
+>(options: Partial<Options<Lang>>): MultiFileRenderResult {
     return new Run(options).runSync();
 }
 
@@ -664,8 +665,8 @@ export function combineRenderResults(
  * @param options Partial options.  For options that are not defined, the
  * defaults will be used.
  */
-export async function quicktype(
-    options: Partial<Options>,
+export async function quicktype<Lang extends LanguageName = LanguageName>(
+    options: Partial<Options<Lang>>,
 ): Promise<SerializedRenderResult> {
     const result = await quicktypeMultiFile(options);
     return combineRenderResults(result);

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -620,7 +620,6 @@ export const CPlusPlusLanguage: Language = {
     ],
     rendererOptions: {},
     quickTestRendererOptions: [
-        { unions: "indirection" },
         { "source-style": "multi-source" },
         { "code-format": "with-struct" },
         { wstring: "use-wstring" },
@@ -852,7 +851,6 @@ export const TypeScriptLanguage: Language = {
         { "runtime-typecheck": "false" },
         { "runtime-typecheck-ignore-unknown-properties": "true" },
         { "nice-property-names": "true" },
-        { "declare-unions": "true" },
         ["pokedex.json", { "prefer-types": "true" }],
         { "acronym-style": "pascal" },
         { converters: "all-objects" },
@@ -910,11 +908,7 @@ export const JavaScriptPropTypesLanguage: Language = {
     skipSchema: [],
     skipMiscJSON: false,
     rendererOptions: { "module-system": "es6" },
-    quickTestRendererOptions: [
-        { "runtime-typecheck": "false" },
-        { "runtime-typecheck-ignore-unknown-properties": "true" },
-        { converters: "top-level" },
-    ],
+    quickTestRendererOptions: [{ converters: "top-level" }],
     sourceFiles: ["src/language/JavaScriptPropTypes/index.ts"],
 };
 
@@ -940,7 +934,6 @@ export const FlowLanguage: Language = {
         { "runtime-typecheck": "false" },
         { "runtime-typecheck-ignore-unknown-properties": "true" },
         { "nice-property-names": "true" },
-        { "declare-unions": "true" },
     ],
     sourceFiles: ["src/language/Flow/index.ts"],
 };
@@ -1602,7 +1595,7 @@ export const TypeScriptZodLanguage: Language = {
         "required-non-properties.schema",
     ],
     rendererOptions: {},
-    quickTestRendererOptions: [{ "array-type": "list" }],
+    quickTestRendererOptions: [],
     sourceFiles: ["src/language/TypeScriptZod/index.ts"],
 };
 
@@ -1717,7 +1710,7 @@ export const TypeScriptEffectSchemaLanguage: Language = {
         "required-non-properties.schema",
     ],
     rendererOptions: {},
-    quickTestRendererOptions: [{ "array-type": "list" }],
+    quickTestRendererOptions: [],
     sourceFiles: ["src/language/TypeScriptEffectSchema/index.ts"],
 };
 

--- a/test/unit/renderer-options.test-d.ts
+++ b/test/unit/renderer-options.test-d.ts
@@ -1,0 +1,90 @@
+// Type-level tests: `rendererOptions` keys and values are validated by the
+// type system against the target language given in `lang`.  When `lang` is
+// a string literal, `quicktype` infers it and unknown option names or
+// invalid enum values are compile errors — there is no runtime validation.
+// See https://github.com/glideapps/quicktype/issues/2933.
+import { describe, test } from "vitest";
+
+import {
+    InputData,
+    type LanguageName,
+    quicktype,
+    quicktypeMultiFile,
+} from "../../packages/quicktype-core/src/index.js";
+
+const inputData = new InputData();
+
+describe("rendererOptions typing", () => {
+    test("accepts a language's own options", () => {
+        void quicktype({
+            inputData,
+            lang: "csharp",
+            rendererOptions: {
+                namespace: "Acme",
+                framework: "SystemTextJson",
+                "csharp-version": "6",
+            },
+        });
+    });
+
+    test("boolean options accept booleans and their string forms", () => {
+        void quicktype({
+            inputData,
+            lang: "typescript",
+            rendererOptions: { "just-types": true },
+        });
+        void quicktype({
+            inputData,
+            lang: "typescript",
+            rendererOptions: { "just-types": "true" },
+        });
+    });
+
+    test("rejects an unknown option name", () => {
+        void quicktype({
+            inputData,
+            lang: "typescript",
+            // @ts-expect-error unknown option name
+            rendererOptions: { "totally-bogus-option": "yes" },
+        });
+    });
+
+    test("rejects another language's option name", () => {
+        void quicktype({
+            inputData,
+            lang: "kotlin",
+            // @ts-expect-error `just-types` is a C#/TypeScript spelling; Kotlin has no such option
+            rendererOptions: { "just-types": "true" },
+        });
+    });
+
+    test("rejects an invalid enum option value", () => {
+        void quicktype({
+            inputData,
+            lang: "csharp",
+            // @ts-expect-error GSON is not a C# serialization framework
+            rendererOptions: { framework: "GSON" },
+        });
+    });
+
+    test("quicktypeMultiFile enforces the same typing", () => {
+        void quicktypeMultiFile({
+            inputData,
+            lang: "csharp",
+            // @ts-expect-error unknown option name
+            rendererOptions: { "totally-bogus-option": "yes" },
+        });
+    });
+
+    test("stays permissive when the language is not a literal", () => {
+        // Callers that don't pin `lang` to a literal — or omit it — keep
+        // the old, unchecked behavior.
+        const lang: LanguageName = "csharp" as LanguageName;
+        void quicktype({
+            inputData,
+            lang,
+            rendererOptions: { "just-types": "true" },
+        });
+        void quicktype({ inputData, rendererOptions: {} });
+    });
+});

--- a/test/unit/tsconfig.json
+++ b/test/unit/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "extends": "@tsconfig/node20/tsconfig.json",
+    "compilerOptions": {
+        "lib": ["ES2022"],
+        "module": "esnext",
+        "moduleResolution": "bundler",
+        "strict": true,
+        "noEmit": true
+    },
+    "include": ["./**/*.test-d.ts"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,5 +5,10 @@ export default defineConfig({
         environment: "node",
         include: ["test/unit/**/*.test.ts"],
         testTimeout: 30_000,
+        typecheck: {
+            enabled: true,
+            include: ["test/unit/**/*.test-d.ts"],
+            tsconfig: "./test/unit/tsconfig.json",
+        },
     },
 });


### PR DESCRIPTION
Fixes #2933.

Unknown `rendererOptions` keys were silently ignored by the quicktype-core API. Per review, this is now enforced **entirely in the type system** — no runtime validation.

## What this does

- Makes `quicktype()`, `quicktypeMultiFile()`, and `quicktypeMultiFileSync()` generic over `Lang extends LanguageName` (inferred from `lang`), and carries the generic through `Options`. With a literal `lang`, `rendererOptions` is typed as that language's option map, so unknown option names and invalid enum values are compile errors:

```ts
await quicktype({
    inputData,
    lang: "csharp",
    rendererOptions: { "totally-bogus": "x" },  // error TS2353: unknown property
});
```

- Fixes `OptionKey`, which fell through to the `Option` class type for non-enum options — even valid usage like `{ namespace: "Acme" }` failed to typecheck before this. String options are now `string`, boolean options `boolean | "true" | "false"` (matching what `BooleanOption.getValue` accepts), enum options keep their key union.

- Callers that don't pin `lang` to a literal — or omit it — keep the old, unchecked behavior, so plain-JS and dynamic callers are unaffected.

## Testing

- `test/unit/renderer-options.test-d.ts` covers valid options, unknown names, another language's option name, invalid enum values, boolean string forms, and the permissive non-literal fallback, using `@ts-expect-error` assertions run by vitest's typecheck mode (newly enabled in `vitest.config.ts`). Verified the harness fails when an expected error doesn't occur.
- The dead renderer options this work uncovered in `test/languages.ts` (C++ `unions`, TypeScript/Flow `declare-unions`, Zod/Effect `array-type`, PropTypes `runtime-typecheck`) stay removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
