### PR TITLE
Fix process.process.exit typo in the test harness error path

### DIFF
--- a/test/test.ts
+++ b/test/test.ts
@@ -85,5 +85,5 @@ async function main(sources: string[]) {
 // skip 2 `node` args
 main(process.argv.slice(2)).catch((reason) => {
     console.error(reason);
-    process.process.exit(1);
+    process.exit(1);
 });


### PR DESCRIPTION
`test/test.ts`'s top-level catch handler has `process.process.exit(1)` (typo from 232e259e, when the `exit` package was replaced). It only executes when `main()` rejects — first seen today on #2964, where a curl SSL flake in the cJSON fixture setup rejected `main()` and the handler crashed with `TypeError: Cannot read properties of undefined (reading 'exit')`, burying the actual error. Exit code was 1 either way; this just restores honest diagnostics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)