### PR TITLE
Move Elm toolchain to 0.19.2

### DIFF
--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -134,7 +134,7 @@ jobs:
             - name: Install Elm
               if: ${{ contains(matrix.fixture, 'elm') }}
               run: |
-                  curl -L -o elm.gz https://github.com/elm/compiler/releases/download/0.19.1/binary-for-linux-64-bit.gz
+                  curl -L -o elm.gz https://github.com/elm/compiler/releases/download/0.19.2/elm-0.19.2-linux-x64.gz
                   gunzip elm.gz
                   chmod +x elm
                   sudo mv elm /usr/local/bin/

--- a/test/fixtures/elm/Warmup.elm
+++ b/test/fixtures/elm/Warmup.elm
@@ -3,7 +3,8 @@ module Warmup exposing (warmup)
 {-| Compiled once by the fixture's setup command so that all package
 dependencies are downloaded and built into the shared ELM_HOME cache
 before the per-sample compiles run in parallel. Concurrent cold-cache
-downloads can corrupt elm 0.19.1's package registry.
+builds corrupt elm's shared package cache (still reproducible with
+elm 0.19.2).
 -}
 
 import Dict exposing (Dict)

--- a/test/fixtures/elm/elm.json
+++ b/test/fixtures/elm/elm.json
@@ -1,7 +1,7 @@
 {
     "type": "application",
     "source-directories": ["."],
-    "elm-version": "0.19.1",
+    "elm-version": "0.19.2",
     "dependencies": {
         "direct": {
             "NoRedInk/elm-json-decode-pipeline": "1.0.1",

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -732,8 +732,9 @@ export const ElmLanguage: Language = {
     name: "elm",
     base: "test/fixtures/elm",
     // Compiling `Warmup.elm` once up front downloads and builds all package
-    // dependencies into the shared ELM_HOME cache; elm 0.19.1 can corrupt
-    // its package registry when parallel compiles race on a cold cache.
+    // dependencies into the shared ELM_HOME cache; elm corrupts its shared
+    // package cache when parallel compiles race on a cold cache (still
+    // reproducible with elm 0.19.2).
     setupCommand: "rm -rf elm-stuff && elm make Warmup.elm --output=/dev/null",
     compileCommand: "elm make Main.elm --output elm.js",
     runCommand(sample: string) {


### PR DESCRIPTION
Follow-up to #2959, which shipped on elm 0.19.1: Elm **0.19.2** was released 2026-07-06 (the first compiler release since 2019), and this moves the Elm fixture toolchain to it.

## What 0.19.2 changes

Per the release notes and the "Faster Builds with Elm 0.19.2" post: compiler performance only (less parser allocation, lower GC/memory) — **no language changes**, so generated code is unaffected.

## Changes here

- `test/fixtures/elm/elm.json` declares `"elm-version": "0.19.2"` — required, since 0.19.2 refuses to build applications declaring 0.19.1 (verified empirically).
- CI downloads the 0.19.2 binary; the release assets are renamed (`elm-0.19.2-linux-x64.gz` instead of 0.19.1's `binary-for-linux-64-bit.gz`).
- The `Warmup.elm` ELM_HOME pre-warm **stays**: 0.19.2 does not fix the concurrent cold-cache corruption. Verified empirically — 3 × 16 parallel cold-cache `elm make` runs against a shared fresh ELM_HOME failed consistently (5-9 of 16 compiles per run) without the warmup. Comments updated to say the issue is still reproducible with 0.19.2.

## Validation

With the 0.19.2 binary and a cold ELM_HOME: `QUICKTEST FIXTURE=elm,schema-elm` passes (100 run / 16 verified skips), and the full corpus passes (266 run: 215 JSON incl. misc + 67 schema, minus skips). `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)