### PR TITLE
fix(cli): surface clear error for duplicate -o instead of internal error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -751,7 +751,6 @@ function parseOptions(
             { argv, partial },
         );
     } catch (e) {
-        assert(!partial, "Partial option parsing should not have failed");
         return messageError("DriverCLIOptionParsingFailed", {
             message: exceptionToString(e),
         });

--- a/test/unit/cli-options.test.ts
+++ b/test/unit/cli-options.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "vitest";
+
+import { parseCLIOptions } from "../../src/index.js";
+
+describe("CLI option parsing", () => {
+    test("reports a duplicate output option as a user input error", () => {
+        expect(() =>
+            parseCLIOptions(["-o", "list.go", "-o", "list.ts"]),
+        ).toThrow(/^Option parsing failed: .*Singular option already set/);
+
+        expect(() =>
+            parseCLIOptions(["-o", "list.go", "-o", "list.ts"]),
+        ).not.toThrow("Internal error");
+    });
+});


### PR DESCRIPTION
## Bug

Passing a singular CLI option twice — e.g. `-o list.go -o list.ts` — produced an opaque, unhelpful error:

```
Error: Internal error: Partial option parsing should not have failed.
```

### Repro

```bash
node dist/index.js -o list.go -o list.ts --package transport --src-lang schema ./list.schema.json
```

## Root cause

`command-line-args` throws `ALREADY_SET` ("Singular option already set [out=...]") when a singular option like `-o`/`--out` is passed more than once — even when parsing with `partial: true`. quicktype's `parseOptions()` in `src/index.ts` wrapped the parse call in a try/catch that asserted partial parsing could never throw:

```ts
} catch (e) {
    assert(!partial, "Partial option parsing should not have failed");
    return messageError("DriverCLIOptionParsingFailed", { message: exceptionToString(e) });
}
```

Since the assertion fired before the library's actual error message could reach the user, the CLI printed a generic "Internal error" instead of routing the failure through the existing `messageError("DriverCLIOptionParsingFailed", ...)` path used for non-partial parse failures.

## Fix

Remove the `assert(!partial, ...)` so partial-parse failures flow through the same `messageError` path as non-partial ones, surfacing the library's actual message.

## Test coverage

Added `test/unit/cli-options.test.ts`, which calls `parseCLIOptions(["-o", "list.go", "-o", "list.ts"])` and asserts it throws a message containing "Singular option already set" and does *not* contain "Internal error". This fails on unfixed code (the internal-error assertion trips) and passes after the fix.

This is CLI option-parsing/error-message behavior, not generated-code output for any target language, so it isn't expressible as a JSON/JSON Schema fixture test per repo conventions — a focused unit test is the appropriate coverage here.

## Verification

- `npm run build` passes.
- `npm run test:unit` — all 164 tests pass (26 files), including the new test.
- Manually re-ran the repro against the built CLI:
  ```
  $ node dist/index.js -o list.go -o list.ts --package transport --src-lang schema ./list.schema.json
  Error: Option parsing failed: ALREADY_SET: Singular option already set [out=list.go].
  ```
  Exit code 1, clear message, no more "Internal error".

Fixes #2457

🤖 Generated with [Claude Code](https://claude.com/claude-code)