### PR TITLE
fix(schema-input): report clean fetch error for missing schema paths

### DIFF
--- a/packages/quicktype-core/src/input/JSONSchemaInput.ts
+++ b/packages/quicktype-core/src/input/JSONSchemaInput.ts
@@ -783,7 +783,7 @@ class Resolver {
             return [schema, result[1]];
         }
 
-        return schemaFetchError(base, virtualRef.address);
+        return schemaFetchError(base, virtualRef.toString());
     }
 
     public async resolveTopLevelRef(ref: Ref): Promise<[JSONSchema, Location]> {

--- a/test/unit/missing-schema-path.test.ts
+++ b/test/unit/missing-schema-path.test.ts
@@ -1,0 +1,36 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import {
+    FetchingJSONSchemaStore,
+    InputData,
+    JSONSchemaInput,
+    quicktype,
+} from "quicktype-core";
+import { expect, test } from "vitest";
+
+// Regression test for issue #2812: shells such as PowerShell pass wildcard
+// arguments through literally, so a schema wildcard with no matching file must
+// report a normal missing-file error rather than an internal error.
+test("missing JSON Schema paths report the fetch error", async () => {
+    const tempDir = fs.mkdtempSync(
+        path.join(os.tmpdir(), "quicktype-missing-schema-"),
+    );
+    const missingPath = path.join(tempDir, "*.json");
+
+    try {
+        const schemaInput = new JSONSchemaInput(new FetchingJSONSchemaStore());
+        await schemaInput.addSource({ name: "TopLevel", uris: [missingPath] });
+        const inputData = new InputData();
+        inputData.addInput(schemaInput);
+
+        await expect(
+            quicktype({ inputData, lang: "typescript" }),
+        ).rejects.toThrow(
+            `Could not fetch schema #, referred to from ${missingPath}#`,
+        );
+    } finally {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+});


### PR DESCRIPTION
## Bug

`--src-lang schema` crashed with an unhelpful internal-error panic when given
a source path that doesn't exist:

```
$ node dist/index.js --src-lang schema --lang typescript --just-types --src '*.json'
Error: Internal error: Defined value expected, but got undefined.
```

This typically bites Windows/PowerShell users, whose shell doesn't expand
`--src *.json` the way POSIX shells do, so the literal, non-existent string
`*.json` is passed through to quicktype. For comparison, `--src-lang json`
with the same missing-path input gives a clean `ENOENT` error instead of a
panic.

## Root cause

`JSONSchemaStore.get` (`packages/quicktype-core/src/input/JSONSchemaStore.ts`)
swallows the fetch error for a missing file and returns `undefined`.
`Resolver.resolveVirtualRef` (`packages/quicktype-core/src/input/JSONSchemaInput.ts`)
then calls `schemaFetchError(base, virtualRef.address)` to report the
failure — but `virtualRef` has no address in this case, and `Ref.address`
panics via `defined()` when `addressURI` is `undefined`. That panic is what
surfaces as "Internal error: Defined value expected, but got undefined."

## Fix

Use `virtualRef.toString()` instead of `virtualRef.address` when building the
fetch-error message. `toString()` doesn't require an address (it degrades to
an empty string for the address portion), so building the error message no
longer panics. The CLI now reports a normal diagnostic:

```
$ node dist/index.js --src-lang schema --lang typescript --just-types --src '*.json'
Error: Could not fetch schema #, referred to from *.json#.
```

This is a minimal, one-line change scoped to the crash itself. CLI-side glob
expansion (the other defect discussed on the issue) is out of scope for this
PR.

## Test coverage

Added `test/unit/missing-schema-path.test.ts`, a regression unit test that
drives `JSONSchemaInput`/`FetchingJSONSchemaStore`/`quicktype()` directly
(the same pattern used by `test/unit/windows-schema-paths.test.ts` for issue
#2869) to assert that a schema source pointing at a nonexistent path (a
literal wildcard, simulating what PowerShell passes through) rejects with a
normal "Could not fetch schema ..." error rather than throwing/panicking.
This is a unit test rather than a fixture test because the bug is about
error-handling/messaging for a missing input file, not about generated
output for valid input — exactly the kind of thing fixtures can't express.

Confirmed the test fails against the unfixed code (the panic message) and
passes after the fix.

## Verification

- `npm run build` passes.
- `npm run test:unit` — all 164 unit tests pass, including the new
  regression test.
- Manually re-ran the exact repro from the issue/triage comment and confirmed
  the internal-error panic no longer occurs; a clean fetch-error message is
  reported instead.
- No fixture test was added since this change does not affect generated
  output for any valid input — CI will additionally validate the full
  fixture suite.

Fixes #2812

🤖 Generated with [Claude Code](https://claude.com/claude-code)