### PR TITLE
test(elm): retry elm make after clearing elm-stuff

### DIFF
--- a/test/languages.ts
+++ b/test/languages.ts
@@ -761,7 +761,11 @@ export const ElmLanguage: Language = {
     // package cache when parallel compiles race on a cold cache (still
     // reproducible with elm 0.19.2).
     setupCommand: "rm -rf elm-stuff && elm make Warmup.elm --output=/dev/null",
-    compileCommand: "elm make Main.elm --output elm.js",
+    // The retry after clearing elm-stuff works around the compiler's flaky
+    // per-project cache locking ("d.dat: withBinaryFile: resource busy",
+    // elm/compiler#2258), which strikes under heavy parallel load.
+    compileCommand:
+        "elm make Main.elm --output elm.js || (rm -rf elm-stuff && elm make Main.elm --output elm.js)",
     runCommand(sample: string) {
         return `node ./runner.js "${sample}"`;
     },


### PR DESCRIPTION
CI run 29758296129 (on #2800) failed with the Elm compiler's internal cache-locking flake:

```
elm-stuff/0.19.2/d.dat: withBinaryFile: resource busy (file is locked)
```

This is a long-standing upstream issue (elm/compiler#2258, same message/file; related cache-corruption family: #2075, #2134, #1845) that 0.19.2 did not fix. Our `Warmup.elm` mitigation covers the shared ELM_HOME race but not the per-run-directory `elm-stuff` lock.

Mitigation: on compile failure, delete the run directory's `elm-stuff` and retry once — the canonical workaround for this bug family. Costs nothing when the compile succeeds; a couple of seconds of dependency rebuild from the warmed ELM_HOME when the flake strikes.

Test-harness-only change; no generated output is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)