### PR TITLE
fix: use output filename in TypeScript usage imports

### DIFF
--- a/packages/quicktype-core/src/language/JavaScript/JavaScriptRenderer.ts
+++ b/packages/quicktype-core/src/language/JavaScript/JavaScriptRenderer.ts
@@ -493,8 +493,20 @@ function r(name${stringAnnotation}) {
 
     protected emitTypes(): void {}
 
-    protected emitUsageImportComment(_givenOutputFilename: string): void {
-        this.emitLine('//   const Convert = require("./file");');
+    protected usageModuleName(givenOutputFilename: string): string {
+        return givenOutputFilename === "stdout"
+            ? "file"
+            : givenOutputFilename
+                  .replace(/^.*[/\\]/, "")
+                  .replace(/\.[^.]+$/, "");
+    }
+
+    protected emitUsageImportComment(givenOutputFilename: string): void {
+        this.emitLine(
+            '//   const Convert = require("./',
+            this.usageModuleName(givenOutputFilename),
+            '");',
+        );
     }
 
     protected emitUsageComments(givenOutputFilename: string): void {

--- a/packages/quicktype-core/src/language/JavaScript/JavaScriptRenderer.ts
+++ b/packages/quicktype-core/src/language/JavaScript/JavaScriptRenderer.ts
@@ -493,15 +493,15 @@ function r(name${stringAnnotation}) {
 
     protected emitTypes(): void {}
 
-    protected emitUsageImportComment(): void {
+    protected emitUsageImportComment(_givenOutputFilename: string): void {
         this.emitLine('//   const Convert = require("./file");');
     }
 
-    protected emitUsageComments(): void {
+    protected emitUsageComments(givenOutputFilename: string): void {
         this.emitMultiline(`// To parse this data:
 //`);
 
-        this.emitUsageImportComment();
+        this.emitUsageImportComment(givenOutputFilename);
         this.emitLine("//");
         this.forEachTopLevel("none", (_t, name) => {
             const camelCaseName = modifySource(camelCase, name);
@@ -537,11 +537,11 @@ function r(name${stringAnnotation}) {
         });
     }
 
-    protected emitSourceStructure(): void {
+    protected emitSourceStructure(givenOutputFilename: string): void {
         if (this.leadingComments !== undefined) {
             this.emitComments(this.leadingComments);
         } else {
-            this.emitUsageComments();
+            this.emitUsageComments(givenOutputFilename);
         }
 
         this.emitTypes();

--- a/packages/quicktype-core/src/language/TypeScriptFlow/FlowRenderer.ts
+++ b/packages/quicktype-core/src/language/TypeScriptFlow/FlowRenderer.ts
@@ -39,9 +39,9 @@ export class FlowRenderer extends TypeScriptFlowBaseRenderer {
         });
     }
 
-    protected emitSourceStructure(): void {
+    protected emitSourceStructure(givenOutputFilename: string): void {
         this.emitLine("// @flow");
         this.ensureBlankLine();
-        super.emitSourceStructure();
+        super.emitSourceStructure(givenOutputFilename);
     }
 }

--- a/packages/quicktype-core/src/language/TypeScriptFlow/TypeScriptFlowBaseRenderer.ts
+++ b/packages/quicktype-core/src/language/TypeScriptFlow/TypeScriptFlowBaseRenderer.ts
@@ -191,9 +191,9 @@ export abstract class TypeScriptFlowBaseRenderer extends JavaScriptRenderer {
         );
     }
 
-    protected emitUsageComments(): void {
+    protected emitUsageComments(givenOutputFilename: string): void {
         if (this._tsFlowOptions.justTypes) return;
-        super.emitUsageComments();
+        super.emitUsageComments(givenOutputFilename);
     }
 
     protected deserializerFunctionLine(t: Type, name: Name): Sourcelike {

--- a/packages/quicktype-core/src/language/TypeScriptFlow/TypeScriptRenderer.ts
+++ b/packages/quicktype-core/src/language/TypeScriptFlow/TypeScriptRenderer.ts
@@ -50,7 +50,7 @@ export class TypeScriptRenderer extends TypeScriptFlowBaseRenderer {
 
     protected emitModuleExports(): void {}
 
-    protected emitUsageImportComment(): void {
+    protected emitUsageImportComment(givenOutputFilename: string): void {
         const topLevelNames: Sourcelike[] = [];
         this.forEachTopLevel(
             "none",
@@ -59,10 +59,18 @@ export class TypeScriptRenderer extends TypeScriptFlowBaseRenderer {
             },
             isNamedType,
         );
+        const moduleName =
+            givenOutputFilename === "stdout"
+                ? "file"
+                : givenOutputFilename
+                      .replace(/^.*[/\\]/, "")
+                      .replace(/\.[^.]+$/, "");
         this.emitLine(
             "//   import { Convert",
             topLevelNames,
-            ' } from "./file";',
+            ' } from "./',
+            moduleName,
+            '";',
         );
     }
 

--- a/packages/quicktype-core/src/language/TypeScriptFlow/TypeScriptRenderer.ts
+++ b/packages/quicktype-core/src/language/TypeScriptFlow/TypeScriptRenderer.ts
@@ -59,17 +59,11 @@ export class TypeScriptRenderer extends TypeScriptFlowBaseRenderer {
             },
             isNamedType,
         );
-        const moduleName =
-            givenOutputFilename === "stdout"
-                ? "file"
-                : givenOutputFilename
-                      .replace(/^.*[/\\]/, "")
-                      .replace(/\.[^.]+$/, "");
         this.emitLine(
             "//   import { Convert",
             topLevelNames,
             ' } from "./',
-            moduleName,
+            this.usageModuleName(givenOutputFilename),
             '";',
         );
     }

--- a/test/unit/typescript-output-filename.test.ts
+++ b/test/unit/typescript-output-filename.test.ts
@@ -6,26 +6,65 @@ import {
     quicktype,
 } from "../../packages/quicktype-core/src/index.js";
 
-describe("TypeScript output filename", () => {
-    test("uses output filename in TypeScript usage imports", async () => {
-        const jsonInput = jsonInputForTargetLanguage("typescript");
-        await jsonInput.addSource({
-            name: "ExperimentCounts",
-            samples: ['{"experiments": 3}'],
-        });
+async function generate(
+    lang: string,
+    outputFilename?: string,
+): Promise<string> {
+    const jsonInput = jsonInputForTargetLanguage(lang);
+    await jsonInput.addSource({
+        name: "ExperimentCounts",
+        samples: ['{"experiments": 3}'],
+    });
 
-        const inputData = new InputData();
-        inputData.addInput(jsonInput);
-        const result = await quicktype({
-            inputData,
-            lang: "typescript",
-            outputFilename: "src/cli/ExperimentCounts.ts",
-        });
-        const output = result.lines.join("\n");
+    const inputData = new InputData();
+    inputData.addInput(jsonInput);
+    const result = await quicktype({
+        inputData,
+        lang,
+        outputFilename,
+    });
+    return result.lines.join("\n");
+}
+
+describe("output filename in usage comments", () => {
+    test("uses output filename in TypeScript usage imports", async () => {
+        const output = await generate(
+            "typescript",
+            "src/cli/ExperimentCounts.ts",
+        );
 
         expect(output).toContain(
             '//   import { Convert, ExperimentCounts } from "./ExperimentCounts";',
         );
         expect(output).not.toContain('from "./file"');
+    });
+
+    test("uses output filename in JavaScript usage require", async () => {
+        const output = await generate(
+            "javascript",
+            "src/cli/ExperimentCounts.js",
+        );
+
+        expect(output).toContain(
+            '//   const Convert = require("./ExperimentCounts");',
+        );
+        expect(output).not.toContain('require("./file")');
+    });
+
+    test("uses output filename in Flow usage require", async () => {
+        const output = await generate("flow", "ExperimentCounts.js");
+
+        expect(output).toContain(
+            '//   const Convert = require("./ExperimentCounts");',
+        );
+        expect(output).not.toContain('require("./file")');
+    });
+
+    test('falls back to "file" when writing to stdout', async () => {
+        const tsOutput = await generate("typescript");
+        expect(tsOutput).toContain(' } from "./file";');
+
+        const jsOutput = await generate("javascript");
+        expect(jsOutput).toContain('//   const Convert = require("./file");');
     });
 });

--- a/test/unit/typescript-output-filename.test.ts
+++ b/test/unit/typescript-output-filename.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "vitest";
+
+import {
+    InputData,
+    jsonInputForTargetLanguage,
+    quicktype,
+} from "../../packages/quicktype-core/src/index.js";
+
+describe("TypeScript output filename", () => {
+    test("uses output filename in TypeScript usage imports", async () => {
+        const jsonInput = jsonInputForTargetLanguage("typescript");
+        await jsonInput.addSource({
+            name: "ExperimentCounts",
+            samples: ['{"experiments": 3}'],
+        });
+
+        const inputData = new InputData();
+        inputData.addInput(jsonInput);
+        const result = await quicktype({
+            inputData,
+            lang: "typescript",
+            outputFilename: "src/cli/ExperimentCounts.ts",
+        });
+        const output = result.lines.join("\n");
+
+        expect(output).toContain(
+            '//   import { Convert, ExperimentCounts } from "./ExperimentCounts";',
+        );
+        expect(output).not.toContain('from "./file"');
+    });
+});


### PR DESCRIPTION
## Summary

Use the requested output filename in generated TypeScript usage imports instead of the hard-coded ./file module, with a focused regression.

## Change

- `packages/quicktype-core/src/language/JavaScript/JavaScriptRenderer.ts`
- `packages/quicktype-core/src/language/TypeScriptFlow/FlowRenderer.ts`
- `packages/quicktype-core/src/language/TypeScriptFlow/TypeScriptFlowBaseRenderer.ts`
- `packages/quicktype-core/src/language/TypeScriptFlow/TypeScriptRenderer.ts`
- `test/unit/typescript-output-filename.test.ts`

### Checks
- `npm run test:unit -- test/unit/typescript-output-filename.test.ts` — passed in a network-isolated container.
- `npm run lint` — passed in a network-isolated container.
- `npm run build` — passed in a network-isolated container.

Fixes #971

---
AI assistance was used; I reviewed and own this change.

<!-- northset-receipt:M-105:start -->
### Verification

[Northset proof-of-pass receipt M-105](https://northset-oss.github.io/verification-pilot/receipts/M-105/)  
This record covers Northset’s own contribution; it is not maintainer verification.
Maintainers can request a separate, private run for a PR already in their queue at oss@northset.ai.
For repositories already onboarded with Northset, adding `northset-verify` to a PR requests a run on that PR.
<!-- northset-receipt:M-105:end -->
