### PR TITLE
fix(typescript-input): support Date and Map in TypeScript input

### DIFF
--- a/packages/quicktype-typescript-input/src/index.ts
+++ b/packages/quicktype-typescript-input/src/index.ts
@@ -4,7 +4,10 @@ import {
     messageError,
 } from "quicktype-core";
 import {
+    type Definition,
+    type JsonSchemaGenerator,
     type PartialArgs,
+    buildGenerator,
     generateSchema,
     // Use the TypeScript instance that typescript-json-schema is compiled
     // against, so the program we create is guaranteed to be compatible with
@@ -23,12 +26,104 @@ const compilerOptions: ts.CompilerOptions = {
     noEmit: true,
     emitDecoratorMetadata: true,
     experimentalDecorators: true,
-    target: ts.ScriptTarget.ES5,
+    target: ts.ScriptTarget.ES2015,
+    // Include the standard library explicitly so built-in types like `Date`
+    // and `Map` resolve (https://github.com/glideapps/quicktype/issues/2935).
+    // The DOM and scripthost libs were part of the default lib for the ES5
+    // target we used previously, so keep them for compatibility.
+    lib: [
+        "lib.es2015.d.ts",
+        "lib.dom.d.ts",
+        "lib.webworker.importscripts.d.ts",
+        "lib.scripthost.d.ts",
+    ],
     module: ts.ModuleKind.CommonJS,
     strictNullChecks: true,
     typeRoots: [],
     rootDir: ".",
 };
+
+// Standard-library types that cannot be represented in JSON. Without this
+// check they would be structurally expanded into nonsense schemas (e.g.
+// `Set<string>` would become `{ size: number }`).
+const unsupportedBuiltins: ReadonlyMap<string, string> = new Map([
+    ["Set", "use an array type instead"],
+    ["WeakMap", "it cannot be represented in JSON"],
+    ["WeakSet", "it cannot be represented in JSON"],
+    ["Promise", "use the resolved type instead"],
+]);
+
+function isDeclaredInDefaultLib(
+    program: ts.Program,
+    symbol: ts.Symbol,
+): boolean {
+    const declarations = symbol.getDeclarations() ?? [];
+    return declarations.some((declaration) =>
+        program.isSourceFileDefaultLibrary(declaration.getSourceFile()),
+    );
+}
+
+function tryGetMapValueType(
+    checker: ts.TypeChecker,
+    type: ts.Type,
+): ts.Type | undefined {
+    if ((type.flags & ts.TypeFlags.Object) === 0) {
+        return undefined;
+    }
+
+    const objectType = type as ts.ObjectType;
+    if ((objectType.objectFlags & ts.ObjectFlags.Reference) === 0) {
+        return undefined;
+    }
+
+    const typeArguments = checker.getTypeArguments(type as ts.TypeReference);
+    return typeArguments.length === 2 ? typeArguments[1] : undefined;
+}
+
+// typescript-json-schema maps `Date` to a date-time string out of the box,
+// but it has no support for `Map`, and it structurally expands other
+// standard-library generics into meaningless schemas. Wrap the generator's
+// type dispatcher to map `Map<K, V>` to a JSON Schema map and to report
+// unsupported built-in types with a helpful message.
+function patchGeneratorForBuiltinTypes(
+    generator: JsonSchemaGenerator,
+    program: ts.Program,
+): void {
+    const checker = program.getTypeChecker();
+    // `getTypeDefinition` is private in the type declarations, but it's the
+    // single funnel through which every type goes. typescript-json-schema is
+    // pinned to an exact version, and the unit tests cover this behavior.
+    const generatorInternals = generator as unknown as {
+        getTypeDefinition: (typ: ts.Type, ...rest: unknown[]) => Definition;
+    };
+    const originalGetTypeDefinition =
+        generatorInternals.getTypeDefinition.bind(generator);
+    generatorInternals.getTypeDefinition = (typ, ...rest) => {
+        const symbol = typ.getSymbol();
+        if (symbol !== undefined && isDeclaredInDefaultLib(program, symbol)) {
+            const name = symbol.getName();
+            if (name === "Map" || name === "ReadonlyMap") {
+                const valueType = tryGetMapValueType(checker, typ);
+                if (valueType !== undefined) {
+                    return {
+                        type: "object",
+                        additionalProperties:
+                            generatorInternals.getTypeDefinition(valueType),
+                    };
+                }
+            }
+
+            const advice = unsupportedBuiltins.get(name);
+            if (advice !== undefined) {
+                return messageError("TypeScriptCompilerError", {
+                    message: `quicktype's TypeScript input does not support '${checker.typeToString(typ)}' - ${advice}`,
+                });
+            }
+        }
+
+        return originalGetTypeDefinition(typ, ...rest);
+    };
+}
 
 // FIXME: We're stringifying and then parsing this schema again. Just pass around
 // the schema directly.
@@ -46,7 +141,16 @@ export function schemaForTypeScriptSources(
         });
     }
 
-    const schema = generateSchema(program, "*", settings);
+    const generator = buildGenerator(program, settings);
+    if (generator === null) {
+        return messageError("TypeScriptCompilerError", {
+            message: "Failed to build the JSON Schema generator",
+        });
+    }
+
+    patchGeneratorForBuiltinTypes(generator, program);
+
+    const schema = generateSchema(program, "*", settings, undefined, generator);
     const uris: string[] = [];
     let topLevelName = "";
 

