### PR TITLE
fix(python): use datetime.date/time for date/time formats

### DIFF
--- a/packages/quicktype-core/src/language/Python/JSONPythonRenderer.ts
+++ b/packages/quicktype-core/src/language/Python/JSONPythonRenderer.ts
@@ -40,6 +40,8 @@ export type ConverterFunction =
     | "to-class"
     | "dict"
     | "union"
+    | "from-date"
+    | "from-time"
     | "from-datetime"
     | "from-stringified-bool"
     | "is-type";
@@ -458,13 +460,64 @@ export class JSONPythonRenderer extends PythonRenderer {
     assert False`);
     }
 
+    protected emitFromDateConverter(): void {
+        this.emitBlock(
+            [
+                "def from_date(",
+                this.typingDecl("x", "Any"),
+                ")",
+                this.typeHint(" -> ", [
+                    this.withModuleImport("datetime"),
+                    ".date",
+                ]),
+                ":",
+            ],
+            () => {
+                this._haveDateutil = true;
+                this.emitLine(
+                    "assert isinstance(x, str) and ",
+                    this.withModuleImport("re"),
+                    '.match(r"^\\d{4}-\\d{2}-\\d{2}$", x)',
+                );
+                this.emitLine("return dateutil.parser.parse(x).date()");
+            },
+        );
+    }
+
+    protected emitFromTimeConverter(): void {
+        this.emitBlock(
+            [
+                "def from_time(",
+                this.typingDecl("x", "Any"),
+                ")",
+                this.typeHint(" -> ", [
+                    this.withModuleImport("datetime"),
+                    ".time",
+                ]),
+                ":",
+            ],
+            () => {
+                this._haveDateutil = true;
+                this.emitLine(
+                    "assert isinstance(x, str) and ",
+                    this.withModuleImport("re"),
+                    '.match(r"^\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?(?:Z|[+-]\\d{2}:\\d{2})?$", x)',
+                );
+                this.emitLine("return dateutil.parser.parse(x).time()");
+            },
+        );
+    }
+
     protected emitFromDatetimeConverter(): void {
         this.emitBlock(
             [
                 "def from_datetime(",
                 this.typingDecl("x", "Any"),
                 ")",
-                this.typeHint(" -> ", this.withImport("datetime", "datetime")),
+                this.typeHint(" -> ", [
+                    this.withModuleImport("datetime"),
+                    ".datetime",
+                ]),
                 ":",
             ],
             () => {
@@ -571,6 +624,16 @@ export class JSONPythonRenderer extends PythonRenderer {
                 return;
             }
 
+            case "from-date": {
+                this.emitFromDateConverter();
+                return;
+            }
+
+            case "from-time": {
+                this.emitFromTimeConverter();
+                return;
+            }
+
             case "from-datetime": {
                 this.emitFromDatetimeConverter();
                 return;
@@ -628,8 +691,16 @@ export class JSONPythonRenderer extends PythonRenderer {
             (enumType) => this.nameForNamedType(enumType),
             (_unionType) => undefined,
             (transformedStringType) => {
+                if (transformedStringType.kind === "date") {
+                    return [this.withModuleImport("datetime"), ".date"];
+                }
+
+                if (transformedStringType.kind === "time") {
+                    return [this.withModuleImport("datetime"), ".time"];
+                }
+
                 if (transformedStringType.kind === "date-time") {
-                    return this.withImport("datetime", "datetime");
+                    return [this.withModuleImport("datetime"), ".datetime"];
                 }
 
                 if (transformedStringType.kind === "uuid") {
@@ -731,6 +802,12 @@ export class JSONPythonRenderer extends PythonRenderer {
                         immediateTargetType,
                     );
                     break;
+                case "date":
+                    vol = this.convFn("from-date", inputTransformer);
+                    break;
+                case "time":
+                    vol = this.convFn("from-time", inputTransformer);
+                    break;
                 case "date-time":
                     vol = this.convFn("from-datetime", inputTransformer);
                     break;
@@ -767,6 +844,8 @@ export class JSONPythonRenderer extends PythonRenderer {
                 case "enum":
                     vol = this.serializer(inputTransformer, xfer.sourceType);
                     break;
+                case "date":
+                case "time":
                 case "date-time":
                     vol = compose(inputTransformer, (v) => [v, ".isoformat()"]);
                     break;
@@ -851,6 +930,14 @@ export class JSONPythonRenderer extends PythonRenderer {
             },
             (transformedStringType) => {
                 // FIXME: handle via transformers
+                if (transformedStringType.kind === "date") {
+                    return this.convFn("from-date", value);
+                }
+
+                if (transformedStringType.kind === "time") {
+                    return this.convFn("from-time", value);
+                }
+
                 if (transformedStringType.kind === "date-time") {
                     return this.convFn("from-datetime", value);
                 }
@@ -942,7 +1029,11 @@ export class JSONPythonRenderer extends PythonRenderer {
                 ]);
             },
             (transformedStringType) => {
-                if (transformedStringType.kind === "date-time") {
+                if (
+                    transformedStringType.kind === "date" ||
+                    transformedStringType.kind === "time" ||
+                    transformedStringType.kind === "date-time"
+                ) {
                     return compose(value, (v) => [v, ".isoformat()"]);
                 }
 

--- a/packages/quicktype-core/src/language/Python/PythonRenderer.ts
+++ b/packages/quicktype-core/src/language/Python/PythonRenderer.ts
@@ -37,6 +37,8 @@ import { classNameStyle, snakeNameStyle } from "./utils.js";
 export class PythonRenderer extends ConvenienceRenderer {
     private readonly imports: Map<string, Set<string>> = new Map();
 
+    private readonly moduleImports: Set<string> = new Set();
+
     private readonly declaredTypes: Set<Type> = new Set();
 
     public constructor(
@@ -130,6 +132,11 @@ export class PythonRenderer extends ConvenienceRenderer {
         }
 
         return name;
+    }
+
+    protected withModuleImport(module: string): Sourcelike {
+        this.moduleImports.add(module);
+        return module;
     }
 
     protected withTyping(name: string): Sourcelike {
@@ -319,8 +326,16 @@ export class PythonRenderer extends ConvenienceRenderer {
                 ];
             },
             (transformedStringType) => {
+                if (transformedStringType.kind === "date") {
+                    return [this.withModuleImport("datetime"), ".date"];
+                }
+
+                if (transformedStringType.kind === "time") {
+                    return [this.withModuleImport("datetime"), ".time"];
+                }
+
                 if (transformedStringType.kind === "date-time") {
-                    return this.withImport("datetime", "datetime");
+                    return [this.withModuleImport("datetime"), ".datetime"];
                 }
 
                 if (transformedStringType.kind === "uuid") {
@@ -481,6 +496,9 @@ export class PythonRenderer extends ConvenienceRenderer {
     }
 
     protected emitImports(): void {
+        this.moduleImports.forEach((module) => {
+            this.emitLine("import ", module);
+        });
         this.imports.forEach((names, module) => {
             this.emitLine(
                 "from ",

--- a/packages/quicktype-core/src/language/Python/language.ts
+++ b/packages/quicktype-core/src/language/Python/language.ts
@@ -105,10 +105,9 @@ export class PythonTargetLanguage extends TargetLanguage<
     public get stringTypeMapping(): StringTypeMapping {
         const mapping: Map<TransformedStringTypeKind, PrimitiveStringTypeKind> =
             new Map();
-        const dateTimeType = "date-time";
-        mapping.set("date", dateTimeType);
-        mapping.set("time", dateTimeType);
-        mapping.set("date-time", dateTimeType);
+        mapping.set("date", "date");
+        mapping.set("time", "time");
+        mapping.set("date-time", "date-time");
         mapping.set("uuid", "uuid");
         mapping.set("integer-string", "integer-string");
         mapping.set("bool-string", "bool-string");

--- a/test/fixtures/python/main.py
+++ b/test/fixtures/python/main.py
@@ -1,8 +1,16 @@
 import quicktype
+import datetime
 import json
 import sys
 import io
 
 f = io.open(sys.argv[1], mode="r", encoding="utf-8")
-obj = quicktype.top_level_from_dict(json.load(f))
+input_obj = json.load(f)
+obj = quicktype.top_level_from_dict(input_obj)
+
+if isinstance(input_obj, dict) and {"date", "time", "date-time"} <= input_obj.keys():
+    assert type(obj.date) is datetime.date
+    assert type(obj.time) is datetime.time
+    assert type(obj.date_time) is datetime.datetime
+
 print(json.dumps(quicktype.top_level_to_dict(obj)))


### PR DESCRIPTION
## Bug

The Python generator mapped JSON Schema string formats `date` and `time` onto the same transformed-string kind as `date-time`. As a result, a schema property with `format: "date"` or `format: "time"` was typed as `datetime.datetime` and serialized with `.isoformat()`, so a date-only value like `"2024-01-01"` round-tripped as a full ISO datetime string (e.g. `"2024-01-01T00:00:00"`), which violates the input schema.

Repro:
```
node dist/index.js --lang python --src-lang schema example.schema.json
```
```json
{
  "$schema": "http://json-schema.org/draft-07/schema#",
  "$ref": "#/definitions/Example",
  "definitions": {
    "Example": {
      "type": "object",
      "additionalProperties": false,
      "properties": {
        "d":  { "type": "string", "format": "date" },
        "t":  { "type": "string", "format": "time" },
        "dt": { "type": "string", "format": "date-time" }
      },
      "required": ["d","t","dt"]
    }
  }
}
```
Before the fix, `d`, `t`, and `dt` were all typed `datetime`. After the fix, `d` is `datetime.date`, `t` is `datetime.time`, and `dt` remains `datetime.datetime`.

## Root cause

`packages/quicktype-core/src/language/Python/language.ts` folded the `date` and `time` `TransformedStringTypeKind`s into `date-time` in `stringTypeMapping`, so every downstream Python renderer switch only ever saw a single `date-time` kind.

## Fix

- `language.ts`: keep `date`, `time`, and `date-time` as distinct kinds in `stringTypeMapping` instead of collapsing them.
- `PythonRenderer.ts`: emit `datetime.date` / `datetime.time` / `datetime.datetime` type names (via a new module-level `import datetime` helper) instead of always using `datetime.datetime`.
- `JSONPythonRenderer.ts`: add `from_date`/`from_time` parsing helpers (using `dateutil.parser.parse(...).date()` / `.time()`, with a format-shape assertion) alongside the existing `from_datetime`, and route the `date`/`time`/`date-time` transformer cases to the correct converter for both parsing and `.isoformat()` serialization.

## Test coverage

`test/fixtures/python/main.py` (the Python fixture driver used by end-to-end schema fixture tests) was strengthened to assert the correct runtime types (`datetime.date`, `datetime.time`, `datetime.datetime`) whenever the round-tripped object has `date`/`time`/`date-time` properties. This is exercised by the existing `test/inputs/schema/date-time.schema` fixture (which already has `date`, `time`, and `date-time` properties plus union-array cases), run via the standard `schema-python` fixture suite — no fixture wiring changes were needed since the schema/inputs already existed, they just weren't checking runtime types before.

## Verification (local)

- `npm run build` passes.
- `npm run test:unit`: 163/163 tests pass.
- `QUICKTEST=true FIXTURE=schema-python script/test`: all 67 tests pass, including `date-time.schema` with the strengthened runtime-type assertions.
- Manually re-ran the repro from the issue: generated code now emits `datetime.date`/`datetime.time`/`datetime.datetime` as expected, and a manual round-trip in Python confirms `to_dict()` now serializes `d` as `"2024-01-01"` and `t` as a time-only ISO string instead of a full datetime string.
- CI will additionally validate the other language fixtures are unaffected.

Fixes #1974

🤖 Generated with [Claude Code](https://claude.com/claude-code)