### PR TITLE
fix(input): reject non-OK HTTP responses when reading from a URL

### DIFF
--- a/packages/quicktype-core/src/input/io/NodeIO.ts
+++ b/packages/quicktype-core/src/input/io/NodeIO.ts
@@ -107,6 +107,11 @@ export async function readableFromFileOrURL(
             const response = await globalThis.fetch(fileOrURL, {
                 headers: parseHeaders(httpHeaders),
             });
+            if (!response.ok) {
+                throw new Error(
+                    `HTTP ${response.status} ${response.statusText}`,
+                );
+            }
 
             return readableFromResponseBody(defined(response.body));
         }

--- a/test/unit/url-input.test.ts
+++ b/test/unit/url-input.test.ts
@@ -19,6 +19,7 @@ import * as path from "node:path";
 
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 
+import { readFromFileOrURL } from "../../packages/quicktype-core/src/input/io/NodeIO.js";
 import { main as quicktype } from "../../src";
 
 const files: Record<string, string> = {
@@ -74,6 +75,12 @@ async function generateTypeScript(
 
 beforeAll(async () => {
     server = http.createServer((request, response) => {
+        if (path.basename(request.url ?? "") === "unauthorized.json") {
+            response.writeHead(401, { "Content-Type": "application/json" });
+            response.end('{"message":"Bad credentials"}');
+            return;
+        }
+
         const content = files[path.basename(request.url ?? "")];
         if (content === undefined) {
             response.writeHead(404);
@@ -103,6 +110,12 @@ describe("native fetch URL inputs", () => {
     test("generates types from a JSON URL", async () => {
         const output = await generateTypeScript("json", "sample.json");
         expect(output).toContain("veryUniquePropertyName");
+    });
+
+    test("rejects an HTTP error response", async () => {
+        await expect(
+            readFromFileOrURL(`${baseURL}/unauthorized.json`),
+        ).rejects.toThrow("HTTP 401 Unauthorized");
     });
 
     test("resolves a relative remote JSON Schema reference", async () => {


### PR DESCRIPTION
## Bug

When quicktype reads JSON/JSON Schema input from a URL (`--src http://...`)
and the server returns an HTTP error status (e.g. a 401 caused by an expired
auth token passed via `--http-header`), quicktype did not report an error.
Instead it silently treated the error response body as legitimate input:

- If the error body happened to be valid JSON, quicktype generated types
  from it and exited 0.
- If it wasn't valid JSON, quicktype emitted a misleading "Syntax error in
  input JSON" with no indication the real cause was an HTTP failure.

## Root cause

In `packages/quicktype-core/src/input/io/NodeIO.ts`,
`readableFromFileOrURL` called `globalThis.fetch()` and passed
`response.body` straight to the parser with no `response.ok` / status check:

```ts
const response = await globalThis.fetch(fileOrURL, {
    headers: parseHeaders(httpHeaders),
});

return readableFromResponseBody(defined(response.body));
```

## Fix

Check `response.ok` right after the fetch call and throw a clear error
(including the HTTP status) when the response is not OK, instead of handing
the error body to the parser:

```ts
if (!response.ok) {
    throw new Error(`HTTP ${response.status} ${response.statusText}`);
}
```

## Test coverage

Added a unit test in `test/unit/url-input.test.ts` (this bug is Node-only
HTTP-fetch behavior that the JSON/JSON Schema fixture-test machinery has no
mechanism to exercise, since fixtures drive file-based input, not an HTTP
server): the local test server now returns HTTP 401 with a JSON body for
`unauthorized.json`, and a new test asserts `readFromFileOrURL` rejects with
an error containing `HTTP 401 Unauthorized` instead of resolving.

## Verification

- Confirmed the bug on unfixed master: a local server returning HTTP 401
  with a JSON body caused `node dist/index.js --lang typescript --src
  http://localhost:8473/data.json --just-types` to print a bogus TypeScript
  interface derived from the error body and exit 0.
- After the fix, the same repro now fails as expected:
  ```
  Error: Cannot read from file or URL http://localhost:8473/data.json: Error: HTTP 401 Unauthorized.
  ```
  with exit code 1.
- `npm run build` passes.
- `npx vitest run test/unit/url-input.test.ts` passes (3/3, including the
  new test).
- Full CI (broader fixture suite) will validate the rest.

Fixes #2572

🤖 Generated with [Claude Code](https://claude.com/claude-code)