### PR TITLE
feat(options)!: unify --just-types across all languages

### DIFF
--- a/packages/quicktype-core/src/language/CSharp/NewtonSoftCSharpRenderer.ts
+++ b/packages/quicktype-core/src/language/CSharp/NewtonSoftCSharpRenderer.ts
@@ -68,8 +68,10 @@ export class NewtonsoftCSharpRenderer extends CSharpRenderer {
         private readonly _options: OptionValues<typeof newtonsoftCSharpOptions>,
     ) {
         super(targetLanguage, renderContext, _options);
-        this._needHelpers = _options.features.helpers;
-        this._needAttributes = _options.features.attributes;
+        // `--just-types` wins over whatever `--features` says.
+        this._needHelpers = _options.features.helpers && !_options.justTypes;
+        this._needAttributes =
+            _options.features.attributes && !_options.justTypes;
         this._needNamespaces = _options.features.namespaces;
     }
 

--- a/packages/quicktype-core/src/language/CSharp/SystemTextJsonCSharpRenderer.ts
+++ b/packages/quicktype-core/src/language/CSharp/SystemTextJsonCSharpRenderer.ts
@@ -69,8 +69,10 @@ export class SystemTextJsonCSharpRenderer extends CSharpRenderer {
         >,
     ) {
         super(targetLanguage, renderContext, _options);
-        this._needHelpers = _options.features.helpers;
-        this._needAttributes = _options.features.attributes;
+        // `--just-types` wins over whatever `--features` says.
+        this._needHelpers = _options.features.helpers && !_options.justTypes;
+        this._needAttributes =
+            _options.features.attributes && !_options.justTypes;
         this._needNamespaces = _options.features.namespaces;
     }
 

--- a/packages/quicktype-core/src/language/CSharp/language.ts
+++ b/packages/quicktype-core/src/language/CSharp/language.ts
@@ -117,6 +117,14 @@ export const cSharpOptions = {
         } as const,
         "complete",
     ),
+    // The boolean spelling of `--features just-types`, so that
+    // `--just-types` works for C# like it does for most other languages.
+    justTypes: new BooleanOption(
+        "just-types",
+        "Plain types only (same as features=just-types)",
+        false,
+        "secondary",
+    ),
     baseclass: new EnumOption(
         "base-class",
         "Base class",
@@ -190,6 +198,13 @@ export class CSharpTargetLanguage extends TargetLanguage<
         renderContext: RenderContext,
         untypedOptionValues: RendererOptions<Lang>,
     ): ConvenienceRenderer {
+        if (cSharpOptions.justTypes.getValue(untypedOptionValues)) {
+            untypedOptionValues = {
+                ...untypedOptionValues,
+                features: "just-types",
+            } as RendererOptions<Lang>;
+        }
+
         const options = getOptionValues(cSharpOptions, untypedOptionValues);
 
         switch (options.framework) {

--- a/packages/quicktype-core/src/language/CSharp/language.ts
+++ b/packages/quicktype-core/src/language/CSharp/language.ts
@@ -104,27 +104,10 @@ export const cSharpOptions = {
                 helpers: false,
                 attributes: true,
             },
-            "just-types-and-namespace": {
-                namespaces: true,
-                helpers: false,
-                attributes: false,
-            },
-            "just-types": {
-                namespaces: true,
-                helpers: false,
-                attributes: false,
-            },
         } as const,
         "complete",
     ),
