### PR TITLE
fix(json-schema): recognize $defs when deriving type names

### DIFF
--- a/packages/quicktype-core/src/input/JSONSchemaInput.ts
+++ b/packages/quicktype-core/src/input/JSONSchemaInput.ts
@@ -306,7 +306,7 @@ export class Ref {
     public get definitionName(): string | undefined {
         const pe = arrayGetFromEnd(this.path, 2);
         if (pe === undefined) return undefined;
-        if (keyOrIndex(pe) === "definitions")
+        if (keyOrIndex(pe) === "definitions" || keyOrIndex(pe) === "$defs")
             return keyOrIndex(defined(arrayLast(this.path)));
         return undefined;
     }

--- a/test/inputs/schema/light.1.json
+++ b/test/inputs/schema/light.1.json
@@ -1,0 +1,7 @@
+{
+  "LightParams": {
+    "outlet_id": "outlet-1",
+    "app_id": "app-1",
+    "rgba": "255,255,255,1"
+  }
+}

--- a/test/inputs/schema/light.schema
+++ b/test/inputs/schema/light.schema
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$defs": {
+    "LightParams": {
+      "type": "object",
+      "properties": {
+        "outlet_id": { "type": "string" },
+        "app_id": { "type": "string" },
+        "rgba": { "type": "string" }
+      },
+      "additionalProperties": false,
+      "required": ["outlet_id", "app_id", "rgba"]
+    }
+  },
+  "type": "object",
+  "properties": {
+    "LightParams": { "$ref": "#/$defs/LightParams" }
+  },
+  "additionalProperties": false,
+  "required": ["LightParams"]
+}

--- a/test/unit/json-schema-definitions.test.ts
+++ b/test/unit/json-schema-definitions.test.ts
@@ -1,0 +1,51 @@
+import {
+    FetchingJSONSchemaStore,
+    InputData,
+    JSONSchemaInput,
+    quicktype,
+} from "quicktype-core";
+import { expect, test } from "vitest";
+
+const lightSchema = {
+    $schema: "https://json-schema.org/draft/2020-12/schema",
+    $defs: {
+        LightParams: {
+            type: "object",
+            properties: {
+                outlet_id: { type: "string" },
+                app_id: { type: "string" },
+                rgba: { type: "string" },
+            },
+            additionalProperties: false,
+            required: ["outlet_id", "app_id", "rgba"],
+        },
+    },
+    type: "object",
+    properties: {
+        LightParams: { $ref: "#/$defs/LightParams" },
+    },
+    additionalProperties: false,
+    required: ["LightParams"],
+};
+
+test("a type under $defs keeps its definition name (issue #2778)", async () => {
+    const schemaInput = new JSONSchemaInput(new FetchingJSONSchemaStore());
+    await schemaInput.addSource({
+        name: "LightSchema",
+        schema: JSON.stringify(lightSchema),
+    });
+    const inputData = new InputData();
+    inputData.addInput(schemaInput);
+
+    const result = await quicktype({
+        inputData,
+        lang: "typescript",
+        rendererOptions: { "just-types": "true" },
+    });
+    const output = result.lines.join("\n");
+
+    // The fixture exercises this schema end-to-end, but generated symbol names
+    // are not observable at runtime, so assert the regression here.
+    expect(output).toContain("LightParams: LightParams;");
+    expect(output).toContain("export interface LightParams {");
+});


### PR DESCRIPTION
## Bug

Fixes #2778.

A JSON Schema that defines a type under `$defs` and references it got a
different, truncated name in generated output than the name given in the
schema. For example, a type named `LightParams` under `$defs` was emitted
as `Light` in generated TypeScript. Renaming `$defs` to the legacy
`definitions` keyword in the same schema produced the correct name,
which pointed at the root cause.

## Root cause

`Ref.definitionName` in `packages/quicktype-core/src/input/JSONSchemaInput.ts`
only recognized the legacy `"definitions"` JSON Schema keyword, not `"$defs"`
(the standard keyword for local definitions since draft 2019-09, used by the
2020-12 draft referenced in the issue). Because of this, a type's `$defs` key
was never treated as a "given name" for the type. The type kept only its
*inferred* names (e.g. the referencing property name, plus a name derived
from the input file name), and `combineNames` in
`packages/quicktype-core/src/attributes/TypeNames.ts` merged those candidates
by common prefix — which produced the truncated/wrong name.

## Fix

`definitionName` now also recognizes `"$defs"` alongside `"definitions"`:

```ts
if (keyOrIndex(pe) === "definitions" || keyOrIndex(pe) === "$defs")
    return keyOrIndex(defined(arrayLast(this.path)));
```

## Test coverage

- New JSON Schema fixture `test/inputs/schema/light.schema` +
  `test/inputs/schema/light.1.json`, reproducing the schema from the issue,
  runs end-to-end (round-trip) for every schema-input language fixture.
- New unit test `test/unit/json-schema-definitions.test.ts` asserts the
  generated TypeScript interface is named `LightParams`, not `Light`. This
  is a unit test rather than a fixture-only check because fixture tests
  validate round-tripping, not the exact generated symbol name — the actual
  regression here.
- Checked `test/inputs/schema/*.schema` for any other existing input using
  `$defs`; `light.schema` is the only one, so no other fixture snapshots are
  affected by this change.

## Verification

- `npm run build` — passes.
- `npm run test:unit` — 164/164 tests pass (26 files).
- Re-ran the exact repro from the issue:
  ```
  node dist/index.js --src-lang schema --lang ts --just-types --no-date-times --alphabetize-properties light.schema.json
  ```
  Before: `export interface Light { ... }` (referenced as `Light`).
  After: `export interface LightParams { ... }` (referenced as `LightParams`), matching the reporter's expectation.
- `QUICKTEST=true FIXTURE=schema-typescript script/test test/inputs/schema/light.schema` — passes.
- `biome check` on changed files — clean.
- Ran the full `schema-typescript` fixture set locally; confirmed one pre-existing, unrelated failure (`vega-lite.schema` hits pre-existing TypeScript compile errors, TS2411, on unmodified master as well — unrelated to this change). CI will validate the rest of the language matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)