### PR TITLE
fix(c++): auto-include Generators.hpp and use real type names in multi-source usage comments

### DIFF
--- a/packages/quicktype-core/src/language/CPlusPlus/CPlusPlusRenderer.ts
+++ b/packages/quicktype-core/src/language/CPlusPlus/CPlusPlusRenderer.ts
@@ -503,21 +503,13 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
                 "",
             ]);
 
-            if (this._options.typeSourceStyle) {
-                this.forEachTopLevel("none", (_, topLevelName) => {
-                    this.emitLine(
-                        "//     ",
-                        topLevelName,
-                        " data = nlohmann::json::parse(jsonString);",
-                    );
-                });
-            } else {
+            this.forEachTopLevel("none", (_, topLevelName) => {
                 this.emitLine(
                     "//     ",
-                    basename,
+                    topLevelName,
                     " data = nlohmann::json::parse(jsonString);",
                 );
-            }
+            });
 
             if (this._options.wstring) {
                 this.emitLine("//");
@@ -3187,6 +3179,7 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
             this.emitHelper();
 
             this.startFile("Generators.hpp", true);
+            this._generatedFiles.add("Generators.hpp");
 
             this._allTypeNames.forEach((t) => {
                 this.emitInclude(false, [t, ".hpp"]);

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -1563,6 +1563,10 @@ export const allFixtures: Fixture[] = [
     new JSONFixture(languages.CJSONMultiHeaderLanguage, "cjson-multi-header"),
     new JSONFixture(languages.CJSONMultiSplitLanguage, "cjson-multi-split"),
     new JSONFixture(languages.CPlusPlusLanguage),
+    new JSONFixture(
+        languages.CPlusPlusMultiSourceLanguage,
+        "cplusplus-multi-source",
+    ),
     new JSONFixture(languages.PHPLanguage),
     new JSONFixture(languages.RustLanguage),
     new JSONFixture(languages.RubyLanguage),

--- a/test/fixtures/cplusplus/main.cpp
+++ b/test/fixtures/cplusplus/main.cpp
@@ -3,8 +3,7 @@
 #include <fstream>
 #include <streambuf>
 
-#include "TopLevel.hpp"
-#include "Generators.hpp"
+#include "quicktype.hpp"
 
 using quicktype::TopLevel;
 using nlohmann::json;

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -712,7 +712,7 @@ export const CPlusPlusLanguage: Language = {
         "union",
         "no-defaults",
     ],
-    output: "TopLevel.hpp",
+    output: "quicktype.hpp",
     topLevel: "TopLevel",
     skipJSON: [
         // fails on a string containing null
@@ -737,7 +737,6 @@ export const CPlusPlusLanguage: Language = {
     ],
     rendererOptions: {},
     quickTestRendererOptions: [
-        { "source-style": "multi-source" },
         { "code-format": "with-struct" },
         { wstring: "use-wstring" },
         { "const-style": "east-const" },
@@ -751,6 +750,13 @@ export const CPlusPlusLanguage: Language = {
         ["pokedex.json", { boost: "true" }],
     ],
     sourceFiles: ["src/language/CPlusPlus/index.ts"],
+};
+
+export const CPlusPlusMultiSourceLanguage: Language = {
+    ...CPlusPlusLanguage,
+    includeJSON: ["pokedex.json"],
+    rendererOptions: { "source-style": "multi-source" },
+    quickTestRendererOptions: [],
 };
 
 export const ElmLanguage: Language = {

--- a/test/unit/cplusplus-multi-source.test.ts
+++ b/test/unit/cplusplus-multi-source.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "vitest";
+
+import {
+    InputData,
+    jsonInputForTargetLanguage,
+    quicktypeMultiFile,
+} from "quicktype-core";
+
+async function cPlusPlusMultiSourceFiles(): Promise<Map<string, string>> {
+    const jsonInput = jsonInputForTargetLanguage("cplusplus");
+    await jsonInput.addSource({
+        name: "ChunkCache",
+        samples: ['{"chunks":["one"],"size":1}'],
+    });
+    await jsonInput.addSource({
+        name: "BufferPath",
+        samples: ['{"path":"somewhere","maxSize":2}'],
+    });
+
+    const inputData = new InputData();
+    inputData.addInput(jsonInput);
+    const result = await quicktypeMultiFile({
+        inputData,
+        lang: "cplusplus",
+        outputFilename: "quicktype.hpp",
+        rendererOptions: { "source-style": "multi-source" },
+    });
+
+    return new Map(
+        Array.from(result, ([filename, serialized]) => [
+            filename,
+            serialized.lines.join("\n"),
+        ]),
+    );
+}
+
+describe("C++ multi-source output", () => {
+    test("the umbrella header includes the JSON generators", async () => {
+        const files = await cPlusPlusMultiSourceFiles();
+        expect(files.get("quicktype.hpp")).toContain(
+            '#include "Generators.hpp"',
+        );
+    });
+
+    test("usage comments name top-level types, not generated files", async () => {
+        const files = await cPlusPlusMultiSourceFiles();
+        for (const [filename, source] of files) {
+            expect(source).toContain(
+                "//     ChunkCache data = nlohmann::json::parse(jsonString);",
+            );
+            expect(source).toContain(
+                "//     BufferPath data = nlohmann::json::parse(jsonString);",
+            );
+            expect(source).not.toContain(
+                `//     ${filename} data = nlohmann::json::parse(jsonString);`,
+            );
+        }
+    });
+});


### PR DESCRIPTION
## Bug

In C++ `--source-style multi-source` output, two related problems made generated code confusing or uncompilable without manual workarounds:

1. **Missing `Generators.hpp` include in the umbrella header.** `Generators.hpp` holds all the `to_json`/`from_json` overloads for the generated types, but the umbrella header (e.g. `myapp.hpp`, built by `emitMultiSourceStructure`) never included it. Any code that only includes the umbrella header and calls `nlohmann::json::parse(...).get<SomeType>()` fails to compile/link because the required `to_json`/`from_json` overloads aren't visible — users had to manually discover and add `#include "Generators.hpp"`.
2. **Misleading usage comments.** Every generated file's leading "how to use this" comment used the *current file's own name* instead of a real top-level type name, e.g. `myapp.hpp data = nlohmann::json::parse(jsonString);` or `helper.hpp data = nlohmann::json::parse(jsonString);` — neither of which is valid or meaningful C++.

## Root cause

Both bugs are in `packages/quicktype-core/src/language/CPlusPlus/CPlusPlusRenderer.ts`:

1. `emitMultiSourceStructure` calls `this.startFile("Generators.hpp", true)` but never adds `"Generators.hpp"` to `this._generatedFiles`. The umbrella header's `#include` list is built later by iterating `_generatedFiles`, so `Generators.hpp` was silently omitted.
2. `startFile` only used `forEachTopLevel` to emit one usage-comment line per real top-level type name when `typeSourceStyle` was true (single-source). For multi-source (`typeSourceStyle` false), it fell back to using the file's own `basename` instead.

## Fix

- Add the missing `this._generatedFiles.add("Generators.hpp")` call so the umbrella header includes it.
- Always use `forEachTopLevel` to emit the usage-comment lines with real top-level type names, regardless of `typeSourceStyle`.

## Test coverage

- `test/unit/cplusplus-multi-source.test.ts` (new): asserts the multi-source umbrella header contains `#include "Generators.hpp"`, and that usage comments across generated files name the real top-level types (`ChunkCache`, `BufferPath`) rather than the generated filename.
- `test/languages.ts` / `test/fixtures.ts`: added a new `cplusplus-multi-source` fixture (`CPlusPlusMultiSourceLanguage`) that runs the existing C++ JSON fixture suite with `source-style: multi-source` against `pokedex.json` (multiple top-level types), so the generated multi-source output is actually compiled and round-tripped by the fixture harness.
- `test/fixtures/cplusplus/main.cpp`: changed to `#include` only the umbrella header (previously it manually included both the umbrella header and `Generators.hpp`, which masked bug #1 from ever being caught by the fixture suite).

## Verification

- `npm run build` passes.
- `npx vitest run test/unit` — 165/165 unit tests pass, including the new `cplusplus-multi-source.test.ts`.
- `QUICKTEST=true FIXTURE=cplusplus-multi-source script/test` — passes locally (compiles with g++, runs, round-trips `pokedex.json` through the multi-source generated C++ code).
- Manually re-ran the exact repro from the issue/triage comment: the umbrella header now contains `#include "Generators.hpp"` and usage comments read `//     ChunkCache data = nlohmann::json::parse(jsonString);` / `//     BufferPath data = nlohmann::json::parse(jsonString);` instead of `myapp.hpp data = ...` / `helper.hpp data = ...`.
- CI will additionally validate the full C++ fixture matrix (including other renderer-option combinations) across languages this PR doesn't specifically target.

Fixes #2438

🤖 Generated with [Claude Code](https://claude.com/claude-code)