### PR TITLE
fix(kotlin): preserve enum string values in --just-types mode

### DIFF
--- a/packages/quicktype-core/src/language/Kotlin/KotlinRenderer.ts
+++ b/packages/quicktype-core/src/language/Kotlin/KotlinRenderer.ts
@@ -33,7 +33,7 @@ import {
 
 import { keywords } from "./constants.js";
 import type { kotlinOptions } from "./language.js";
-import { kotlinNameStyle } from "./utils.js";
+import { kotlinNameStyle, stringEscape } from "./utils.js";
 
 export class KotlinRenderer extends ConvenienceRenderer {
     public constructor(
@@ -391,10 +391,38 @@ export class KotlinRenderer extends ConvenienceRenderer {
     protected emitEnumDefinition(e: EnumType, enumName: Name): void {
         this.emitDescription(this.descriptionForType(e));
 
-        this.emitBlock(["enum class ", enumName], () => {
+        this.emitBlock(["enum class ", enumName, "(val value: String)"], () => {
             let count = e.cases.size;
-            this.forEachEnumCase(e, "none", (name) => {
-                this.emitLine(name, --count === 0 ? "" : ",");
+            this.forEachEnumCase(e, "none", (name, json) => {
+                this.emitLine(
+                    name,
+                    `("${stringEscape(json)}")`,
+                    --count === 0 ? ";" : ",",
+                );
+            });
+            this.ensureBlankLine();
+            this.emitBlock("companion object", () => {
+                this.emitBlock(
+                    [
+                        "fun fromValue(value: String): ",
+                        enumName,
+                        " = when (value)",
+                    ],
+                    () => {
+                        const table: Sourcelike[][] = [];
+                        this.forEachEnumCase(e, "none", (name, json) => {
+                            table.push([
+                                [`"${stringEscape(json)}"`],
+                                [" -> ", name],
+                            ]);
+                        });
+                        table.push([
+                            ["else"],
+                            [" -> throw IllegalArgumentException()"],
+                        ]);
+                        this.emitTable(table);
+                    },
+                );
             });
         });
     }

--- a/test/unit/just-types-option.test.ts
+++ b/test/unit/just-types-option.test.ts
@@ -3,15 +3,20 @@
 // `features=just-types` / `features=just-types-and-namespace` and Kotlin's,
 // Scala 3's, and Smithy4s's `framework=just-types` are gone; the boolean
 // wins over a conflicting explicit enum value.
+import * as fs from "node:fs";
+import * as path from "node:path";
+
 import { describe, expect, test } from "vitest";
 
 import {
     InputData,
+    JSONSchemaInput,
     type LanguageName,
     type RendererOptions,
     jsonInputForTargetLanguage,
     quicktype,
 } from "quicktype-core";
+import { schemaForTypeScriptSources } from "quicktype-typescript-input";
 
 async function linesFor(
     lang: LanguageName,
@@ -28,6 +33,29 @@ async function linesFor(
     return result.lines.join("\n");
 }
 
+async function kotlinLinesForTypeScript(source: string): Promise<string> {
+    const temporaryDirectory = fs.mkdtempSync(
+        path.join(process.cwd(), ".tmp-kotlin-just-types-test-"),
+    );
+    const fileName = path.join(temporaryDirectory, "input.ts");
+
+    try {
+        fs.writeFileSync(fileName, source);
+        const schemaInput = new JSONSchemaInput(undefined);
+        await schemaInput.addSource(schemaForTypeScriptSources([fileName]));
+        const inputData = new InputData();
+        inputData.addInput(schemaInput);
+        const result = await quicktype({
+            inputData,
+            lang: "kotlin",
+            rendererOptions: { "just-types": true },
+        });
+        return result.lines.join("\n");
+    } finally {
+        fs.rmSync(temporaryDirectory, { recursive: true, force: true });
+    }
+}
+
 describe("just-types generates plain types in every language", () => {
     test("C#: no attributes, no helpers, but a namespace", async () => {
         const output = await linesFor("csharp", { "just-types": true });
@@ -41,6 +69,31 @@ describe("just-types generates plain types in every language", () => {
         const output = await linesFor("kotlin", { "just-types": true });
         expect(output).toContain("data class Person");
         expect(output).not.toContain("Klaxon");
+    });
+
+    test("Kotlin: enum cases retain their TypeScript string values", async () => {
+        const output = await kotlinLinesForTypeScript(`
+            export enum CanvasAction {
+                ADD = "add",
+                BRING_TO_FRONT = "bringtofront",
+                DELETE = "delete",
+                FLIP = "flip",
+                INVERT = "invert",
+                UNDO = "undo",
+                REDO = "redo",
+            }
+
+            export interface Canvas {
+                action: CanvasAction;
+            }
+        `);
+
+        expect(output).toContain("enum class CanvasAction(val value: String)");
+        expect(output).toContain('Add("add")');
+        expect(output).toContain('Bringtofront("bringtofront")');
+        expect(output).toContain(
+            "fun fromValue(value: String): CanvasAction = when (value)",
+        );
     });
 
     test("Scala 3: plain case classes, no circe", async () => {


### PR DESCRIPTION
## Bug

Kotlin `--just-types` output dropped the original string value associated
with each enum case. Given:

```ts
export enum CanvasAction {
  ADD = 'add',
  BRING_TO_FRONT = 'bringtofront',
  ...
}
```

`quicktype --lang kotlin --just-types` produced:

```kotlin
enum class CanvasAction {
    Add,
    Bringtofront,
    ...
}
```

with no way to recover which JSON string (`"add"`, `"bringtofront"`, ...)
each case originally corresponded to.

## Root cause

Kotlin's base `KotlinRenderer` (used by `--just-types` mode) had its own
`emitEnumDefinition` that emitted a bare `enum class` with no value
information. Every other Kotlin framework — Klaxon, Jackson, and kotlinx —
overrides `emitEnumDefinition` and *does* preserve the value via a
`value: String` constructor arg plus a `fromValue`/`toValue` mapping. Java's
`--just-types` mode also preserves the value (via `toValue()`/`forValue()`),
without depending on any JSON library. So Kotlin `--just-types` was the
outlier, silently losing information other modes and other languages
already keep.

## Fix

`KotlinRenderer.emitEnumDefinition` now emits each case with its original
(escaped) string value as a constructor argument, plus a framework-independent
`companion object` with a `fromValue(value: String): EnumName` lookup —
consistent with the shape already used by the other Kotlin renderers, but
with no dependency on any JSON library (as required for `--just-types`
mode):

```kotlin
enum class CanvasAction(val value: String) {
    Add("add"),
    Bringtofront("bringtofront"),
    ...;

    companion object {
        fun fromValue(value: String): CanvasAction = when (value) {
            "add"          -> Add
            "bringtofront" -> Bringtofront
            ...
            else           -> throw IllegalArgumentException()
        }
    }
}
```

## Test coverage

Added a regression test to `test/unit/just-types-option.test.ts` that
generates Kotlin `--just-types` output from the exact TypeScript enum from
the issue report and asserts the case constructors carry their original
string values and that a `fromValue` lookup is emitted. The test was
confirmed to fail against the unfixed renderer and pass after the fix.

A unit test (rather than a JSON/JSON Schema fixture) was used because there
is no existing compile-and-run fixture for Kotlin `--just-types` mode (that
mode has no serialization to round-trip, which appears to be why one was
never set up for it), matching the precedent already established by the
other `--just-types` assertions in that same test file.

## Verification

- `npm run build` — passes.
- `npm run test:unit` — 164/164 tests pass.
- Manually re-ran the exact repro from the issue
  (`node dist/index.js --lang kotlin --just-types canvas.ts`) and confirmed
  the generated output now preserves the enum values.
- The Kotlin compiler toolchain (`kotlinc`) is not available in this
  environment, so the compile-and-run Kotlin fixtures (Klaxon, Jackson,
  kotlinx) could not be executed locally. This change only modifies
  `KotlinRenderer.emitEnumDefinition`, which every one of those three
  frameworks overrides with its own implementation, so it should have no
  effect on their generated output; CI will validate this.

Fixes #1601

🤖 Generated with [Claude Code](https://claude.com/claude-code)