### PR TITLE
feat(swift): add final classes option

### DIFF
--- a/packages/quicktype-core/src/language/Swift/SwiftRenderer.ts
+++ b/packages/quicktype-core/src/language/Swift/SwiftRenderer.ts
@@ -500,6 +500,7 @@ export class SwiftRenderer extends ConvenienceRenderer {
 
         const isClass = this._options.useClasses || this.isCycleBreakerType(c);
         const structOrClass = isClass ? "class" : "struct";
+        const finalPrefix = isClass ? "final " : "";
 
         if (isClass && this._options.objcSupport) {
             // [Michael Fey (@MrRooni), 2019-4-24] Swift 5 or greater, must come before the access declaration for the class.
@@ -508,6 +509,7 @@ export class SwiftRenderer extends ConvenienceRenderer {
 
         this.emitBlockWithAccess(
             [
+                finalPrefix,
                 structOrClass,
                 " ",
                 className,
@@ -1163,12 +1165,12 @@ encoder.dateEncodingStrategy = .formatted(formatter)`);
                 this.emitLine(
                     this.objcMembersDeclaration,
                     this.accessLevel,
-                    "class JSONNull: NSObject, Codable {",
+                    "final class JSONNull: NSObject, Codable {",
                 );
             } else {
                 this.emitLine(
                     this.accessLevel,
-                    "class JSONNull: Codable, Hashable {",
+                    "final class JSONNull: Codable, Hashable {",
                 );
             }
 
@@ -1214,7 +1216,7 @@ encoder.dateEncodingStrategy = .formatted(formatter)`);
 
         if (this._needAny) {
             this.ensureBlankLine();
-            this.emitMultiline(`class JSONCodingKey: CodingKey {
+            this.emitMultiline(`final class JSONCodingKey: CodingKey {
 	let key: String
 	
 	required init?(intValue: Int) {
@@ -1239,10 +1241,13 @@ encoder.dateEncodingStrategy = .formatted(formatter)`);
                 this.emitLine(
                     this.objcMembersDeclaration,
                     this.accessLevel,
-                    "class JSONAny: NSObject, Codable {",
+                    "final class JSONAny: NSObject, Codable {",
                 );
             } else {
-                this.emitLine(this.accessLevel, "class JSONAny: Codable {");
+                this.emitLine(
+                    this.accessLevel,
+                    "final class JSONAny: Codable {",
+                );
             }
 
             this.ensureBlankLine();

--- a/packages/quicktype-core/src/language/Swift/SwiftRenderer.ts
+++ b/packages/quicktype-core/src/language/Swift/SwiftRenderer.ts
@@ -500,7 +500,8 @@ export class SwiftRenderer extends ConvenienceRenderer {
 
         const isClass = this._options.useClasses || this.isCycleBreakerType(c);
         const structOrClass = isClass ? "class" : "struct";
-        const finalPrefix = isClass ? "final " : "";
+        const finalPrefix =
+            isClass && this._options.finalClasses ? "final " : "";
 
         if (isClass && this._options.objcSupport) {
             // [Michael Fey (@MrRooni), 2019-4-24] Swift 5 or greater, must come before the access declaration for the class.
@@ -1165,12 +1166,14 @@ encoder.dateEncodingStrategy = .formatted(formatter)`);
                 this.emitLine(
                     this.objcMembersDeclaration,
                     this.accessLevel,
-                    "final class JSONNull: NSObject, Codable {",
+                    this._options.finalClasses ? "final " : "",
+                    "class JSONNull: NSObject, Codable {",
                 );
             } else {
                 this.emitLine(
                     this.accessLevel,
-                    "final class JSONNull: Codable, Hashable {",
+                    this._options.finalClasses ? "final " : "",
+                    "class JSONNull: Codable, Hashable {",
                 );
             }
 
@@ -1216,7 +1219,7 @@ encoder.dateEncodingStrategy = .formatted(formatter)`);
 
         if (this._needAny) {
             this.ensureBlankLine();
-            this.emitMultiline(`final class JSONCodingKey: CodingKey {
+            this.emitMultiline(`${this._options.finalClasses ? "final " : ""}class JSONCodingKey: CodingKey {
 	let key: String
 	
 	required init?(intValue: Int) {
@@ -1241,12 +1244,14 @@ encoder.dateEncodingStrategy = .formatted(formatter)`);
                 this.emitLine(
                     this.objcMembersDeclaration,
                     this.accessLevel,
-                    "final class JSONAny: NSObject, Codable {",
+                    this._options.finalClasses ? "final " : "",
+                    "class JSONAny: NSObject, Codable {",
                 );
             } else {
                 this.emitLine(
                     this.accessLevel,
-                    "final class JSONAny: Codable {",
+                    this._options.finalClasses ? "final " : "",
+                    "class JSONAny: Codable {",
                 );
             }
 

--- a/packages/quicktype-core/src/language/Swift/language.ts
+++ b/packages/quicktype-core/src/language/Swift/language.ts
@@ -54,6 +54,11 @@ export const swiftOptions = {
         } as const,
         "struct",
     ),
+    finalClasses: new BooleanOption(
+        "final-classes",
+        "Mark classes as final",
+        false,
+    ),
     mutableProperties: new BooleanOption(
         "mutable-properties",
         "Use var instead of let for object properties",

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -769,6 +769,10 @@ export const SwiftLanguage: Language = {
     quickTestRendererOptions: [
         { "support-linux": "false" },
         { "struct-or-class": "class" },
+        [
+            "simple-object.json",
+            { "struct-or-class": "class", "final-classes": "true" },
+        ],
         { density: "dense" },
         { density: "normal" },
         { "access-level": "internal" },

--- a/test/unit/swift-final-classes.test.ts
+++ b/test/unit/swift-final-classes.test.ts
@@ -1,0 +1,93 @@
+import {
+    InputData,
+    JSONSchemaInput,
+    type RendererOptions,
+    quicktype,
+} from "../../packages/quicktype-core/src/index.js";
+import { describe, expect, test } from "vitest";
+
+async function renderSwift(
+    schema: object,
+    rendererOptions: RendererOptions = {},
+): Promise<string> {
+    const schemaInput = new JSONSchemaInput(undefined);
+    await schemaInput.addSource({
+        name: "TopLevel",
+        schema: JSON.stringify(schema),
+    });
+
+    const inputData = new InputData();
+    inputData.addInput(schemaInput);
+
+    const result = await quicktype({
+        inputData,
+        lang: "swift",
+        rendererOptions,
+    });
+    return result.lines.join("\n");
+}
+
+function classDeclarations(output: string): string[] {
+    return output
+        .split("\n")
+        .filter((line) =>
+            /^\s*(?:(?:public|internal)\s+)?(?:final\s+)?class\s+/.test(line),
+        );
+}
+
+describe("Swift class generation", () => {
+    test("marks requested model classes as final", async () => {
+        const output = await renderSwift(
+            {
+                type: "object",
+                properties: {
+                    child: {
+                        type: "object",
+                        properties: { name: { type: "string" } },
+                        required: ["name"],
+                    },
+                },
+                required: ["child"],
+            },
+            { "struct-or-class": "class" },
+        );
+        const declarations = classDeclarations(output);
+
+        expect(declarations).toHaveLength(2);
+        expect(declarations).toEqual(
+            expect.arrayContaining([
+                expect.stringContaining("final class TopLevel"),
+                expect.stringContaining("final class Child"),
+            ]),
+        );
+    });
+
+    test("marks cycle breakers and Codable helper classes as final", async () => {
+        const output = await renderSwift({
+            $ref: "#/definitions/Node",
+            definitions: {
+                Node: {
+                    type: "object",
+                    properties: {
+                        next: { $ref: "#/definitions/Node" },
+                        value: {},
+                    },
+                    required: ["value"],
+                },
+            },
+        });
+        const declarations = classDeclarations(output);
+
+        expect(declarations).toEqual(
+            expect.arrayContaining([
+                expect.stringContaining("final class TopLevel"),
+                expect.stringContaining("final class JSONNull"),
+                expect.stringContaining("final class JSONCodingKey"),
+                expect.stringContaining("final class JSONAny"),
+            ]),
+        );
+        expect(declarations.every((line) => line.includes("final class"))).toBe(
+            true,
+        );
+    });
+});

--- a/test/unit/swift-final-classes.test.ts
+++ b/test/unit/swift-final-classes.test.ts
@@ -36,21 +36,51 @@ function classDeclarations(output: string): string[] {
 }
 
 describe("Swift class generation", () => {
-    test("marks requested model classes as final", async () => {
-        const output = await renderSwift(
-            {
+    const modelSchema = {
+        type: "object",
+        properties: {
+            child: {
+                type: "object",
+                properties: { name: { type: "string" } },
+                required: ["name"],
+            },
+        },
+        required: ["child"],
+    };
+    const recursiveSchema = {
+        $ref: "#/definitions/Node",
+        definitions: {
+            Node: {
                 type: "object",
                 properties: {
-                    child: {
-                        type: "object",
-                        properties: { name: { type: "string" } },
-                        required: ["name"],
-                    },
+                    next: { $ref: "#/definitions/Node" },
+                    value: {},
                 },
-                required: ["child"],
+                required: ["value"],
             },
-            { "struct-or-class": "class" },
+        },
+    };
+
+    test("keeps classes open by default", async () => {
+        const modelOutput = await renderSwift(modelSchema, {
+            "struct-or-class": "class",
+        });
+        const recursiveOutput = await renderSwift(recursiveSchema);
+        const declarations = classDeclarations(
+            `${modelOutput}\n${recursiveOutput}`,
         );
+
+        expect(declarations.length).toBeGreaterThan(0);
+        expect(
+            declarations.every((line) => !line.includes("final class")),
+        ).toBe(true);
+    });
+
+    test("marks requested model classes as final when enabled", async () => {
+        const output = await renderSwift(modelSchema, {
+            "struct-or-class": "class",
+            "final-classes": "true",
+        });
         const declarations = classDeclarations(output);
 
         expect(declarations).toHaveLength(2);
@@ -63,18 +93,8 @@ describe("Swift class generation", () => {
     });
 
     test("marks cycle breakers and Codable helper classes as final", async () => {
-        const output = await renderSwift({
-            $ref: "#/definitions/Node",
-            definitions: {
-                Node: {
-                    type: "object",
-                    properties: {
-                        next: { $ref: "#/definitions/Node" },
-                        value: {},
-                    },
-                    required: ["value"],
-                },
-            },
+        const output = await renderSwift(recursiveSchema, {
+            "final-classes": "true",
         });
         const declarations = classDeclarations(output);
 


### PR DESCRIPTION
## Description

Add an opt-in `--final-classes` Swift renderer option. When enabled, it emits every generated Swift reference type as a `final class`:

- models explicitly emitted as classes via `--struct-or-class class`
- models promoted to classes to break recursive value-type cycles
- the generated `JSONNull`, `JSONCodingKey`, and `JSONAny` Codable helpers

The option defaults to `false`, so existing Swift output remains unchanged. Struct output is unchanged in either mode.

## Related Issue

Closes #1241

## Motivation and Context

Final classes communicate that generated models are not intended as subclassing surfaces and can avoid dynamic subclass dispatch. Making the behavior opt-in provides that benefit without introducing a breaking change for users who currently subclass generated types.

The renderer previously had no option for this behavior: it selected only `class` or `struct` for model declarations and hard-coded bare `class` declarations for helper types.

## Previous Behaviour / Output

```swift
class Person: Codable {
    // ...
}

class JSONAny: Codable {
    // ...
}
```

## New Behaviour / Output

With `--final-classes`:

```swift
final class Person: Codable {
    // ...
}

final class JSONAny: Codable {
    // ...
}
```

## How Has This Been Tested?

- focused final-class tests: 3/3 passed, including default-off compatibility
- `npm run test:unit`: 17 files and 130 tests passed with no type errors
- `FIXTURE=swift npm run test:fixtures`: all 241 Swift fixture runs passed with Swift 6.2.3, including the explicit `struct-or-class: class, final-classes: true` variant
- `npm run build`
- Biome on all four changed files
- `git diff --check`
- manual CLI generation confirmed bare `class` by default and `final class` with `--final-classes`

The repository's requested Node 24.6.0 was not installed in this environment; validation used Node 25.6.1. Implementation and validation were assisted by OpenAI Codex and reviewed against the repository guidance.

## Screenshots (if appropriate):

Not applicable; this changes generated source output.
