### PR TITLE
fix(swift): honor --acronym-style for leading acronyms

### DIFF
--- a/packages/quicktype-core/src/language/Swift/utils.ts
+++ b/packages/quicktype-core/src/language/Swift/utils.ts
@@ -69,7 +69,7 @@ export function swiftNameStyle(
         legalizeName,
         isUpper ? firstUpperWordStyle : allLowerWordStyle,
         firstUpperWordStyle,
-        isUpper ? allUpperWordStyle : allLowerWordStyle,
+        isUpper ? acronymsStyle : allLowerWordStyle,
         acronymsStyle,
         "",
         isStartCharacter,

--- a/test/unit/swift-acronym-names.test.ts
+++ b/test/unit/swift-acronym-names.test.ts
@@ -1,0 +1,45 @@
+// The fixture harness cannot catch acronym casing in Swift type names: the
+// generated identifiers are self-consistent, so the code still compiles and
+// round-trips JSON successfully. Generate Swift directly and assert on the
+// emitted struct declaration instead.
+
+import {
+    InputData,
+    jsonInputForTargetLanguage,
+    quicktype,
+} from "../../packages/quicktype-core/src/index.js";
+import { describe, expect, test } from "vitest";
+
+async function swiftStructName(acronymStyle: string): Promise<string> {
+    const jsonInput = jsonInputForTargetLanguage("swift");
+    await jsonInput.addSource({
+        name: "FaqCoordinate",
+        samples: ['{"x":1,"y":2}'],
+    });
+
+    const inputData = new InputData();
+    inputData.addInput(jsonInput);
+
+    const result = await quicktype({
+        inputData,
+        lang: "swift",
+        rendererOptions: { "acronym-style": acronymStyle },
+    });
+    const output = result.lines.join("\n");
+    const match = output.match(/^struct (\w+): Codable \{$/m);
+
+    // biome-ignore lint/suspicious/noMisplacedAssertion: helper is only called from within tests
+    expect(match, `generated Swift output:\n${output}`).not.toBeNull();
+    return match?.[1] ?? "";
+}
+
+describe("Swift leading acronym casing", () => {
+    test.each([
+        ["original", "FaqCoordinate"],
+        ["pascal", "FAQCoordinate"],
+        ["camel", "FaqCoordinate"],
+        ["lowerCase", "faqCoordinate"],
+    ])("honors acronym-style=%s for struct names", async (acronymStyle, expectedName) => {
+        await expect(swiftStructName(acronymStyle)).resolves.toBe(expectedName);
+    });
+});


### PR DESCRIPTION
## Bug

With `--acronym-style` set to anything other than the default (`pascal`),
Swift type names with a leading acronym word ignored the option. For
example, with `--acronym-style original` the JSON key `FaqCoordinate`
incorrectly produced:

```swift
struct FAQCoordinate: Codable {
```

while `AFaqCoordinate` (where the acronym "Faq" is not the first word)
correctly produced:

```swift
struct AFaqCoordinate: Codable {
```

## Root cause

`swiftNameStyle` in `packages/quicktype-core/src/language/Swift/utils.ts`
calls `combineWords` with separate style functions for the first word vs.
the rest of a name, and separately again for acronym vs. non-acronym words.
The style used for a first-word *acronym* was hardcoded to
`isUpper ? allUpperWordStyle : allLowerWordStyle`, instead of being derived
from the `acronymsStyle` parameter that carries the user's
`--acronym-style` choice. The style used for a *later*-word acronym
(`restAcronymStyle`) already correctly used `acronymsStyle`. So acronyms
anywhere but the first word honored the option; the first word did not.

## Fix

Changed the hardcoded `firstWordAcronymStyle` argument to use `acronymsStyle`
(matching how Kotlin's equivalent `kotlinNameStyle` already wires this up)
when `isUpper` is true:

```diff
-        isUpper ? allUpperWordStyle : allLowerWordStyle,
+        isUpper ? acronymsStyle : allLowerWordStyle,
```

Non-upper (camelCase, e.g. property names) first words are left as
`allLowerWordStyle`, matching existing behavior and JS/Swift lowerCamelCase
identifier conventions.

## Test coverage

Added `test/unit/swift-acronym-names.test.ts`, which generates Swift output
directly via `quicktype()` for a type whose only property-bearing name is
`FaqCoordinate` and asserts on the emitted `struct` declaration name across
`--acronym-style` values `original`, `pascal`, `camel`, and `lowerCase`.

A unit test (rather than a JSON/JSON Schema fixture) is used because this
class of bug is invisible to the fixture harness: fixture tests round-trip
JSON through the generated code and diff the result, but the identifier
casing bug only affects the *generated source identifier* (the struct/type
name), not the JSON keys/values that get serialized and compared — the
mangled identifier is still self-consistent, compiles, and round-trips
correctly. This mirrors the precedent set by `test/unit/java-acronym-names.test.ts`
(added in #2851 for a related Java enum-constant acronym-casing bug), which
documents the same reasoning.

## Verification

- Added the regression test first and confirmed it failed on unfixed code
  (3 of 4 acronym-style cases produced `FAQCoordinate` instead of the
  expected casing).
- Applied the fix; the regression test now passes (4/4).
- Ran the full unit suite (`npx vitest run test/unit`): 167/167 passing, no
  regressions.
- `npm run build` passes.
- Manually re-ran the CLI repro from the issue
  (`node dist/index.js -l swift --acronym-style original input.json`) and
  confirmed `FaqCoordinate` now renders correctly, while re-checking
  `--acronym-style pascal` (the default) still renders `FAQCoordinate` as
  before (no behavior change for the default style).
- The Swift fixture/compile tests (`FIXTURE=swift script/test`) were not run
  locally — the `swiftc` toolchain is not available in this environment.
  This will be validated by CI; note that fixture tests would not have
  caught this bug in the first place (see above), so the unit test is the
  operative coverage here.

Fixes #1599

🤖 Generated with [Claude Code](https://claude.com/claude-code)
