### PR TITLE
fix(golang): always emit consolidated imports regardless of leadingComments

### DIFF
--- a/packages/quicktype-core/src/language/Golang/GolangRenderer.ts
+++ b/packages/quicktype-core/src/language/Golang/GolangRenderer.ts
@@ -12,7 +12,7 @@ import { assert, defined } from "../../support/Support.js";
 import type { TargetLanguage } from "../../TargetLanguage.js";
 import {
     type ClassProperty,
-    type ClassType,
+    ClassType,
     type EnumType,
     type Type,
     type TypeKind,
@@ -194,28 +194,37 @@ export class GoRenderer extends ConvenienceRenderer {
         if (
             this._options.multiFileOutput &&
             this._options.justTypes === false &&
-            this._options.justTypesAndPackage === false &&
-            this.leadingComments === undefined
+            this._options.justTypesAndPackage === false
         ) {
-            this.emitLineOnce(
-                "// Code generated from JSON Schema using quicktype. DO NOT EDIT.",
-            );
-            this.emitLineOnce(
-                "// To parse and unparse this JSON data, add this code to your project and do:",
-            );
-            this.emitLineOnce("//");
-            const ref = modifySource(camelCase, name);
-            this.emitLineOnce(
-                "//    ",
-                ref,
-                ", err := ",
-                defined(this._topLevelUnmarshalNames.get(name)),
-                "(bytes)",
-            );
-            this.emitLineOnce("//    bytes, err = ", ref, ".Marshal()");
+            if (this.leadingComments !== undefined) {
+                this.emitComments(this.leadingComments);
+            } else {
+                this.emitLineOnce(
+                    "// Code generated from JSON Schema using quicktype. DO NOT EDIT.",
+                );
+                this.emitLineOnce(
+                    "// To parse and unparse this JSON data, add this code to your project and do:",
+                );
+                this.emitLineOnce("//");
+                const ref = modifySource(camelCase, name);
+                this.emitLineOnce(
+                    "//    ",
+                    ref,
+                    ", err := ",
+                    defined(this._topLevelUnmarshalNames.get(name)),
+                    "(bytes)",
+                );
+                this.emitLineOnce("//    bytes, err = ", ref, ".Marshal()");
+            }
         }
 
-        this.emitPackageDefinitons(true);
+        const imports =
+            t instanceof ClassType
+                ? this.collectClassImports(t)
+                : t instanceof UnionType
+                  ? this.collectUnionImports(t)
+                  : undefined;
+        this.emitPackageDefinitons(true, imports);
 
         const unmarshalName = defined(this._topLevelUnmarshalNames.get(name));
         if (this.namedTypeToNameForTopLevel(t) === undefined) {
@@ -305,7 +314,7 @@ export class GoRenderer extends ConvenienceRenderer {
 
     private emitUnion(u: UnionType, unionName: Name): void {
         this.startFile(unionName);
-        this.emitPackageDefinitons(false);
+        this.emitPackageDefinitons(false, this.collectUnionImports(u));
         const [hasNull, nonNulls] = removeNullFromUnion(u);
         const isNullableArg = hasNull !== null ? "true" : "false";
 
@@ -610,10 +619,13 @@ func marshalUnion(pi *int64, pf *float64, pb *bool, ps *string, haveArray bool, 
         if (
             this._options.multiFileOutput === false &&
             this._options.justTypes === false &&
-            this._options.justTypesAndPackage === false &&
-            this.leadingComments === undefined
+            this._options.justTypesAndPackage === false
         ) {
-            this.emitSingleFileHeaderComments();
+            if (this.leadingComments !== undefined) {
+                this.emitComments(this.leadingComments);
+            } else {
+                this.emitSingleFileHeaderComments();
+            }
             this.emitPackageDefinitons(false, this.collectAllImports());
         }
 

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -849,9 +849,7 @@ class LeadingCommentsGoFixture extends JSONSchemaFixture {
     }
 
     private async inputData(filename: string): Promise<InputData> {
-        const schemaInput = new JSONSchemaInput(
-            new FetchingJSONSchemaStore(),
-        );
+        const schemaInput = new JSONSchemaInput(new FetchingJSONSchemaStore());
         await schemaInput.addSource({
             name: this.language.topLevel,
             schema: fs.readFileSync(filename, "utf8"),

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -25,7 +25,16 @@ import {
     callAndExpectFailure,
 } from "./utils";
 import * as languages from "./languages";
-import type { LanguageName, Option, RendererOptions } from "quicktype-core";
+import {
+    FetchingJSONSchemaStore,
+    InputData,
+    JSONSchemaInput,
+    type LanguageName,
+    type Option,
+    type RendererOptions,
+    quicktype as quicktypeCore,
+    quicktypeMultiFile,
+} from "quicktype-core";
 import {
     mustNotHappen,
     defined,
@@ -823,6 +832,85 @@ class JSONSchemaFixture extends LanguageFixture {
     }
 }
 
+// `leadingComments` is a quicktype-core API option, so the CLI fixture path
+// cannot exercise it.
+class LeadingCommentsGoFixture extends JSONSchemaFixture {
+    constructor() {
+        super(languages.GoLanguage, "schema-golang-leading-comments");
+    }
+
+    getSamples(sources: string[]): { priority: Sample[]; others: Sample[] } {
+        return samplesFromSources(
+            sources,
+            ["test/inputs/schema/date-time.schema"],
+            [],
+            "schema",
+        );
+    }
+
+    private async inputData(filename: string): Promise<InputData> {
+        const schemaInput = new JSONSchemaInput(
+            new FetchingJSONSchemaStore(),
+        );
+        await schemaInput.addSource({
+            name: this.language.topLevel,
+            schema: fs.readFileSync(filename, "utf8"),
+        });
+        const inputData = new InputData();
+        inputData.addInput(schemaInput);
+        return inputData;
+    }
+
+    async runQuicktype(
+        filename: string,
+        additionalRendererOptions: RendererOptions,
+    ): Promise<void> {
+        const rendererOptions = _.merge(
+            {},
+            this.language.rendererOptions,
+            additionalRendererOptions,
+        );
+        const result = await quicktypeCore({
+            inputData: await this.inputData(filename),
+            lang: this.language.name,
+            leadingComments: [],
+            rendererOptions,
+        });
+        fs.writeFileSync(this.language.output, result.lines.join("\n"));
+
+        const multiFileResult = await quicktypeMultiFile({
+            inputData: await this.inputData(filename),
+            lang: this.language.name,
+            leadingComments: [],
+            rendererOptions: {
+                ...rendererOptions,
+                "multi-file-output": true,
+            },
+        });
+        mkdirs("multi");
+        for (const [outputFilename, output] of multiFileResult) {
+            fs.writeFileSync(
+                path.join("multi", outputFilename),
+                output.lines.join("\n"),
+            );
+        }
+    }
+
+    async test(
+        filename: string,
+        additionalRendererOptions: RendererOptions,
+        additionalFiles: string[],
+    ): Promise<number> {
+        const numFiles = await super.test(
+            filename,
+            additionalRendererOptions,
+            additionalFiles,
+        );
+        await execAsync("go test multi/*.go");
+        return numFiles + testsInDir("multi", "go").length;
+    }
+}
+
 type TreeSitterTarget = {
     displayName: string;
     language: languages.Language;
@@ -1602,6 +1690,7 @@ export const allFixtures: Fixture[] = [
         "schema-java-lombok",
     ),
     new JSONSchemaFixture(languages.GoLanguage),
+    new LeadingCommentsGoFixture(),
     new JSONSchemaFixture(languages.CJSONLanguage),
     new JSONSchemaFixture(languages.CPlusPlusLanguage),
     new JSONSchemaFixture(languages.RustLanguage),


### PR DESCRIPTION
## Bug

Passing `leadingComments` (even `[]`) to the `quicktype-core` API's `quicktype()` function for Go output produced invalid, non-compiling Go code. For example, a schema with a `date-time` field would emit `import "time"` in the middle of the file, between two struct definitions — Go requires all `import` declarations to precede any other top-level declarations.

## Root cause

In `GolangRenderer.ts`, `emitSourceStructure` (single-file mode) and `emitTopLevel` (multi-file mode) both gated their entire header block — including the consolidated top-of-file import collection (`emitPackageDefinitons(false, collectAllImports())`) — behind `this.leadingComments === undefined`. Passing any `leadingComments` value (including `[]`) skipped that whole block, so the consolidated import block was never emitted. A later, per-class emission of `import "time"` (for `time.Time` fields) is normally deduplicated against that header block via `emitLineOnce`, but with no header block to dedupe against, the bare `import "time"` landed wherever the class happened to be emitted in the file — i.e. mid-file.

Other language renderers (`CSharpRenderer`, `JavaRenderer`, `SwiftRenderer`, `RustRenderer`, `KotlinRenderer`, etc.) use a different, correct pattern: `leadingComments`, when set, only replaces the default generated-file header *comment*; it does not suppress unrelated output like import blocks. `GolangRenderer` was the outlier that conflated the two.

## Fix

- `emitTopLevel` (multi-file) and `emitSourceStructure` (single-file) now always emit the import/package block; `leadingComments`, when provided, replaces the default header comment text instead of skipping the whole block, matching the pattern used elsewhere in the codebase.
- While fixing this, also corrected a related latent issue in multi-file output: `emitTopLevel` now collects and emits the actual imports needed by the top-level type (via `collectClassImports`/`collectUnionImports`) instead of emitting no imports at all for the top-level file's own type.

## Test coverage

Added `LeadingCommentsGoFixture` (fixture id `schema-golang-leading-comments`) in `test/fixtures.ts`, which is registered in `allFixtures`. Since `leadingComments` is a `quicktype-core` API option not exposed via the CLI, this fixture drives `quicktype-core`'s `quicktype()`/`quicktypeMultiFile()` directly (rather than through the CLI-based fixture path) using `test/inputs/schema/date-time.schema`, with `leadingComments: []` set, and verifies both single-file and multi-file Go output actually compiles and runs correctly (`go test`/`go run` via the existing Go fixture driver).

This fixture reproduces the bug on unfixed code (`imports must appear before other declarations`) and passes after the fix.

## Verification performed locally

- `npm run build` passes.
- `npm run test:unit` — 163 tests passed.
- `FIXTURE=schema-golang-leading-comments QUICKTEST=true script/test` — passes (new fixture, compiles and runs generated Go for both single- and multi-file output).
- `FIXTURE=schema-golang QUICKTEST=true script/test` — passes (no regression in existing Go schema fixtures).
- `FIXTURE=golang QUICKTEST=true script/test` — passes for the vast majority of samples; a few samples (`bitcoin-block.json`, `getting-started.json`, `uuids.json`) hit an unrelated, environment-level flake (`go: cannot determine current directory: getwd: no such file or directory`) from running many `go run` processes across 16 parallel workers in this sandbox. Re-running each of those three samples individually with `go run` succeeded cleanly (exit 0, correct output), confirming this is sandbox/concurrency flakiness, not a code regression. CI will validate the full fixture matrix.
- Manually re-ran the exact repro from the issue (and from the maintainer triage comment) against the built `quicktype-core` package before and after the fix, confirming the `import "time"` now lands in the consolidated top-of-file import block instead of mid-file.

Fixes #2670

🤖 Generated with [Claude Code](https://claude.com/claude-code)