### PR TITLE
fix(python): drop typing.Type dependency for Python 3.6 target

### DIFF
--- a/packages/quicktype-core/src/language/Python/JSONPythonRenderer.ts
+++ b/packages/quicktype-core/src/language/Python/JSONPythonRenderer.ts
@@ -334,12 +334,20 @@ export class JSONPythonRenderer extends PythonRenderer {
         );
     }
 
+    protected typingTypeHint(tvar: Sourcelike): Sourcelike {
+        if (!this.pyOptions.features.typingType) {
+            return [];
+        }
+
+        return this.typeHint(": ", this.withTyping("Type"), "[", tvar, "]");
+    }
+
     protected emitToEnumConverter(): void {
         const tvar = this.enumTypeVar();
         this.emitBlock(
             [
                 "def to_enum(c",
-                this.typeHint(": ", this.withTyping("Type"), "[", tvar, "]"),
+                this.typingTypeHint(tvar),
                 ", ",
                 this.typingDecl("x", "Any"),
                 ")",
@@ -393,7 +401,7 @@ export class JSONPythonRenderer extends PythonRenderer {
         this.emitBlock(
             [
                 "def to_class(c",
-                this.typeHint(": ", this.withTyping("Type"), "[", tvar, "]"),
+                this.typingTypeHint(tvar),
                 ", ",
                 this.typingDecl("x", "Any"),
                 ")",
@@ -500,7 +508,7 @@ export class JSONPythonRenderer extends PythonRenderer {
         this.emitBlock(
             [
                 "def is_type(t",
-                this.typeHint(": ", this.withTyping("Type"), "[", tvar, "]"),
+                this.typingTypeHint(tvar),
                 ", ",
                 this.typingDecl("x", "Any"),
                 ")",

--- a/packages/quicktype-core/src/language/Python/language.ts
+++ b/packages/quicktype-core/src/language/Python/language.ts
@@ -25,6 +25,8 @@ export interface PythonFeatures {
     builtinGenerics: boolean;
     dataClasses: boolean;
     typeHints: boolean;
+    /** `typing.Type`, unavailable in Python 3.6.0 */
+    typingType: boolean;
     /** PEP 604 union operators (`str | None`), Python 3.10+ */
     unionOperators: boolean;
 }
@@ -36,30 +38,35 @@ export const pythonOptions = {
         {
             "3.5": {
                 typeHints: false,
+                typingType: false,
                 dataClasses: false,
                 builtinGenerics: false,
                 unionOperators: false,
             },
             "3.6": {
                 typeHints: true,
+                typingType: false,
                 dataClasses: false,
                 builtinGenerics: false,
                 unionOperators: false,
             },
             "3.7": {
                 typeHints: true,
+                typingType: true,
                 dataClasses: true,
                 builtinGenerics: false,
                 unionOperators: false,
             },
             "3.9": {
                 typeHints: true,
+                typingType: true,
                 dataClasses: true,
                 builtinGenerics: true,
                 unionOperators: false,
             },
             "3.10": {
                 typeHints: true,
+                typingType: true,
                 dataClasses: true,
                 builtinGenerics: true,
                 unionOperators: true,

--- a/test/unit/python-typing-type.test.ts
+++ b/test/unit/python-typing-type.test.ts
@@ -1,0 +1,79 @@
+// Python fixtures exercise every version preset, but cannot verify that the
+// generated imports also work on the first Python 3.6 micro-version.
+import { describe, expect, test } from "vitest";
+
+import {
+    InputData,
+    JSONSchemaInput,
+    jsonInputForTargetLanguage,
+    quicktype,
+} from "quicktype-core";
+
+const schema = {
+    type: "object",
+    properties: {
+        child: {
+            type: "object",
+            properties: { name: { type: "string" } },
+            required: ["name"],
+        },
+        status: { type: "string", enum: ["ready", "done"] },
+        value: { oneOf: [{ type: "integer" }, { type: "string" }] },
+    },
+    required: ["child", "status", "value"],
+};
+
+async function pythonFor(version: "3.6" | "3.7"): Promise<string> {
+    const schemaInput = new JSONSchemaInput(undefined);
+    await schemaInput.addSource({
+        name: "TopLevel",
+        schema: JSON.stringify(schema),
+    });
+    const inputData = new InputData();
+    inputData.addInput(schemaInput);
+    const schemaResult = await quicktype({
+        inputData,
+        lang: "python",
+        rendererOptions: { "python-version": version },
+    });
+
+    // An inferred integer-string union exercises the is_type helper.
+    const jsonInput = jsonInputForTargetLanguage("python");
+    await jsonInput.addSource({
+        name: "MixedValues",
+        samples: ['{"mixed":[null,1,"1",{}]}'],
+    });
+    const jsonInputData = new InputData();
+    jsonInputData.addInput(jsonInput);
+    const jsonResult = await quicktype({
+        inputData: jsonInputData,
+        lang: "python",
+        rendererOptions: { "python-version": version },
+    });
+
+    return [...schemaResult.lines, ...jsonResult.lines].join("\n");
+}
+
+describe("Python typing.Type compatibility (issue #1728)", () => {
+    test("Python 3.6 does not import or use typing.Type", async () => {
+        const output = await pythonFor("3.6");
+
+        expect(output).toContain('T = TypeVar("T")');
+        expect(output).not.toMatch(/from typing import [^\n]*\bType\b/);
+        expect(output).not.toMatch(/\bType\[/);
+        expect(output).toContain("def to_class(c, x: Any) -> dict:");
+        expect(output).toContain("def to_enum(c, x: Any) -> EnumT:");
+        expect(output).toContain("def is_type(t, x: Any) -> T:");
+    });
+
+    test("Python 3.7 keeps typing.Type annotations", async () => {
+        const output = await pythonFor("3.7");
+
+        expect(output).toMatch(/from typing import [^\n]*\bType\b/);
+        expect(output).toContain("def to_class(c: Type[T], x: Any) -> dict:");
+        expect(output).toContain(
+            "def to_enum(c: Type[EnumT], x: Any) -> EnumT:",
+        );
+        expect(output).toContain("def is_type(t: Type[T], x: Any) -> T:");
+    });
+});


### PR DESCRIPTION
## Bug

`--lang python --python-version 3.6` generated code that imports and uses
`typing.Type`:

```python
from typing import Any, TypeVar, Type, cast
...
def to_class(c: Type[T], x: Any) -> dict:
```

`typing.Type` was only added to the standard library in Python 3.5.3 / 3.6.1
— it does not exist in Python 3.6.0, the very first 3.6 release. This makes
quicktype's "3.6" output incompatible with that micro-version, even though
the user asked for 3.6 compatibility.

## Root cause

The `3.6` preset in `pythonOptions.features` (`packages/quicktype-core/src/language/Python/language.ts`)
sets `typeHints: true`. With type hints enabled, `JSONPythonRenderer`
unconditionally emitted `Type[T]` (imported from `typing`) as the parameter
type hint for the `c`/`t` parameter of the generated `to_class`, `to_enum`,
and `is_type` helper functions — regardless of Python version.

## Fix

Added a new `typingType` flag to `PythonFeatures`, set to `false` for the
`3.5`/`3.6` presets and `true` for `3.7`+ (where `typing.Type` has long been
available). `JSONPythonRenderer` now only emits the `Type[T]` annotation when
`typingType` is enabled; when it's disabled, the `c`/`t` parameter is left
without a type hint. All other type hints for Python 3.6 are unaffected, and
3.7+ output is unchanged.

## Test coverage

Added `test/unit/python-typing-type.test.ts`, which generates code for both
Python 3.6 and 3.7 from a schema/JSON pair exercising `to_class`, `to_enum`,
and `is_type`, and asserts:
- Python 3.6 output never imports or references `typing.Type`.
- Python 3.7 output still imports and uses `Type[T]` as before (no
  regression for versions where `typing.Type` is safe to use).

The existing end-to-end Python fixture suite (`test/languages.ts`) already
parametrizes on `python-version` (3.5/3.6/3.7/3.9) via
`quickTestRendererOptions`, compiling generated code with `mypy` and
executing it — this continues to pass with the changed 3.6 output, verifying
the generated code stays syntactically valid and mypy-clean.

## Verification performed locally

- `npm run build` — passes.
- Repro re-run: `node dist/index.js --lang python --python-version 3.6 sample.json`
  no longer imports/uses `Type`; `--python-version 3.7` output is unchanged.
- `npx vitest run test/unit/python-typing-type.test.ts` — passes (2/2).
- `QUICKTEST=true FIXTURE=python script/test` — 61/61 tests pass, including
  the `python-version: 3.5/3.6/3.7/3.9` combinations.
- `biome check` on changed files — clean.
- CI will run the full fixture matrix and unit suite.

Fixes #1728

🤖 Generated with [Claude Code](https://claude.com/claude-code)