### PR TITLE
feat(csharp): option to suppress DateOnly/TimeOnly converters (System.Text.Json)

### DIFF
--- a/packages/quicktype-core/src/language/CSharp/SystemTextJsonCSharpRenderer.ts
+++ b/packages/quicktype-core/src/language/CSharp/SystemTextJsonCSharpRenderer.ts
@@ -512,8 +512,11 @@ export class SystemTextJsonCSharpRenderer extends CSharpRenderer {
                             }
                         }
 
-                        this.emitLine("new DateOnlyConverter(),");
-                        this.emitLine("new TimeOnlyConverter(),");
+                        if (this._options.dateTimeOnlyConverters) {
+                            this.emitLine("new DateOnlyConverter(),");
+                            this.emitLine("new TimeOnlyConverter(),");
+                        }
+
                         this.emitLine("IsoDateTimeOffsetConverter.Singleton");
                         // this.emitLine("new IsoDateTimeConverter { DateTimeStyles = DateTimeStyles.AssumeUniversal }");
                     });
@@ -1305,7 +1308,16 @@ export class SystemTextJsonCSharpRenderer extends CSharpRenderer {
             this.forEachTransformation("leading-and-interposing", (n, t) =>
                 this.emitTransformation(n, t),
             );
-            this.emitMultiline(`
+            if (this._options.dateTimeOnlyConverters) {
+                this.emitDateTimeOnlyConverters();
+            }
+
+            this.emitIsoDateTimeOffsetConverter();
+        }
+    }
+
+    private emitDateTimeOnlyConverters(): void {
+        this.emitMultiline(`
 public class DateOnlyConverter : JsonConverter<DateOnly>
 {
 	private readonly string serializationFormat;
@@ -1345,9 +1357,12 @@ public class TimeOnlyConverter : JsonConverter<TimeOnly>
 
 	public override void Write(Utf8JsonWriter writer, TimeOnly value, JsonSerializerOptions options)
 			=> writer.WriteStringValue(value.ToString(serializationFormat));
-}
+}`);
+    }
 
-internal class IsoDateTimeOffsetConverter : JsonConverter<DateTimeOffset>
+    private emitIsoDateTimeOffsetConverter(): void {
+        this.ensureBlankLine();
+        this.emitMultiline(`internal class IsoDateTimeOffsetConverter : JsonConverter<DateTimeOffset>
 {
 	public override bool CanConvert(Type t) => t == typeof(DateTimeOffset);
 
@@ -1415,7 +1430,6 @@ internal class IsoDateTimeOffsetConverter : JsonConverter<DateTimeOffset>
 
 	public static readonly IsoDateTimeOffsetConverter Singleton = new IsoDateTimeOffsetConverter();
 }`);
-        }
     }
 
     protected needNamespace(): boolean {

--- a/packages/quicktype-core/src/language/CSharp/language.ts
+++ b/packages/quicktype-core/src/language/CSharp/language.ts
@@ -133,7 +133,15 @@ export const cSharpOptions = {
 
 export const newtonsoftCSharpOptions = { ...cSharpOptions };
 
-export const systemTextJsonCSharpOptions = { ...cSharpOptions };
+export const systemTextJsonCSharpOptions = {
+    ...cSharpOptions,
+    dateTimeOnlyConverters: new BooleanOption(
+        "dateonly-timeonly-converters",
+        "Emit DateOnly/TimeOnly converters (requires .NET 6 or later)",
+        true,
+        "secondary",
+    ),
+};
 
 export const cSharpLanguageConfig = {
     displayName: "C#",
@@ -148,8 +156,8 @@ export class CSharpTargetLanguage extends TargetLanguage<
         super(cSharpLanguageConfig);
     }
 
-    public getOptions(): typeof cSharpOptions {
-        return cSharpOptions;
+    public getOptions(): typeof systemTextJsonCSharpOptions {
+        return systemTextJsonCSharpOptions;
     }
 
     public get stringTypeMapping(): StringTypeMapping {

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -180,6 +180,9 @@ export const CSharpLanguageSystemTextJson: Language = {
         { density: "dense" },
         { "number-type": "decimal" },
         { "any-type": "dynamic" },
+        // Suppressing the DateOnly/TimeOnly converters (for pre-.NET 6
+        // targets) must still produce compiling, round-tripping code.
+        ["unions.json", { "dateonly-timeonly-converters": "false" }],
     ],
     sourceFiles: ["src/language/CSharp/index.ts"],
 };

--- a/test/unit/csharp-dateonly-timeonly-converters.test.ts
+++ b/test/unit/csharp-dateonly-timeonly-converters.test.ts
@@ -1,0 +1,59 @@
+import {
+    InputData,
+    JSONSchemaInput,
+    type RendererOptions,
+    quicktype,
+} from "../../packages/quicktype-core/src/index.js";
+import { describe, expect, test } from "vitest";
+
+async function renderCSharp(
+    rendererOptions: RendererOptions = {},
+): Promise<string> {
+    const schema = {
+        type: "object",
+        properties: {
+            name: { type: "string" },
+            count: { type: "integer" },
+        },
+        required: ["name", "count"],
+    };
+
+    const schemaInput = new JSONSchemaInput(undefined);
+    await schemaInput.addSource({
+        name: "TopLevel",
+        schema: JSON.stringify(schema),
+    });
+
+    const inputData = new InputData();
+    inputData.addInput(schemaInput);
+
+    const result = await quicktype({
+        inputData,
+        lang: "csharp",
+        rendererOptions: { framework: "SystemTextJson", ...rendererOptions },
+    });
+    return result.lines.join("\n");
+}
+
+describe("C# System.Text.Json DateOnly/TimeOnly converters", () => {
+    test("emits the converters by default", async () => {
+        const output = await renderCSharp();
+
+        expect(output).toContain("class DateOnlyConverter");
+        expect(output).toContain("class TimeOnlyConverter");
+        expect(output).toContain("new DateOnlyConverter(),");
+        expect(output).toContain("new TimeOnlyConverter(),");
+    });
+
+    test("omits the converters with dateonly-timeonly-converters=false", async () => {
+        const output = await renderCSharp({
+            "dateonly-timeonly-converters": "false",
+        });
+
+        expect(output).not.toContain("DateOnlyConverter");
+        expect(output).not.toContain("TimeOnlyConverter");
+        // The DateTimeOffset converter is unaffected.
+        expect(output).toContain("class IsoDateTimeOffsetConverter");
+        expect(output).toContain("IsoDateTimeOffsetConverter.Singleton");
+    });
+});


### PR DESCRIPTION
Supersedes #2842, fixes #2629.

This is a reimplementation of @findyoucef's PR #2842, which could not be rebased (conflicts with the C# 8 default work plus unrelated dependency churn). The core idea — making the System.Text.Json `DateOnly`/`TimeOnly` converter emission optional — is theirs; their authorship is preserved via a `Co-authored-by` trailer on the commit.

## Problem

The System.Text.Json C# renderer unconditionally emits `DateOnlyConverter` and `TimeOnlyConverter` helper classes and registers them in `Converter.Settings`. `DateOnly`/`TimeOnly` only exist on .NET 6+, so the generated code does not compile on .NET Standard or older target frameworks (#2629).

## Change

A new System.Text.Json-only boolean option:

```
--[no-]dateonly-timeonly-converters    Emit DateOnly/TimeOnly converters (requires .NET 6 or later) (on by default)
```

With `--no-dateonly-timeonly-converters`, both converter classes and their `Converters = { ... }` registrations are omitted. Nothing else in the generated code references them, so the output still compiles and round-trips. Default output is byte-for-byte identical to master.

The option lives in `systemTextJsonCSharpOptions` rather than the shared `cSharpOptions`, so only the System.Text.Json renderer's typed options include it — it is not a silent no-op field on the Newtonsoft options object (the original PR put its flags in the shared options). `CSharpTargetLanguage.getOptions()` now returns the System.Text.Json superset so the CLI accepts and documents the flag.

### Kept from #2842 vs. dropped

- **Kept**: conditional emission and registration of the two converters, gated on a renderer option — as one flag instead of the original two (`no-dateonly`/`no-timeonly`), since `DateOnly` and `TimeOnly` were introduced together in .NET 6 and no target wants only one of them.
- **Dropped**: the `csTypeLocal` DateOnly→DateTime / TimeOnly→TimeSpan remapping helper (dead code — the C# type mapper never produces `DateOnly`/`TimeOnly` property types; dates map to `DateTimeOffset`); the `package.json`/`package-lock.json` dependency bumps; `.vscode/tasks.json`; and the whitespace reformat of the converter boilerplate (keeping default output byte-identical).

## Testing

- Fixture: `csharp-SystemTextJson` gains a pinned quick-test — `unions.json` with `dateonly-timeonly-converters: false` — proving that generated code with the converters suppressed still compiles and round-trips.
- Unit test `test/unit/csharp-dateonly-timeonly-converters.test.ts`: default output contains both converter classes and registrations; with the flag set it contains neither, while `IsoDateTimeOffsetConverter` is unaffected.
- Locally green: `FIXTURE=csharp-SystemTextJson` (236/236 samples), `FIXTURE=schema-csharp-SystemTextJson`, `FIXTURE=csharp`, `FIXTURE=schema-csharp`, and `npm run test:unit` (165 tests, type tests included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
