### PR TITLE
fix(dart): keep top-level fromJson/toJson names with --from-map

### DIFF
--- a/packages/quicktype-core/src/language/Dart/DartRenderer.ts
+++ b/packages/quicktype-core/src/language/Dart/DartRenderer.ts
@@ -117,12 +117,12 @@ export class DartRenderer extends ConvenienceRenderer {
         const encoder = new DependencyName(
             propertyNamingFunction,
             name.order,
-            (lookup) => `${lookup(name)}_${this.toJson}`,
+            (lookup) => `${lookup(name)}_toJson`,
         );
         const decoder = new DependencyName(
             propertyNamingFunction,
             name.order,
-            (lookup) => `${lookup(name)}_${this.fromJson}`,
+            (lookup) => `${lookup(name)}_fromJson`,
         );
         this._topLevelDependents.set(name, { encoder, decoder });
         return [encoder, decoder];

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1628,8 +1628,12 @@ export const DartLanguage: Language = {
     skipMiscJSON: true,
     rendererOptions: {},
     // The default is final-props=true; this keeps the mutable-property
-    // code path covered.
-    quickTestRendererOptions: [{ "final-props": "false" }],
+    // code path covered.  The targeted from-map sample also verifies that
+    // the fixture driver can keep calling the top-level JSON string helpers.
+    quickTestRendererOptions: [
+        { "final-props": "false" },
+        ["simple-object.json", { "from-map": "true" }],
+    ],
     sourceFiles: ["src/language/Dart/index.ts"],
 };
 

--- a/test/unit/dart-method-names.test.ts
+++ b/test/unit/dart-method-names.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "vitest";
+
+import {
+    InputData,
+    type RendererOptions,
+    jsonInputForTargetLanguage,
+    quicktype,
+} from "../../packages/quicktype-core/src/index.js";
+
+async function renderDart(
+    rendererOptions: RendererOptions = {},
+): Promise<string[]> {
+    const jsonInput = jsonInputForTargetLanguage("dart");
+    await jsonInput.addSource({
+        name: "Sensordata",
+        samples: ['{"sensor":"temp","data":[1,2,3]}'],
+    });
+
+    const inputData = new InputData();
+    inputData.addInput(jsonInput);
+
+    const result = await quicktype({
+        inputData,
+        lang: "dart",
+        rendererOptions,
+    });
+    return result.lines;
+}
+
+describe("Dart JSON method names", () => {
+    test("from-map only renames class-level map methods", async () => {
+        const lines = await renderDart({ "from-map": "true" });
+
+        expect(lines).toContain(
+            "Sensordata sensordataFromJson(String str) => Sensordata.fromMap(json.decode(str));",
+        );
+        expect(lines).toContain(
+            "String sensordataToJson(Sensordata data) => json.encode(data.toMap());",
+        );
+        expect(lines).toContain(
+            "    factory Sensordata.fromMap(Map<String, dynamic> json) => Sensordata(",
+        );
+        expect(lines).toContain("    Map<String, dynamic> toMap() => {");
+        expect(lines.some((line) => line.includes("sensordataFromMap"))).toBe(
+            false,
+        );
+        expect(lines.some((line) => line.includes("sensordataToMap"))).toBe(
+            false,
+        );
+    });
+
+    test("uses Json names at both levels by default", async () => {
+        const lines = await renderDart();
+
+        expect(lines).toContain(
+            "Sensordata sensordataFromJson(String str) => Sensordata.fromJson(json.decode(str));",
+        );
+        expect(lines).toContain(
+            "String sensordataToJson(Sensordata data) => json.encode(data.toJson());",
+        );
+        expect(lines).toContain(
+            "    factory Sensordata.fromJson(Map<String, dynamic> json) => Sensordata(",
+        );
+        expect(lines).toContain("    Map<String, dynamic> toJson() => {");
+        expect(lines.some((line) => line.includes("fromMap"))).toBe(false);
+        expect(lines.some((line) => line.includes("toMap"))).toBe(false);
+    });
+});


### PR DESCRIPTION
## Bug

With `--from-map` (`methodNamesWithMap`), quicktype's Dart output renamed the
top-level free functions `sensordataFromJson`/`sensordataToJson` to
`sensordataFromMap`/`sensordataToMap`, even though those top-level functions
take/return a JSON `String` (via `json.decode`/`json.encode`), not a `Map`.
Only the class-level factory constructor and instance method — which really
do operate on `Map<String, dynamic>` — should change name when `--from-map`
is used.

Repro:

```
node dist/index.js -l dart --from-map --top-level Sensordata sensordata.json
```

Before the fix:

```dart
Sensordata sensordataFromMap(String str) => Sensordata.fromMap(json.decode(str));
String sensordataToMap(Sensordata data) => json.encode(data.toMap());
```

After the fix:

```dart
Sensordata sensordataFromJson(String str) => Sensordata.fromMap(json.decode(str));
String sensordataToJson(Sensordata data) => json.encode(data.toMap());
```

## Root cause

`DartRenderer.makeTopLevelDependencyNames` built the top-level encoder/decoder
names using the `toJson`/`fromJson` getters, which are conditional on
`methodNamesWithMap` and return `toMap`/`fromMap` when the option is set.
Those getters are also (correctly) used for the class-level
`fromMap`/`toMap` methods emitted by `_emitMapEncoderDecoder`, so the
top-level functions inherited the same renaming even though they don't
operate on a `Map`.

## Fix

`makeTopLevelDependencyNames` now hard-codes the `_toJson`/`_fromJson`
suffixes for the top-level function names, independent of
`methodNamesWithMap`. The class-level Map methods are untouched and keep
using the conditional naming, matching the fix suggested by a maintainer in
the issue thread.

## Test coverage

- `test/unit/dart-method-names.test.ts` (new): renders Dart both with and
  without the `from-map` renderer option and asserts the top-level functions
  are always named `..FromJson`/`..ToJson` while the class-level
  factory/method are named `fromMap`/`toMap` only when the option is set
  (and `fromJson`/`toJson` otherwise, i.e. no regression to the default
  case).
- `test/languages.ts`: added a `from-map` renderer-option variant to the Dart
  fixture's `quickTestRendererOptions` (using `simple-object.json`) so the
  end-to-end fixture also exercises code generation with this option.

## Verification

- Confirmed the bug on unfixed master with the CLI repro above.
- Added the failing unit test first, confirmed it failed against the
  unfixed code, then applied the fix and confirmed it passes.
- `npm run build` passes.
- `npm run test:unit` — 165/165 tests pass.
- Re-ran the CLI repro manually; output now matches the expected
  `fromJson`/`toJson` top-level names while class-level `fromMap`/`toMap`
  names are preserved, and confirmed no regression when `--from-map` is
  omitted.
- The Dart toolchain (`dart` binary) is not available in this sandboxed
  environment, so the `FIXTURE=dart script/test` end-to-end run itself
  wasn't executed locally; the new `from-map` fixture variant will be
  validated by CI.

Fixes #1719

🤖 Generated with [Claude Code](https://claude.com/claude-code)