### PR TITLE
fix(php): stop re-checking scalar types PHP already enforces

### DIFF
--- a/packages/quicktype-core/src/language/Php/PhpRenderer.ts
+++ b/packages/quicktype-core/src/language/Php/PhpRenderer.ts
@@ -1016,6 +1016,7 @@ export class PhpRenderer extends ConvenienceRenderer {
         t: Type,
         attrName: Sourcelike,
         scopeAttrName: string,
+        skipPrimitiveTypeCheck = false,
     ): void {
         const is = (isfn: string, myT: Name = className): void => {
             this.emitBlock(["if (!", isfn, "(", scopeAttrName, "))"], () =>
@@ -1038,30 +1039,38 @@ export class PhpRenderer extends ConvenienceRenderer {
                 // non-string arguments.)
             },
             (_nullType) => is("is_null"),
-            (_boolType) => is("is_bool"),
-            (_integerType) => is("is_integer"),
-            (_doubleType) => {
-                // PHP integers are acceptable wherever floats are, and
-                // json_decode gives an int for a whole JSON number.
-                this.emitBlock(
-                    [
-                        "if (!is_float(",
-                        scopeAttrName,
-                        ") && !is_int(",
-                        scopeAttrName,
-                        "))",
-                    ],
-                    () =>
-                        this.emitLine(
-                            'throw new Exception("Attribute Error:',
-                            className,
-                            "::",
-                            attrName,
-                            '");',
-                        ),
-                );
+            (_boolType) => {
+                if (!skipPrimitiveTypeCheck) is("is_bool");
             },
-            (_stringType) => is("is_string"),
+            (_integerType) => {
+                if (!skipPrimitiveTypeCheck) is("is_integer");
+            },
+            (_doubleType) => {
+                if (!skipPrimitiveTypeCheck) {
+                    // PHP integers are acceptable wherever floats are, and
+                    // json_decode gives an int for a whole JSON number.
+                    this.emitBlock(
+                        [
+                            "if (!is_float(",
+                            scopeAttrName,
+                            ") && !is_int(",
+                            scopeAttrName,
+                            "))",
+                        ],
+                        () =>
+                            this.emitLine(
+                                'throw new Exception("Attribute Error:',
+                                className,
+                                "::",
+                                attrName,
+                                '");',
+                            ),
+                    );
+                }
+            },
+            (_stringType) => {
+                if (!skipPrimitiveTypeCheck) is("is_string");
+            },
             (arrayType) => {
                 is("is_array");
                 this.emitLine(
@@ -1110,6 +1119,7 @@ export class PhpRenderer extends ConvenienceRenderer {
                                 nullable,
                                 attrName,
                                 scopeAttrName,
+                                skipPrimitiveTypeCheck,
                             );
                         },
                     );
@@ -1146,7 +1156,7 @@ export class PhpRenderer extends ConvenienceRenderer {
                 }
 
                 if (transformedStringType.kind === "uuid") {
-                    is("is_string");
+                    if (!skipPrimitiveTypeCheck) is("is_string");
                     this.emitBlock(
                         [
                             "if (!preg_match('/^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$/', ",
@@ -1286,7 +1296,10 @@ export class PhpRenderer extends ConvenienceRenderer {
                 " $value): bool",
             ],
             () => {
-                this.phpValidate(className, p.type, name, "$value");
+                // PHP has already enforced scalar parameter type hints before
+                // entering this method.  Recursive collection and union
+                // validation still performs its own runtime checks.
+                this.phpValidate(className, p.type, name, "$value", true);
                 this.emitLine("return true;");
             },
         );

--- a/test/inputs/json/priority/php-validation.json
+++ b/test/inputs/json/priority/php-validation.json
@@ -1,0 +1,7 @@
+{
+    "boolean": true,
+    "integer": 1,
+    "number": 1.5,
+    "string": "value",
+    "integers": [1, 2, 3]
+}

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1809,6 +1809,7 @@ export const PHPLanguage: Language = {
         // The motivating repro for non-nullable union support: a
         // heterogeneous array under a PHP-reserved-word property name.
         "php-mixed-union.json",
+        "php-validation.json",
     ],
     skipMiscJSON: true,
     skipSchema: [

--- a/test/unit/php-validation.test.ts
+++ b/test/unit/php-validation.test.ts
@@ -1,0 +1,76 @@
+import {
+    InputData,
+    JSONSchemaInput,
+    quicktype,
+} from "../../packages/quicktype-core/src/index.js";
+import { describe, expect, test } from "vitest";
+
+async function phpForSchema(schema: object): Promise<string> {
+    const schemaInput = new JSONSchemaInput(undefined);
+    await schemaInput.addSource({
+        name: "ScalarValidation",
+        schema: JSON.stringify(schema),
+    });
+
+    const inputData = new InputData();
+    inputData.addInput(schemaInput);
+    const result = await quicktype({ inputData, lang: "php" });
+    return result.lines.join("\n");
+}
+
+function validationMethod(php: string, propertyName: string): string {
+    const start = php.indexOf(
+        `public static function validate${propertyName}(`,
+    );
+    expect(start).toBeGreaterThanOrEqual(0);
+    const end = php.indexOf("\n    /**", start);
+    return php.slice(start, end < 0 ? undefined : end);
+}
+
+describe("PHP property validation", () => {
+    test("does not recheck scalar parameter types", async () => {
+        const php = await phpForSchema({
+            type: "object",
+            properties: {
+                boolean: { type: "boolean" },
+                integer: { type: "integer" },
+                number: { type: "number" },
+                nullableNumber: { type: ["number", "null"] },
+                string: { type: "string" },
+                integers: { type: "array", items: { type: "integer" } },
+                scalarUnion: { oneOf: [{ type: "integer" }, { type: "string" }] },
+            },
+            required: [
+                "boolean",
+                "integer",
+                "number",
+                "nullableNumber",
+                "string",
+                "integers",
+                "scalarUnion",
+            ],
+        });
+
+        for (const property of [
+            "Boolean",
+            "Integer",
+            "Number",
+            "NullableNumber",
+            "String",
+        ]) {
+            expect(validationMethod(php, property)).not.toMatch(
+                /is_(?:bool|float|int|integer|string)\(/,
+            );
+        }
+
+        expect(validationMethod(php, "Integers")).toContain(
+            "if (!is_integer($value_v))",
+        );
+        expect(validationMethod(php, "ScalarUnion")).toContain(
+            "if (is_int($value))",
+        );
+        expect(validationMethod(php, "ScalarUnion")).toContain(
+            "elseif (is_string($value))",
+        );
+    });
+});

--- a/test/unit/php-validation.test.ts
+++ b/test/unit/php-validation.test.ts
@@ -22,7 +22,11 @@ function validationMethod(php: string, propertyName: string): string {
     const start = php.indexOf(
         `public static function validate${propertyName}(`,
     );
-    expect(start).toBeGreaterThanOrEqual(0);
+    if (start < 0) {
+        throw new Error(
+            `No validate${propertyName} method found in generated PHP`,
+        );
+    }
     const end = php.indexOf("\n    /**", start);
     return php.slice(start, end < 0 ? undefined : end);
 }
@@ -38,7 +42,9 @@ describe("PHP property validation", () => {
                 nullableNumber: { type: ["number", "null"] },
                 string: { type: "string" },
                 integers: { type: "array", items: { type: "integer" } },
-                scalarUnion: { oneOf: [{ type: "integer" }, { type: "string" }] },
+                scalarUnion: {
+                    oneOf: [{ type: "integer" }, { type: "string" }],
+                },
             },
             required: [
                 "boolean",


### PR DESCRIPTION
## Bug

quicktype's PHP output generates a `validate<Property>()` static method for
every property. For primitive-typed properties (`bool`, `int`, `float`,
`string`), the generated body contains runtime `is_bool`/`is_integer`/
`is_float`/`is_int`/`is_string` guards that can never fire, because PHP
itself already enforces the parameter's type hint (e.g. `?float $value`)
before the method body ever runs — PHP throws a `TypeError` first, or, in
non-strict-types mode, coerces the value to match the type. Example (before
the fix):

```php
public static function validateLatitude(?float $value): bool {
    if (!is_null($value)) {
        if (!is_float($value) && !is_int($value)) {
            throw new Exception("Attribute Error:Coordinate::latitude");
        }
    }
    return true;
}
```

## Root cause

`emitValidateMethod` in `packages/quicktype-core/src/language/Php/PhpRenderer.ts`
calls `phpValidate()` unconditionally for the property's declared type. For
scalar (`bool`/`int`/`float`/`string`) branches, `phpValidate` emits an
`is_*` check on the parameter — but the parameter to `validate<Property>()`
already carries that exact scalar type hint, so the check is dead code that
can never throw.

## Fix

`phpValidate` now accepts a `skipPrimitiveTypeCheck` flag. The
`validate<Property>()` call site passes `true`, so the top-level
bool/int/float/string checks are skipped there (PHP's own type hint already
guarantees them), while validation for nested/recursive shapes — array
elements, union members, transformed strings (e.g. UUID format) — is left
untouched, since those still need runtime checks that PHP's type system
cannot express.

## Test coverage

- `test/unit/php-validation.test.ts`: generates PHP for a schema with
  boolean/integer/number/nullable-number/string/array/union properties and
  asserts the scalar `validate<Property>()` bodies no longer contain
  `is_bool`/`is_integer`/`is_float`/`is_string` checks, while confirming
  checks are still emitted for array elements and union members.
- `test/inputs/json/priority/php-validation.json` was added to the PHP
  fixture's JSON inputs (`test/languages.ts`) so the generated code is also
  exercised end-to-end through the PHP fixture's round-trip test.

## Verification

- `npm run build` passes.
- `npx vitest run test/unit/php-validation.test.ts` passes.
- Re-ran the original repro (`node dist/index.js --lang php --src-lang schema coord.schema.json`)
  and confirmed `validateLatitude`/`validateLongitude` now generate as:
  ```php
  public static function validateLatitude(float $value): bool {
      return true;
  }
  ```
- The PHP fixture test (`FIXTURE=php script/test`) requires a local PHP/
  composer toolchain that isn't available in this environment, so it was not
  run locally; CI will exercise it.

Fixes #2770

🤖 Generated with [Claude Code](https://claude.com/claude-code)