### PR TITLE
fix(cpp): silence unused-parameter warnings for empty objects

### DIFF
--- a/packages/quicktype-core/src/language/CPlusPlus/CPlusPlusRenderer.ts
+++ b/packages/quicktype-core/src/language/CPlusPlus/CPlusPlusRenderer.ts
@@ -1373,6 +1373,11 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
             ],
             false,
             () => {
+                if (c.getProperties().size === 0) {
+                    this.emitLine("(void)j;");
+                    this.emitLine("(void)x;");
+                }
+
                 this.forEachClassProperty(c, "none", (name, json, p) => {
                     const [, , setterName] = defined(
                         this._gettersAndSettersForPropertyName.get(name),
@@ -1562,6 +1567,10 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
             false,
             () => {
                 this.emitLine("j = json::object();");
+                if (c.getProperties().size === 0) {
+                    this.emitLine("(void)x;");
+                }
+
                 this.forEachClassProperty(c, "none", (name, json, p) => {
                     const propType = p.type;
                     cppType = this.cppType(

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -688,7 +688,8 @@ export const CPlusPlusLanguage: Language = {
     base: "test/fixtures/cplusplus",
     setupCommand:
         "curl -o json.hpp https://raw.githubusercontent.com/nlohmann/json/87df1d6708915ffbfa26a051ad7562ecc22e5579/src/json.hpp",
-    compileCommand: "g++ -O0 -o quicktype -std=c++17 main.cpp",
+    compileCommand:
+        "g++ -O0 -o quicktype -std=c++17 -Werror=unused-parameter main.cpp",
     runCommand(sample: string) {
         return `./quicktype "${sample}"`;
     },


### PR DESCRIPTION
## What was broken

For a JSON Schema empty object (`{"type": "object", "additionalProperties": false}`), quicktype's C++ target generated `from_json`/`to_json` free functions that don't reference all their parameters:

```cpp
inline void from_json(const json & j, Out& x) {
}

inline void to_json(json & j, const Out & x) {
    j = json::object();
}
```

`from_json` uses neither `j` nor `x`; `to_json` doesn't use `x`. Compiling with `-Wextra -Wunused-parameter -Werror` (a common strict build configuration) turns these into hard errors, breaking consumer builds.

## Root cause

`CPlusPlusRenderer.emitClassFunctions` (in `packages/quicktype-core/src/language/CPlusPlus/CPlusPlusRenderer.ts`) always names both parameters when emitting `from_json`/`to_json`, but for a class with zero properties nothing in the body ever touches them.

## Fix

In `emitClassFunctions`, when a class has no properties, emit `(void)j; (void)x;` at the top of `from_json`'s body and `(void)x;` after `j = json::object();` in `to_json`'s body — the standard idiom for silencing unused-parameter warnings while keeping the parameter names (needed to match the function signature) intact.

## Test coverage

The existing schema fixture `test/inputs/schema/constructor.schema` already generates a nested empty class (`additionalProperties: false`, no properties) via a `oneOf` union member. The C++ fixture's compile command in `test/languages.ts` now passes `-Werror=unused-parameter`, so this fixture fails to compile on unfixed code (reproducing the reported warnings) and compiles cleanly after the fix.

## Verification

- Reproduced the bug locally: `node dist/index.js --lang cpp --src-lang schema empty.schema.json -o out.hpp`, then compiled the output with `g++ -std=c++17 -Wextra -Wunused-parameter -Werror` — reproduced all three reported errors (unused `j` and `x` in `from_json`, unused `x` in `to_json`) before the fix; no unused-parameter errors after.
- `npm run build` passes.
- Ran the full `schema-cplusplus` fixture suite locally (`QUICKTEST=true FIXTURE=schema-cplusplus script/test`) to confirm no regressions across the many C++ renderer option combinations.
- CI will additionally validate the broader JSON/JSON Schema fixture matrix.

Fixes #2362

🤖 Generated with [Claude Code](https://claude.com/claude-code)