### PR TITLE
fix(swift): remove deprecated JSONNull.hashValue

### DIFF
--- a/packages/quicktype-core/src/language/Swift/SwiftRenderer.ts
+++ b/packages/quicktype-core/src/language/Swift/SwiftRenderer.ts
@@ -1184,13 +1184,8 @@ encoder.dateEncodingStrategy = .formatted(formatter)`);
 
             if (this._options.objcSupport === false) {
                 this.ensureBlankLine();
-                this.emitMultiline(`    public var hashValue: Int {
-		return 0
-	}`);
-
-                this.ensureBlankLine();
                 this.emitMultiline(`    public func hash(into hasher: inout Hasher) {
-		// No-op
+		hasher.combine(0)
 	}`);
             }
 

--- a/test/unit/swift-json-null-hashable.test.ts
+++ b/test/unit/swift-json-null-hashable.test.ts
@@ -13,7 +13,7 @@ const schema = JSON.stringify({
     required: ["value"],
 });
 
-test("emits hash(into:) for JSONNull by default", async () => {
+test("emits modern Hashable implementation for JSONNull by default", async () => {
     const schemaInput = new JSONSchemaInput(undefined);
     await schemaInput.addSource({ name: "TopLevel", schema });
 
@@ -24,4 +24,6 @@ test("emits hash(into:) for JSONNull by default", async () => {
     const output = result.lines.join("\n");
 
     expect(output).toContain("public func hash(into hasher: inout Hasher)");
+    expect(output).toContain("hasher.combine(0)");
+    expect(output).not.toContain("public var hashValue: Int");
 });


### PR DESCRIPTION
## Bug

quicktype's default Swift output for `JSONNull` emitted both the
deprecated `hashValue` protocol requirement and `hash(into:)`:

```swift
class JSONNull: Codable, Hashable {
    public static func == (lhs: JSONNull, rhs: JSONNull) -> Bool {
        return true
    }

    public var hashValue: Int {
        return 0
    }

    public func hash(into hasher: inout Hasher) {
        // No-op
    }
    ...
}
```

Explicitly implementing `hashValue` triggers the Swift compiler warning
`'Hashable.hashValue' is deprecated as a protocol requirement; conform
type 'JSONNull' to 'Hashable' by implementing 'hash(into:)' instead`,
since `hashValue` was deprecated as a `Hashable` requirement in Swift
4.2.

A previous PR (#2928 / commit `7a233c5b`) made `hash(into:)` emit
unconditionally instead of only under `--swift-5-support`, but it did
not remove the old `hashValue` property, so the deprecation warning
remained.

## Root cause

`packages/quicktype-core/src/language/Swift/SwiftRenderer.ts` always
emits both `hashValue` and `hash(into:)` for `JSONNull` (when
`objcSupport` is disabled), instead of only the modern `hash(into:)`
requirement.

## Fix

Removed the deprecated `hashValue` computed property and changed
`hash(into:)`'s body from a no-op comment to `hasher.combine(0)`, as
suggested in the issue.

## Test coverage

`test/unit/swift-json-null-hashable.test.ts` already asserted that
`hash(into:)` was emitted, but it didn't assert the deprecated
`hashValue` was absent, so it passed even with the bug present.
Strengthened it to additionally assert:
- `hasher.combine(0)` is emitted, and
- `public var hashValue: Int` is **not** emitted.

I verified this test fails against the pre-fix renderer and passes
after the fix. This is a unit test rather than a fixture test because
the Swift fixture harness only compiles the generated code and
round-trips JSON through it — both the buggy and fixed `JSONNull`
implementations compile and behave identically at runtime, so a
fixture round-trip cannot distinguish them; only the generated source
text differs (per `CLAUDE.md`, this is exactly the kind of "asserting
what is/isn't generated" case unit tests are for). Existing Swift JSON
and JSON Schema fixture inputs already exercise the `JSONNull`
codepath through nullable values, so fixture coverage for the
surrounding code is unaffected.

## Verification

- `npm run build` — passes.
- `npx vitest run test/unit/swift-json-null-hashable.test.ts
  test/unit/swift-final-classes.test.ts` — passes (4/4).
- Manually confirmed with `node dist/index.js --lang swift sample.json`
  that the generated `JSONNull` no longer contains `hashValue` and that
  `hash(into:)` now calls `hasher.combine(0)`.
- `swiftc` is not installed in this environment, so the Swift fixture
  suite (which compiles and runs the generated code) could not be run
  locally; CI will validate actual Swift compilation of the fixture
  inputs.

Fixes #1698

🤖 Generated with [Claude Code](https://claude.com/claude-code)
