### PR TITLE
fix(typescript-input): strip brace-wrapped types from JSDoc @type tags

### DIFF
--- a/packages/quicktype-typescript-input/src/index.ts
+++ b/packages/quicktype-typescript-input/src/index.ts
@@ -125,6 +125,30 @@ function patchGeneratorForBuiltinTypes(
     };
 }
 
+// typescript-json-schema copies JSDoc `@type {string}` annotations into the
+// generated schema verbatim. Strip the JSDoc braces so the value is a valid
+// JSON Schema type.
+function sanitizeTypeAnnotations(value: unknown): void {
+    if (Array.isArray(value)) {
+        value.forEach(sanitizeTypeAnnotations);
+        return;
+    }
+
+    if (value === null || typeof value !== "object") {
+        return;
+    }
+
+    const schema = value as Record<string, unknown>;
+    if (typeof schema.type === "string") {
+        const match = /^\{([^{}]+)\}$/.exec(schema.type);
+        if (match !== null) {
+            schema.type = match[1];
+        }
+    }
+
+    Object.values(schema).forEach(sanitizeTypeAnnotations);
+}
+
 // FIXME: We're stringifying and then parsing this schema again. Just pass around
 // the schema directly.
 export function schemaForTypeScriptSources(
@@ -151,6 +175,8 @@ export function schemaForTypeScriptSources(
     patchGeneratorForBuiltinTypes(generator, program);
 
     const schema = generateSchema(program, "*", settings, undefined, generator);
+    sanitizeTypeAnnotations(schema);
+
     const uris: string[] = [];
     let topLevelName = "";
 

--- a/test/unit/typescript-input.test.ts
+++ b/test/unit/typescript-input.test.ts
@@ -84,6 +84,23 @@ describe("schemaForTypeScriptSources", () => {
         expect(schema.definitions.Person.type).toBe("object");
     });
 
+    // https://github.com/glideapps/quicktype/issues/2695
+    test("strips braces from JSDoc type annotations", () => {
+        const { schema } = schemaForSource(`
+            export type Person = {
+                /**
+                 * @type {string}
+                 * @memberOf {Person}
+                 */
+                name: string;
+            };
+
+            export type MemberInfo = Required<Person>;
+        `);
+
+        expect(schema.definitions.Person.properties.name.type).toBe("string");
+    });
+
     test("class property initializers become defaults", () => {
         const { schema } = schemaForSource(`
             export class Config {


### PR DESCRIPTION
## Bug

TypeScript input properties documented with a JSDoc `@type {...}` tag (e.g.
`@type {string}`) produced invalid `"type": "{string}"` in the generated
JSON Schema instead of `"type": "string"`, when converting via
`--src-lang typescript --lang schema`.

```ts
export type Person = {
  /**
   * @type {string}
   */
  name: string;
}
```

produced:

```json
{ "type": "{string}", "title": "name" }
```

instead of the expected:

```json
{ "type": "string", "title": "name" }
```

Because the resulting schema is invalid JSON Schema, feeding it back into
quicktype for *any other* target language then failed hard with
`Invalid type {string} in JSON Schema`.

## Root cause

`packages/quicktype-typescript-input` wraps the `typescript-json-schema` npm
package (a normal, unforked dependency). That package hardcodes `type` as an
always-on "validation keyword": when it sees a JSDoc `@type {TypeExpression}`
tag on a symbol, it copies the tag's raw text — including the surrounding
braces from the JSDoc syntax — verbatim into the generated schema's `type`
field, overwriting the correct type inferred from the TypeScript type. This
behavior isn't configurable via the settings quicktype passes in, so it can't
be disabled at the call site.

## Fix

Added a small post-processing pass (`sanitizeTypeAnnotations`) in
`packages/quicktype-typescript-input/src/index.ts`, run on the schema
right after `generateSchema()` returns (in the same spirit as the existing
post-processing already done in that function). It walks the schema
recursively and strips a single pair of surrounding braces from any string
`type` value, e.g. turning `"{string}"` into `"string"`.

## Test coverage

Added a regression test in `test/unit/typescript-input.test.ts` reproducing
the issue's exact TypeScript input (a `@type {string}`-documented property
plus a `Required<Person>` usage) and asserting the generated schema's
property type is the plain string `"string"`. The test was confirmed to fail
on unfixed code (`Received: "{string}"`) before the fix was applied.

## Verification

- `npm run build` — passes
- `npm run test:unit` — 25 files, 164 tests pass (including the new
  regression test)
- Manually re-ran the issue's repro:
  `node dist/index.js --src person.ts --src-lang typescript --lang schema`
  now emits `"type": "string"` instead of `"type": "{string}"`
- Manually confirmed the cascading failure is also fixed: generating Go
  output from the same TypeScript input (`--lang go`) now succeeds instead
  of erroring with `Invalid type {string} in JSON Schema`
- This bug is on the TypeScript-as-input-language path, which isn't
  exercised by the JSON/JSON-Schema fixture system (that operates on
  JSON/JSON-Schema *inputs*, not TypeScript source), so unit test coverage
  in `test/unit/` is the appropriate mechanism here, consistent with how the
  rest of that file already tests `schemaForTypeScriptSources`. CI will run
  the full fixture and unit test suites.

Fixes #2695

🤖 Generated with [Claude Code](https://claude.com/claude-code)