-    // The boolean spelling of `--features just-types`, so that
-    // `--just-types` works for C# like it does for most other languages.
-    justTypes: new BooleanOption(
-        "just-types",
-        "Plain types only (same as features=just-types)",
-        false,
-        "secondary",
-    ),
+    justTypes: new BooleanOption("just-types", "Plain types only", false),
     baseclass: new EnumOption(
         "base-class",
         "Base class",
@@ -198,13 +181,6 @@ export class CSharpTargetLanguage extends TargetLanguage<
         renderContext: RenderContext,
         untypedOptionValues: RendererOptions<Lang>,
     ): ConvenienceRenderer {
-        if (cSharpOptions.justTypes.getValue(untypedOptionValues)) {
-            untypedOptionValues = {
-                ...untypedOptionValues,
-                features: "just-types",
-            } as RendererOptions<Lang>;
-        }
-
         const options = getOptionValues(cSharpOptions, untypedOptionValues);
 
         switch (options.framework) {

--- a/packages/quicktype-core/src/language/Kotlin/language.ts
+++ b/packages/quicktype-core/src/language/Kotlin/language.ts
@@ -1,6 +1,7 @@
 import type { ConvenienceRenderer } from "../../ConvenienceRenderer.js";
 import type { RenderContext } from "../../Renderer.js";
 import {
+    BooleanOption,
     EnumOption,
     StringOption,
     getOptionValues,
@@ -26,6 +27,15 @@ export const kotlinOptions = {
             kotlinx: "KotlinX",
         } as const,
         "klaxon",
+    ),
+    // The boolean spelling of `--framework just-types`, so that
+    // `--just-types` works for Kotlin like it does for most other
+    // languages.
+    justTypes: new BooleanOption(
+        "just-types",
+        "Plain types only (same as framework=just-types)",
+        false,
+        "secondary",
     ),
     acronymStyle: acronymOption(AcronymStyleOptions.Pascal),
     packageName: new StringOption("package", "Package", "PACKAGE", "quicktype"),
@@ -60,6 +70,13 @@ export class KotlinTargetLanguage extends TargetLanguage<
         renderContext: RenderContext,
         untypedOptionValues: RendererOptions<Lang>,
     ): ConvenienceRenderer {
+        if (kotlinOptions.justTypes.getValue(untypedOptionValues)) {
+            untypedOptionValues = {
+                ...untypedOptionValues,
+                framework: "just-types",
+            } as RendererOptions<Lang>;
+        }
+
         const options = getOptionValues(kotlinOptions, untypedOptionValues);
 
         switch (options.framework) {

--- a/packages/quicktype-core/src/language/Kotlin/language.ts
+++ b/packages/quicktype-core/src/language/Kotlin/language.ts
@@ -17,25 +17,16 @@ import { KotlinRenderer } from "./KotlinRenderer.js";
 import { KotlinXRenderer } from "./KotlinXRenderer.js";
 
 export const kotlinOptions = {
+    justTypes: new BooleanOption("just-types", "Plain types only", false),
     framework: new EnumOption(
         "framework",
         "Serialization framework",
         {
-            "just-types": "None",
             jackson: "Jackson",
             klaxon: "Klaxon",
             kotlinx: "KotlinX",
         } as const,
         "klaxon",
-    ),
-    // The boolean spelling of `--framework just-types`, so that
-    // `--just-types` works for Kotlin like it does for most other
-    // languages.
-    justTypes: new BooleanOption(
-        "just-types",
-        "Plain types only (same as framework=just-types)",
-        false,
-        "secondary",
     ),
     acronymStyle: acronymOption(AcronymStyleOptions.Pascal),
     packageName: new StringOption("package", "Package", "PACKAGE", "quicktype"),
@@ -70,18 +61,14 @@ export class KotlinTargetLanguage extends TargetLanguage<
         renderContext: RenderContext,
         untypedOptionValues: RendererOptions<Lang>,
     ): ConvenienceRenderer {
-        if (kotlinOptions.justTypes.getValue(untypedOptionValues)) {
-            untypedOptionValues = {
-                ...untypedOptionValues,
-                framework: "just-types",
-            } as RendererOptions<Lang>;
-        }
-
         const options = getOptionValues(kotlinOptions, untypedOptionValues);
 
+        // `--just-types` wins over whatever `--framework` says.
+        if (options.justTypes) {
+            return new KotlinRenderer(this, renderContext, options);
+        }
+
         switch (options.framework) {
-            case "None":
-                return new KotlinRenderer(this, renderContext, options);
             case "Jackson":
                 return new KotlinJacksonRenderer(this, renderContext, options);
             case "Klaxon":

--- a/packages/quicktype-core/src/language/Scala3/language.ts
+++ b/packages/quicktype-core/src/language/Scala3/language.ts
@@ -1,6 +1,7 @@
 import type { ConvenienceRenderer } from "../../ConvenienceRenderer.js";
 import type { RenderContext } from "../../Renderer.js";
 import {
+    BooleanOption,
     EnumOption,
     StringOption,
     getOptionValues,
@@ -23,6 +24,15 @@ export const scala3Options = {
             upickle: "Upickle",
         } as const,
         "just-types",
+    ),
+    // The boolean spelling of `--framework just-types`, so that
+    // `--just-types` works for Scala like it does for most other
+    // languages.
+    justTypes: new BooleanOption(
+        "just-types",
+        "Plain types only (same as framework=just-types)",
+        false,
+        "secondary",
     ),
     packageName: new StringOption("package", "Package", "PACKAGE", "quicktype"),
 };
@@ -56,6 +66,13 @@ export class Scala3TargetLanguage extends TargetLanguage<
         renderContext: RenderContext,
         untypedOptionValues: RendererOptions<Lang>,
     ): ConvenienceRenderer {
+        if (scala3Options.justTypes.getValue(untypedOptionValues)) {
+            untypedOptionValues = {
+                ...untypedOptionValues,
+                framework: "just-types",
+            } as RendererOptions<Lang>;
+        }
+
         const options = getOptionValues(scala3Options, untypedOptionValues);
 
         switch (options.framework) {

--- a/packages/quicktype-core/src/language/Scala3/language.ts
+++ b/packages/quicktype-core/src/language/Scala3/language.ts
@@ -15,24 +15,15 @@ import { Scala3Renderer } from "./Scala3Renderer.js";
 import { UpickleRenderer } from "./UpickleRenderer.js";
 
 export const scala3Options = {
+    justTypes: new BooleanOption("just-types", "Plain types only", false),
     framework: new EnumOption(
         "framework",
         "Serialization framework",
         {
-            "just-types": "None",
             circe: "Circe",
             upickle: "Upickle",
         } as const,
-        "just-types",
-    ),
-    // The boolean spelling of `--framework just-types`, so that
-    // `--just-types` works for Scala like it does for most other
-    // languages.
-    justTypes: new BooleanOption(
-        "just-types",
-        "Plain types only (same as framework=just-types)",
-        false,
-        "secondary",
+        "circe",
     ),
     packageName: new StringOption("package", "Package", "PACKAGE", "quicktype"),
 };
@@ -66,18 +57,14 @@ export class Scala3TargetLanguage extends TargetLanguage<
         renderContext: RenderContext,
         untypedOptionValues: RendererOptions<Lang>,
     ): ConvenienceRenderer {
-        if (scala3Options.justTypes.getValue(untypedOptionValues)) {
-            untypedOptionValues = {
-                ...untypedOptionValues,
-                framework: "just-types",
-            } as RendererOptions<Lang>;
-        }
-
         const options = getOptionValues(scala3Options, untypedOptionValues);
 
+        // `--just-types` wins over whatever `--framework` says.
+        if (options.justTypes) {
+            return new Scala3Renderer(this, renderContext, options);
+        }
+
         switch (options.framework) {
-            case "None":
-                return new Scala3Renderer(this, renderContext, options);
             case "Upickle":
                 return new UpickleRenderer(this, renderContext, options);
             case "Circe":

--- a/packages/quicktype-core/src/language/Smithy4s/language.ts
+++ b/packages/quicktype-core/src/language/Smithy4s/language.ts
@@ -1,6 +1,7 @@
 import type { ConvenienceRenderer } from "../../ConvenienceRenderer.js";
 import type { RenderContext } from "../../Renderer.js";
 import {
+    BooleanOption,
     EnumOption,
     StringOption,
     getOptionValues,
@@ -22,6 +23,14 @@ export const smithyOptions = {
         "Serialization framework",
         { "just-types": Framework.None } as const,
         "just-types",
+    ),
+    // Smithy only ever generates plain types; the flag is accepted for
+    // consistency with the other languages.
+    justTypes: new BooleanOption(
+        "just-types",
+        "Plain types only (the only mode Smithy supports)",
+        false,
+        "secondary",
     ),
     packageName: new StringOption("package", "Package", "PACKAGE", "quicktype"),
 };

--- a/packages/quicktype-core/src/language/Smithy4s/language.ts
+++ b/packages/quicktype-core/src/language/Smithy4s/language.ts
@@ -2,36 +2,18 @@ import type { ConvenienceRenderer } from "../../ConvenienceRenderer.js";
 import type { RenderContext } from "../../Renderer.js";
 import {
     BooleanOption,
-    EnumOption,
     StringOption,
     getOptionValues,
 } from "../../RendererOptions/index.js";
-import { assertNever } from "../../support/Support.js";
 import { TargetLanguage } from "../../TargetLanguage.js";
 import type { LanguageName, RendererOptions } from "../../types.js";
 
 import { Smithy4sRenderer } from "./Smithy4sRenderer.js";
 
-export enum Framework {
-    None = "None",
-}
-
 export const smithyOptions = {
-    // FIXME: why does this exist
-    framework: new EnumOption(
-        "framework",
-        "Serialization framework",
-        { "just-types": Framework.None } as const,
-        "just-types",
-    ),
-    // Smithy only ever generates plain types; the flag is accepted for
-    // consistency with the other languages.
-    justTypes: new BooleanOption(
-        "just-types",
-        "Plain types only (the only mode Smithy supports)",
-        false,
-        "secondary",
-    ),
+    // Plain types is the only mode Smithy supports; the flag is accepted
+    // for consistency with the other languages.
+    justTypes: new BooleanOption("just-types", "Plain types only", false),
     packageName: new StringOption("package", "Package", "PACKAGE", "quicktype"),
 };
 
@@ -64,13 +46,10 @@ export class SmithyTargetLanguage extends TargetLanguage<
         renderContext: RenderContext,
         untypedOptionValues: RendererOptions<Lang>,
     ): ConvenienceRenderer {
-        const options = getOptionValues(smithyOptions, untypedOptionValues);
-
-        switch (options.framework) {
-            case Framework.None:
-                return new Smithy4sRenderer(this, renderContext, options);
-            default:
-                return assertNever(options.framework);
-        }
+        return new Smithy4sRenderer(
+            this,
+            renderContext,
+            getOptionValues(smithyOptions, untypedOptionValues),
+        );
     }
 }

--- a/packages/quicktype-vscode/src/extension.ts
+++ b/packages/quicktype-vscode/src/extension.ts
@@ -106,19 +106,12 @@ async function runQuicktype(
         vscode.workspace.getConfiguration(configurationSection);
     const justTypes = forceJustTypes || configuration.justTypes;
 
-    const rendererOptions: RendererOptions = {};
-    if (justTypes) {
-        // FIXME: The target language should have a property to return these options.
-        if (lang.name === "csharp") {
-            (rendererOptions as RendererOptions<"csharp">).features =
-                "just-types";
-        } else if (lang.name === "kotlin") {
-            (rendererOptions as RendererOptions<"kotlin">).framework =
-                "just-types";
-        } else if ("just-types" in rendererOptions) {
-            rendererOptions["just-types"] = "true";
-        }
-    }
+    // Not every language has a `just-types` option — JSON Schema, for
+    // example, has no serialization helpers to leave out.
+    const rendererOptions: RendererOptions =
+        justTypes && lang.optionDefinitions.some((o) => o.name === "just-types")
+            ? ({ "just-types": "true" } as RendererOptions)
+            : {};
 
     const inputData = new InputData();
     switch (kind) {

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1083,7 +1083,7 @@ I havea no idea how to encode these tests correctly.
     ],
     skipSchema: [],
     skipMiscJSON: false,
-    rendererOptions: { framework: "just-types" },
+    rendererOptions: { "just-types": "true" },
     quickTestRendererOptions: [],
     sourceFiles: ["src/language/Smithy4s/index.ts"],
 };

--- a/test/unit/just-types-option.test.ts
+++ b/test/unit/just-types-option.test.ts
@@ -1,8 +1,8 @@
-// Most languages spell "generate plain types without (de)serialization
-// helpers" as a `just-types` boolean option, but C# spelled it
-// `features=just-types` and Kotlin/Scala/Smithy `framework=just-types`, so
-// the CLI's `--just-types` flag was rejected for those languages.  They now
-// also accept `just-types`, which forces the corresponding enum option.
+// Every quicktype language spells "generate plain types without
+// (de)serialization helpers" as the boolean `just-types` option.  C#'s
+// `features=just-types` / `features=just-types-and-namespace` and Kotlin's,
+// Scala 3's, and Smithy4s's `framework=just-types` are gone; the boolean
+// wins over a conflicting explicit enum value.
 import { describe, expect, test } from "vitest";
 
 import {
@@ -15,7 +15,7 @@ import {
 
 async function linesFor(
     lang: LanguageName,
-    rendererOptions: RendererOptions,
+    rendererOptions: RendererOptions = {},
 ): Promise<string> {
     const jsonInput = jsonInputForTargetLanguage(lang);
     await jsonInput.addSource({
@@ -28,39 +28,111 @@ async function linesFor(
     return result.lines.join("\n");
 }
 
-describe("just-types is accepted by every enum-spelled language", () => {
-    test("C#: just-types matches features=just-types", async () => {
-        const viaBoolean = await linesFor("csharp", { "just-types": true });
-        const viaEnum = await linesFor("csharp", { features: "just-types" });
-        expect(viaBoolean).toEqual(viaEnum);
-        expect(viaBoolean).not.toContain("JsonConverter");
+describe("just-types generates plain types in every language", () => {
+    test("C#: no attributes, no helpers, but a namespace", async () => {
+        const output = await linesFor("csharp", { "just-types": true });
+        expect(output).toContain("namespace QuickType");
+        expect(output).toContain("public partial class Person");
+        expect(output).not.toContain("JsonConverter");
+        expect(output).not.toContain("JsonProperty");
     });
 
-    test("Kotlin: just-types matches framework=just-types", async () => {
-        const viaBoolean = await linesFor("kotlin", { "just-types": true });
-        const viaEnum = await linesFor("kotlin", { framework: "just-types" });
-        expect(viaBoolean).toEqual(viaEnum);
-        expect(viaBoolean).not.toContain("Klaxon");
+    test("Kotlin: plain data classes, no Klaxon", async () => {
+        const output = await linesFor("kotlin", { "just-types": true });
+        expect(output).toContain("data class Person");
+        expect(output).not.toContain("Klaxon");
     });
 
-    test("Scala: just-types matches framework=just-types", async () => {
-        const viaBoolean = await linesFor("scala3", { "just-types": true });
-        const viaEnum = await linesFor("scala3", { framework: "just-types" });
-        expect(viaBoolean).toEqual(viaEnum);
+    test("Scala 3: plain case classes, no circe", async () => {
+        const output = await linesFor("scala3", { "just-types": true });
+        expect(output).toContain("case class Person");
+        expect(output).not.toContain("circe");
     });
 
-    test("Smithy: just-types is accepted", async () => {
+    test("Smithy: accepted (plain types is the only mode)", async () => {
         const viaBoolean = await linesFor("smithy4a", { "just-types": true });
-        const viaDefault = await linesFor("smithy4a", {});
-        expect(viaBoolean).toEqual(viaDefault);
+        expect(viaBoolean).toContain("structure Person");
+        expect(viaBoolean).toEqual(await linesFor("smithy4a"));
+    });
+});
+
+describe("the removed enum spellings are errors", () => {
+    // The old spellings aren't valid `RendererOptions` anymore, which is
+    // the point: they must also fail for API callers who evade the types.
+    test("C#: features=just-types", async () => {
+        const options = { features: "just-types" } as RendererOptions;
+        await expect(linesFor("csharp", options)).rejects.toThrow(
+            "Unknown value just-types for option features",
+        );
     });
 
-    test("the boolean wins over a conflicting enum value", async () => {
-        const viaBoolean = await linesFor("kotlin", {
+    test("C#: features=just-types-and-namespace", async () => {
+        const options = {
+            features: "just-types-and-namespace",
+        } as RendererOptions;
+        await expect(linesFor("csharp", options)).rejects.toThrow(
+            "Unknown value just-types-and-namespace for option features",
+        );
+    });
+
+    test("Kotlin: framework=just-types", async () => {
+        const options = { framework: "just-types" } as RendererOptions;
+        await expect(linesFor("kotlin", options)).rejects.toThrow(
+            "Unknown value just-types for option framework",
+        );
+    });
+
+    test("Scala 3: framework=just-types", async () => {
+        const options = { framework: "just-types" } as RendererOptions;
+        await expect(linesFor("scala3", options)).rejects.toThrow(
+            "Unknown value just-types for option framework",
+        );
+    });
+});
+
+describe("just-types wins over a conflicting enum option", () => {
+    test("C#: just-types beats features=attributes-only", async () => {
+        const output = await linesFor("csharp", {
+            "just-types": true,
+            features: "attributes-only",
+        });
+        expect(output).toEqual(
+            await linesFor("csharp", { "just-types": true }),
+        );
+        expect(output).not.toContain("JsonProperty");
+    });
+
+    test("Kotlin: just-types beats framework=jackson", async () => {
+        const output = await linesFor("kotlin", {
             "just-types": true,
             framework: "jackson",
         });
-        const plain = await linesFor("kotlin", { framework: "just-types" });
-        expect(viaBoolean).toEqual(plain);
+        expect(output).toEqual(
+            await linesFor("kotlin", { "just-types": true }),
+        );
+        expect(output).not.toContain("jackson");
+    });
+
+    test("Scala 3: just-types beats framework=upickle", async () => {
+        const output = await linesFor("scala3", {
+            "just-types": true,
+            framework: "upickle",
+        });
+        expect(output).toEqual(
+            await linesFor("scala3", { "just-types": true }),
+        );
+        expect(output).not.toContain("upickle");
+    });
+});
+
+describe("framework defaults", () => {
+    test("Scala 3 defaults to circe", async () => {
+        const output = await linesFor("scala3");
+        expect(output).toContain("io.circe");
+    });
+
+    test("Kotlin defaults to Klaxon", async () => {
+        const output = await linesFor("kotlin");
+        expect(output).toContain("com.beust.klaxon");
     });
 });

--- a/test/unit/just-types-option.test.ts
+++ b/test/unit/just-types-option.test.ts
@@ -1,0 +1,66 @@
+// Most languages spell "generate plain types without (de)serialization
+// helpers" as a `just-types` boolean option, but C# spelled it
+// `features=just-types` and Kotlin/Scala/Smithy `framework=just-types`, so
+// the CLI's `--just-types` flag was rejected for those languages.  They now
+// also accept `just-types`, which forces the corresponding enum option.
+import { describe, expect, test } from "vitest";
+
+import {
+    InputData,
+    type LanguageName,
+    type RendererOptions,
+    jsonInputForTargetLanguage,
+    quicktype,
+} from "quicktype-core";
+
+async function linesFor(
+    lang: LanguageName,
+    rendererOptions: RendererOptions,
+): Promise<string> {
+    const jsonInput = jsonInputForTargetLanguage(lang);
+    await jsonInput.addSource({
+        name: "Person",
+        samples: ['{"name": "Alice", "age": 37}'],
+    });
+    const inputData = new InputData();
+    inputData.addInput(jsonInput);
+    const result = await quicktype({ inputData, lang, rendererOptions });
+    return result.lines.join("\n");
+}
+
+describe("just-types is accepted by every enum-spelled language", () => {
+    test("C#: just-types matches features=just-types", async () => {
+        const viaBoolean = await linesFor("csharp", { "just-types": true });
+        const viaEnum = await linesFor("csharp", { features: "just-types" });
+        expect(viaBoolean).toEqual(viaEnum);
+        expect(viaBoolean).not.toContain("JsonConverter");
+    });
+
+    test("Kotlin: just-types matches framework=just-types", async () => {
+        const viaBoolean = await linesFor("kotlin", { "just-types": true });
+        const viaEnum = await linesFor("kotlin", { framework: "just-types" });
+        expect(viaBoolean).toEqual(viaEnum);
+        expect(viaBoolean).not.toContain("Klaxon");
+    });
+
+    test("Scala: just-types matches framework=just-types", async () => {
+        const viaBoolean = await linesFor("scala3", { "just-types": true });
+        const viaEnum = await linesFor("scala3", { framework: "just-types" });
+        expect(viaBoolean).toEqual(viaEnum);
+    });
+
+    test("Smithy: just-types is accepted", async () => {
+        const viaBoolean = await linesFor("smithy4a", { "just-types": true });
+        const viaDefault = await linesFor("smithy4a", {});
+        expect(viaBoolean).toEqual(viaDefault);
+    });
+
+    test("the boolean wins over a conflicting enum value", async () => {
+        const viaBoolean = await linesFor("kotlin", {
+            "just-types": true,
+            framework: "jackson",
+        });
+        const plain = await linesFor("kotlin", { framework: "just-types" });
+        expect(viaBoolean).toEqual(plain);
+    });
+});

--- a/test/unit/renderer-options.test-d.ts
+++ b/test/unit/renderer-options.test-d.ts
@@ -52,8 +52,8 @@ describe("rendererOptions typing", () => {
     test("rejects another language's option name", () => {
         void quicktype({
             inputData,
-            lang: "kotlin",
-            // @ts-expect-error `just-types` is a C#/TypeScript spelling; Kotlin has no such option
+            lang: "rust",
+            // @ts-expect-error Rust has no `just-types` option
             rendererOptions: { "just-types": "true" },
         });
     });


### PR DESCRIPTION
`--just-types` is the common spelling for "plain types, no (de)serialization helpers" — 15 languages accept it as a boolean option. But C# spelled it `--features just-types`, and Kotlin, Scala 3, and Smithy4s `--framework just-types`, so the flag everyone reaches for first failed with `Option parsing failed: Unknown option: --just-types.`

## What this does

> [!WARNING]
> **This is a breaking change.** It targets the next **major** version. The enum spellings are removed, not deprecated: they now fail with `Unknown value just-types for option …` (CLI and API alike).

Every quicktype language now spells "plain types" the same way: the boolean `--just-types`. It goes through the normal option registry, so it shows up in `--help` and in the typed `rendererOptions` maps. When both `--just-types` and an explicit `--features`/`--framework` are given, `--just-types` wins.

### Migration

| Language | Old spelling | New spelling |
| --- | --- | --- |
| C# | `--features just-types` | `--just-types` |
| C# | `--features just-types-and-namespace` | `--just-types` (the two enum values had identical semantics) |
| Kotlin | `--framework just-types` | `--just-types` |
| Scala 3 | `--framework just-types` | `--just-types` |
| Smithy4s | `--framework just-types` | `--just-types` — or nothing: plain types is Smithy4s's only mode, and its single-value `--framework` option is gone |

API callers: same renames in `rendererOptions` (e.g. `{ framework: "just-types" }` → `{ "just-types": true }`).

### ⚠️ Scala 3's default output changes

`--framework just-types` was Scala 3's *default*, and a removed enum value can't stay the default. The default is now **circe**: a bare `quicktype -l scala3` generates circe (de)serialization instead of plain case classes. To keep the old output, pass `--just-types`. Kotlin's default (klaxon) and C#'s default (`--features complete`, Newtonsoft) are unchanged.

### Cleanups this enables

- C#'s `features` enum keeps `complete` (default) and `attributes-only`; the renderers derive "need helpers/attributes" from `features` and `justTypes` directly.
- Kotlin/Scala 3 renderer dispatch is a plain `if (justTypes)` in front of the framework switch; Smithy4s's framework switch (marked `FIXME: why does this exist`) is deleted.
- The VS Code extension's per-language special-casing collapses into one generic check — which also fixes a bug where its "just types" commands silently generated *full* serialization code for every language other than C# and Kotlin.
- The renderer-options type test keeps `rust` as its "another language's option" compile-error case (Rust really has no `just-types`).

## Testing

Unit tests (all 119 green) assert: `--just-types` yields plain output for all four languages; the removed enum spellings raise `Unknown value … for option …`; the boolean wins over a conflicting explicit enum for C#/Kotlin/Scala 3; Scala 3's bare default now emits circe and Kotlin's stays klaxon. Verified `--just-types`, the conflict rule, the new errors, and `--help` for all four languages with the built CLI. The Smithy4s fixture definition migrates to `{ "just-types": "true" }` (kotlinc isn't available in this environment, so the compile fixtures ride on CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