--- a/test/unit/typescript-input.test.ts
+++ b/test/unit/typescript-input.test.ts
@@ -112,6 +112,73 @@ describe("schemaForTypeScriptSources", () => {
         );
     });
 
+    // https://github.com/glideapps/quicktype/issues/2935
+    test("Date properties become date-time strings", () => {
+        const { schema } = schemaForSource(`
+            export interface User {
+                id: number;
+                createdAt: Date;
+            }
+        `);
+
+        expect(schema.definitions.User.properties.createdAt).toMatchObject({
+            type: "string",
+            format: "date-time",
+        });
+    });
+
+    // https://github.com/glideapps/quicktype/issues/1858
+    test("Map properties become map schemas", () => {
+        const { schema } = schemaForSource(`
+            export interface Env {
+                flags: Map<string, boolean>;
+                services: Map<string, Service>;
+                nested: ReadonlyMap<string, Map<string, number>>;
+            }
+
+            export interface Service {
+                url: string;
+            }
+        `);
+
+        const properties = schema.definitions.Env.properties;
+        expect(properties.flags).toMatchObject({
+            type: "object",
+            additionalProperties: { type: "boolean" },
+        });
+        expect(properties.services.additionalProperties.$ref).toBe(
+            "#/definitions/Service",
+        );
+        expect(properties.nested.additionalProperties).toMatchObject({
+            type: "object",
+            additionalProperties: { type: "number" },
+        });
+    });
+
+    test("a user-defined Map type is not treated as the built-in Map", () => {
+        const { schema } = schemaForSource(`
+            export interface Map {
+                width: number;
+            }
+
+            export interface Atlas {
+                map: Map;
+            }
+        `);
+
+        expect(schema.definitions.Map.properties.width.type).toBe("number");
+    });
+
+    test("unsupported built-in types are reported with a helpful message", () => {
+        expect(() =>
+            schemaForSource(`
+                export interface Bag {
+                    tags: Set<string>;
+                }
+            `),
+        ).toThrow(/does not support 'Set<string>'/);
+    });
+
     test("compiler errors are reported as quicktype errors", () => {
         expect(() =>
             schemaForSource(`


### PR DESCRIPTION
## Problem

TypeScript input compiled with `target: ES5` and no explicit `lib`, so built-in types from later standard libraries failed to resolve, and quicktype surfaced raw compiler errors like:

```
Error: TypeScript error: Cannot find name 'Map'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later..
```

That advice is inapplicable for CLI users — there is no `lib` option to change. Worse, quicktype's own generated TypeScript declares date-time properties as `Date`, so round-tripping quicktype's TS output back through `--src-lang typescript` could fail on code quicktype itself produced.

## Fix

- **Standard library**: compile TypeScript input with `target: ES2015` and an explicit `lib` (es2015 plus the dom/scripthost libs that the old ES5 default `lib.d.ts` already included), so `Date`, `Map`, and friends resolve deterministically. typescript-json-schema already maps `Date` to `{"type": "string", "format": "date-time"}`, which becomes quicktype's date-time type — so `createdAt: Date` now comes out as `time.Time` in Go and round-trips to `Date` in TypeScript.
- **`Map<K, V>` support** (also #1858): without help, typescript-json-schema structurally expands `Map` into a nonsense `{size: number, __@toStringTag@…: string}` object. We now build the schema generator via `buildGenerator` and wrap its `getTypeDefinition` funnel to map `Map`/`ReadonlyMap` from the default library to a JSON Schema map (`{"type": "object", "additionalProperties": <value schema>}`). Values recurse through normal schema generation, so maps of interfaces and nested maps work; user-defined types named `Map` are left alone. `getTypeDefinition` is private in the type declarations, but typescript-json-schema is pinned to an exact version and the new unit tests cover the behavior.
- **Friendly errors**: `Set`, `WeakMap`, `WeakSet`, and `Promise` properties now produce a helpful "quicktype's TypeScript input does not support 'Set<string>' - use an array type instead" message rather than a raw compiler error (before) or a silently wrong schema (after the lib bump alone).

## Example

```ts
export interface User {
    id: number;
    createdAt: Date;
    flags: Map<string, boolean>;
}
```

`quicktype --src-lang typescript input.ts -l go` now produces:

```go
type User struct {
	CreatedAt time.Time       `json:"createdAt"`
	Flags     map[string]bool `json:"flags"`
	ID        float64         `json:"id"`
}
```

and `-l typescript` round-trips to `createdAt: Date` / `flags: { [key: string]: boolean }`.

## Testing

- New unit tests in `test/unit/typescript-input.test.ts`: `Date` → date-time, `Map` of primitives / interfaces / nested `ReadonlyMap`, a user-defined `Map` interface staying untouched, and the friendly `Set` error.
- Full unit suite passes (75 tests), lint clean.
- Verified the CLI end to end on the issue repro for Go and TypeScript targets, including feeding quicktype's own TS output back in as input.

Fixes #2935
Fixes #1858

🤖 Generated with [Claude Code](https://claude.com/claude-code)