### PR TITLE
fix(csharp): throw JsonException/NotSupportedException in SystemTextJson converters

### DIFF
--- a/packages/quicktype-core/src/language/CSharp/SystemTextJsonCSharpRenderer.ts
+++ b/packages/quicktype-core/src/language/CSharp/SystemTextJsonCSharpRenderer.ts
@@ -375,8 +375,11 @@ export class SystemTextJsonCSharpRenderer extends CSharpRenderer {
         this.emitLine("case JsonTokenType.", tokenType, ":");
     }
 
-    private emitThrow(message: Sourcelike): void {
-        this.emitLine("throw new Exception(", message, ");");
+    private emitThrow(
+        exceptionType: "JsonException" | "NotSupportedException",
+        message: Sourcelike,
+    ): void {
+        this.emitLine("throw new ", exceptionType, "(", message, ");");
     }
 
     private deserializeTypeCode(typeName: Sourcelike): Sourcelike {
@@ -1239,7 +1242,7 @@ export class SystemTextJsonCSharpRenderer extends CSharpRenderer {
                         (v) => this.emitLine("return ", v, ";"),
                     );
                     if (!allHandled) {
-                        this.emitThrow([
+                        this.emitThrow("JsonException", [
                             '"Cannot unmarshal type ',
                             csType,
                             '"',
@@ -1266,7 +1269,7 @@ export class SystemTextJsonCSharpRenderer extends CSharpRenderer {
                             () => this.emitLine("return;"),
                         );
                         if (!allHandled) {
-                            this.emitThrow([
+                            this.emitThrow("NotSupportedException", [
                                 '"Cannot marshal type ',
                                 csType,
                                 '"',

--- a/test/unit/csharp-system-text-json-exceptions.test.ts
+++ b/test/unit/csharp-system-text-json-exceptions.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "vitest";
+
+import {
+    InputData,
+    JSONSchemaInput,
+    quicktype,
+} from "../../packages/quicktype-core/src/index.js";
+
+async function renderSystemTextJsonCSharp(schema: object): Promise<string> {
+    const schemaInput = new JSONSchemaInput(undefined);
+    await schemaInput.addSource({
+        name: "TopLevel",
+        schema: JSON.stringify(schema),
+    });
+
+    const inputData = new InputData();
+    inputData.addInput(schemaInput);
+
+    const result = await quicktype({
+        inputData,
+        lang: "csharp",
+        rendererOptions: { framework: "SystemTextJson" },
+    });
+    return result.lines.join("\n");
+}
+
+describe("C# System.Text.Json converters", () => {
+    test("throw serializer-supported exceptions for union conversion failures", async () => {
+        const output = await renderSystemTextJsonCSharp({
+            type: "object",
+            properties: {
+                mixed: { oneOf: [{ type: "integer" }, { type: "string" }] },
+            },
+            required: ["mixed"],
+        });
+
+        expect(output).toContain(
+            'throw new JsonException("Cannot unmarshal type Mixed");',
+        );
+        expect(output).toContain(
+            'throw new NotSupportedException("Cannot marshal type Mixed");',
+        );
+        expect(output).not.toContain("throw new Exception(");
+    });
+});


### PR DESCRIPTION
## Bug

Per MS docs (https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/converters-how-to?pivots=dotnet-7-0#error-handling), custom `System.Text.Json` `JsonConverter`s should throw `JsonException` (malformed/unexpected tokens) or `NotSupportedException`, so the serializer can attach JSON path/line/position diagnostics to the error. Generated C# `SystemTextJson` union converters instead threw a bare `System.Exception`, losing that diagnostic info for callers.

## Root cause

Both throw sites in `emitTransformation` (the union-type read/write converter emitter) funneled through the `emitThrow()` helper in `packages/quicktype-core/src/language/CSharp/SystemTextJsonCSharpRenderer.ts`, which always emitted `throw new Exception(...)`.

## Fix

`emitThrow()` now takes an explicit exception type parameter:
- The `Read` (unmarshal) failure path now throws `JsonException`.
- The `Write` (marshal) failure path now throws `NotSupportedException`.

This only affects the `SystemTextJson` C# framework (`--framework SystemTextJson`); the `NewtonSoft` C# renderer is untouched.

## Repro

```
node dist/index.js --lang csharp --src-lang json --framework SystemTextJson -o out.cs sample.json
```
with `sample.json`:
```json
[
  {"kind": "alpha", "mixed": 5},
  {"kind": "beta", "mixed": "five"}
]
```

Before: `throw new Exception("Cannot unmarshal type Mixed");` / `throw new Exception("Cannot marshal type Mixed");`
After: `throw new JsonException("Cannot unmarshal type Mixed");` / `throw new NotSupportedException("Cannot marshal type Mixed");`

## Test coverage

Since the existing end-to-end fixtures only check that the driver process exits nonzero on failure (any exception type satisfies that — they can't distinguish `Exception` from `JsonException`), this change is covered by a new unit test, `test/unit/csharp-system-text-json-exceptions.test.ts`, following the established "assert on generated source text" pattern (see `test/unit/swift-final-classes.test.ts`). It renders a schema producing a C# union with `framework: SystemTextJson` and asserts the generated source contains `JsonException`/`NotSupportedException` throws and no bare `throw new Exception(`.

## Verification

- Confirmed the regression test fails against the pre-fix code.
- `npm run build` passes.
- `npm run test:unit` — all 164 tests pass.
- Manually re-ran the CLI repro above and confirmed the generated code now throws `JsonException`/`NotSupportedException`.
- The `dotnet` toolchain is not available in this environment, so the `csharp-SystemTextJson` end-to-end fixture (`FIXTURE=csharp-SystemTextJson script/test`) was not run locally; CI will validate that the generated code still compiles and the union round-trip fixtures still pass (they only assert nonzero exit on failure, so this change is expected to be compatible).

Fixes #2364

🤖 Generated with [Claude Code](https://claude.com/claude-code)