### PR TITLE
fix(schema): emit min/max constraints for applicable type kinds

### DIFF
--- a/packages/quicktype-core/src/attributes/Constraints.ts
+++ b/packages/quicktype-core/src/attributes/Constraints.ts
@@ -97,7 +97,7 @@ export class MinMaxConstraintTypeAttributeKind extends TypeAttributeKind<MinMaxC
         t: Type,
         attr: MinMaxConstraint,
     ): void {
-        if (this._typeKinds.has(t.kind)) return;
+        if (!this._typeKinds.has(t.kind)) return;
 
         const [min, max] = attr;
         if (min !== undefined) {

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -1587,6 +1587,7 @@ export const allFixtures: Fixture[] = [
     new JSONSchemaJSONFixture(languages.CSharpLanguage),
     new JSONTypeScriptFixture(languages.CSharpLanguage),
     // new JSONSchemaFixture(languages.CrystalLanguage),
+    new JSONSchemaFixture(languages.JSONSchemaLanguage),
     new JSONSchemaFixture(languages.CSharpLanguage),
     new JSONSchemaFixture(
         languages.CSharpLanguageSystemTextJson,

--- a/test/fixtures/schema/main.js
+++ b/test/fixtures/schema/main.js
@@ -1,0 +1,22 @@
+const fs = require("node:fs");
+
+const Ajv = require("ajv");
+const addFormats = require("ajv-formats");
+const draft06MetaSchema = require("ajv/dist/refs/json-schema-draft-06.json");
+
+const schema = JSON.parse(fs.readFileSync("TopLevel.schema", "utf8"));
+const input = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+
+const ajv = new Ajv({ ownProperties: true });
+ajv.addMetaSchema(draft06MetaSchema);
+addFormats(ajv);
+ajv.addVocabulary(["qt-uri-protocols", "qt-uri-extensions"]);
+ajv.addFormat("integer", true);
+ajv.addFormat("boolean", true);
+
+if (!ajv.validate(schema, input)) {
+    console.error(ajv.errorsText());
+    process.exit(1);
+}
+
+console.log(JSON.stringify(input));

--- a/test/inputs/schema/schema-constraints.1.fail.minmaxlength.json
+++ b/test/inputs/schema/schema-constraints.1.fail.minmaxlength.json
@@ -1,0 +1,4 @@
+{
+  "minMaxLength": "1234",
+  "percent": 0.5
+}

--- a/test/inputs/schema/schema-constraints.1.json
+++ b/test/inputs/schema/schema-constraints.1.json
@@ -1,0 +1,4 @@
+{
+  "minMaxLength": "12345",
+  "percent": 0.5
+}

--- a/test/inputs/schema/schema-constraints.2.fail.minmaxlength.json
+++ b/test/inputs/schema/schema-constraints.2.fail.minmaxlength.json
@@ -1,0 +1,4 @@
+{
+  "minMaxLength": "123456",
+  "percent": 0.5
+}

--- a/test/inputs/schema/schema-constraints.3.fail.minmax.json
+++ b/test/inputs/schema/schema-constraints.3.fail.minmax.json
@@ -1,0 +1,4 @@
+{
+  "minMaxLength": "12345",
+  "percent": -0.5
+}

--- a/test/inputs/schema/schema-constraints.4.fail.minmax.json
+++ b/test/inputs/schema/schema-constraints.4.fail.minmax.json
@@ -1,0 +1,4 @@
+{
+  "minMaxLength": "12345",
+  "percent": 2
+}

--- a/test/inputs/schema/schema-constraints.schema
+++ b/test/inputs/schema/schema-constraints.schema
@@ -1,0 +1,16 @@
+{
+  "type": "object",
+  "properties": {
+    "minMaxLength": {
+      "type": "string",
+      "minLength": 5,
+      "maxLength": 5
+    },
+    "percent": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    }
+  },
+  "required": ["minMaxLength", "percent"]
+}

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -602,6 +602,7 @@ export const CJSONLanguage: Language = {
         "prefix-items.schema",
         /* Constraints (min/max and regex) are not supported (for the current implementation, can be added later, should abord parsing and return NULL) */
         "minmaxlength.schema",
+        "schema-constraints.schema",
         "optional-const-ref.schema",
         /* Same unsupported min/max, length and regex constraints, applied to optional properties */
         "optional-constraints.schema",

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -81,6 +81,26 @@ export interface Language {
     sourceFiles?: string[];
 }
 
+export const JSONSchemaLanguage: Language = {
+    name: "schema",
+    base: "test/fixtures/schema",
+    runCommand(sample: string) {
+        return `node main.js "${sample}"`;
+    },
+    diffViaSchema: false,
+    skipDiffViaSchema: [],
+    allowMissingNull: false,
+    features: ["minmax", "minmaxlength", "pattern"],
+    output: "TopLevel.schema",
+    topLevel: "TopLevel",
+    skipJSON: [],
+    skipMiscJSON: false,
+    skipSchema: [],
+    rendererOptions: {},
+    quickTestRendererOptions: [],
+    sourceFiles: ["src/language/JSONSchema/JSONSchemaRenderer.ts"],
+};
+
 export const CSharpLanguage: Language = {
     name: "csharp",
     base: "test/fixtures/csharp",


### PR DESCRIPTION
## Bug

Reported in #2557: converting a JSON Schema through quicktype's
`--src-lang schema ... --lang schema` round trip silently dropped
`minLength`/`maxLength` (on strings) and `minimum`/`maximum` (on
numbers/integers) from the output schema, while `pattern` and
`description` survived correctly. Since the schema-to-schema pass is the
first stage of every other output language too, this also meant the
constraints never reached downstream generators (TypeScript, zod, etc.).

## Root cause

`MinMaxConstraintTypeAttributeKind.addToSchema` in
`packages/quicktype-core/src/attributes/Constraints.ts` had an inverted
applicability guard:

```ts
if (this._typeKinds.has(t.kind)) return;
```

`_typeKinds` holds the type kinds a given constraint kind actually
applies to (`{"integer", "double"}` for min/max value,  `{"string"}` for
min/max length). As written, the method bailed out and skipped emitting
the constraint into the schema exactly when the type's kind *was*
applicable — the opposite of the intended behavior. Compare with
`PatternTypeAttributeKind.addToSchema`, which has the correct polarity
(`if (t.kind !== "string") return;`) and is why `pattern` round-tripped
fine while `minLength`/`maxLength`/`minimum`/`maximum` did not.

## Fix

Inverted the guard:

```ts
if (!this._typeKinds.has(t.kind)) return;
```

This is a one-line change; the zod/TypeScript renderers not emitting
these constraints into generated validation code is a separate, unrelated
missing feature and is out of scope for this PR.

## Test coverage

- Added a new `schema-schema` fixture (`test/fixtures/schema/main.js`)
  that validates the round-tripped JSON Schema output against the
  original sample using AJV, registered in `test/languages.ts` /
  `test/fixtures.ts`.
- Added `test/inputs/schema/schema-constraints.schema` with:
  - `schema-constraints.1.json` — a sample that satisfies
    `minLength`/`maxLength`/`minimum`/`maximum`.
  - `schema-constraints.{1,2}.fail.minmaxlength.json` — samples that
    violate `minLength`/`maxLength` and must be rejected by the
    generated schema.
  - `schema-constraints.{3,4}.fail.minmax.json` — samples that violate
    `minimum`/`maximum` and must be rejected by the generated schema.

These fail samples only pass once the generated schema actually contains
the constraints, so they reproduce the bug on unfixed code and verify the
fix.

## Verification (local)

- `npm run build` — passes.
- `QUICKTEST=true FIXTURE=schema-schema script/test` — 68/68 passed
  (including the new `schema-constraints.schema` cases).
- `npm run test:unit` — 163/163 tests passed across 25 files.
- Manually re-ran the reporter's repro
  (`node dist/index.js --src-lang schema bad-schema.json --lang schema`)
  and confirmed `minLength`/`maxLength`/`minimum`/`maximum` are now
  present in the generated schema.
- Full multi-language fixture suite (`FIXTURE=schema`, all
  `schema-<lang>` targets) is left to CI, since several target-language
  toolchains (e.g. `dotnet`) aren't available in this environment.

Fixes #2557

🤖 Generated with [Claude Code](https://claude.com/claude-code)