### PR TITLE
fix(swift): allow Sendable conformance with objective-c-support

### DIFF
--- a/packages/quicktype-core/src/language/Swift/SwiftRenderer.ts
+++ b/packages/quicktype-core/src/language/Swift/SwiftRenderer.ts
@@ -386,8 +386,7 @@ export class SwiftRenderer extends ConvenienceRenderer {
 
         if (
             this._options.sendable &&
-            (!this._options.mutableProperties || !isClass) &&
-            !this._options.objcSupport
+            (!this._options.mutableProperties || !isClass)
         ) {
             protocols.push("Sendable");
         }
@@ -501,7 +500,11 @@ export class SwiftRenderer extends ConvenienceRenderer {
         const isClass = this._options.useClasses || this.isCycleBreakerType(c);
         const structOrClass = isClass ? "class" : "struct";
         const finalPrefix =
-            isClass && this._options.finalClasses ? "final " : "";
+            isClass &&
+            (this._options.finalClasses ||
+                (this._options.sendable && !this._options.mutableProperties))
+                ? "final "
+                : "";
 
         if (isClass && this._options.objcSupport) {
             // [Michael Fey (@MrRooni), 2019-4-24] Swift 5 or greater, must come before the access declaration for the class.

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -1647,6 +1647,10 @@ export const allFixtures: Fixture[] = [
     new JSONFixture(languages.PythonLanguage),
     new JSONFixture(languages.ElmLanguage),
     new JSONFixture(languages.SwiftLanguage),
+    new JSONFixture(
+        languages.SwiftSendableObjectiveCSupportLanguage,
+        "swift-sendable-objective-c",
+    ),
     new JSONFixture(languages.ObjectiveCLanguage),
     new JSONFixture(languages.TypeScriptLanguage),
     new JSONFixture(languages.TypeScriptZodLanguage),

--- a/test/fixtures/swift/verify-sendable.cjs
+++ b/test/fixtures/swift/verify-sendable.cjs
@@ -1,0 +1,37 @@
+const fs = require("fs");
+
+const source = fs.readFileSync("quicktype.swift", "utf8");
+const declarations = source
+    .split("\n")
+    .filter((line) =>
+        /^(?:@objcMembers )?(?:final )?(?:class|struct|enum) /.test(line),
+    );
+
+if (declarations.length === 0) {
+    throw new Error("No generated type declarations found");
+}
+
+if (!declarations.some((line) => line.startsWith("enum "))) {
+    throw new Error("No generated enum declaration found");
+}
+
+if (
+    !declarations.some(
+        (line) => line.includes("class ") || line.startsWith("struct "),
+    )
+) {
+    throw new Error("No generated class or struct declaration found");
+}
+
+for (const declaration of declarations) {
+    if (!declaration.includes("Sendable")) {
+        throw new Error(`Generated type is not Sendable: ${declaration}`);
+    }
+
+    if (
+        declaration.includes("class ") &&
+        !declaration.startsWith("@objcMembers final class ")
+    ) {
+        throw new Error(`Generated Sendable class is not final: ${declaration}`);
+    }
+}

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -945,6 +945,24 @@ export const SwiftLanguage: Language = {
     sourceFiles: ["src/language/Swift/index.ts"],
 };
 
+export const SwiftSendableObjectiveCSupportLanguage: Language = {
+    ...SwiftLanguage,
+    compileCommand: "node verify-sendable.cjs",
+    diffViaSchema: false,
+    includeJSON: ["pokedex.json"],
+    rendererOptions: {
+        ...SwiftLanguage.rendererOptions,
+        sendable: "true",
+        "struct-or-class": "class",
+        "objective-c-support": "true",
+    },
+    quickTestRendererOptions: [
+        ["pokedex.json", { "struct-or-class": "struct" }],
+    ],
+    runCommand: undefined,
+    skipMiscJSON: true,
+};
+
 export const ObjectiveCLanguage: Language = {
     name: "objective-c",
     base: "test/fixtures/objective-c",


### PR DESCRIPTION
## Bug

With `--sendable --objective-c-support`, generated Swift types lost `Sendable` conformance entirely — even enums, which have no NSObject/Objective-C interop concern at all.

Repro (from issue #2781, using the maintainer triage's schema/flags):
```
node dist/index.js --lang swift --src-lang schema --src example.schema.json \
  --sendable --struct-or-class class --objective-c-support --top-level Example
```
Before: `@objcMembers class Example: NSObject, Codable { ... }` and `enum Fruit: String, Codable { ... }` — zero occurrences of `Sendable`.

Without `--objective-c-support`, the same input correctly produced `class Example: Codable, Sendable` and `enum Fruit: String, Codable, Sendable`.

## Root cause

`getProtocolsArray` in `packages/quicktype-core/src/language/Swift/SwiftRenderer.ts` unconditionally dropped `Sendable` whenever `objcSupport` was enabled, regardless of declaration kind (`class`/`struct`/`enum`). Enums and structs have no NSObject interop concern, so the guard was over-broad. For classes, Swift does allow `Sendable` conformance on an `NSObject` subclass provided the class is `final` and has only immutable, `Sendable` stored properties.

## Fix

- Dropped the blanket `!this._options.objcSupport` guard in `getProtocolsArray`, so `Sendable` is added whenever `--sendable` is set and (for classes) properties are immutable — independent of `objcSupport`.
- When emitting a class declaration, also emit `final` whenever `sendable` is on and properties are immutable (in addition to the existing `finalClasses` option), since Swift requires `NSObject` subclasses to be `final` to conform to `Sendable`.
- Classes with `--mutable-properties` remain non-`Sendable`/non-`final`, matching existing (correct) behavior without `--objective-c-support`.

## Test coverage

Added a new fixture, `swift-sendable-objective-c` (`test/languages.ts` / `test/fixtures.ts`), that generates Swift with `--sendable --struct-or-class class --objective-c-support` (plus a `struct-or-class: struct` variant via `quickTestRendererOptions`) and runs a small verification script (`test/fixtures/swift/verify-sendable.cjs`) asserting every generated `class`/`struct`/`enum` declaration includes `Sendable`, and that `Sendable` classes are emitted `@objcMembers final class`.

Real `swiftc` compilation isn't available in this environment (and the existing `swift`/`schema-swift` fixtures are already disabled in CI's `test-pr.yaml` due to a pre-existing "pgp issue"), so this fixture verifies the generated source text directly rather than compiling/running it, following the same `includeJSON`/custom-`compileCommand` pattern already used elsewhere in `test/languages.ts` (e.g. the `nbl-stats.json`-scoped fixtures).

## Verification performed locally

- Confirmed the new fixture fails (exit 1, `Generated type is not Sendable`) against the pre-fix renderer, and passes after the fix.
- `QUICKTEST=true FIXTURE=swift-sendable-objective-c script/test` passes.
- `npm run test:unit` — 169/169 tests pass.
- `npm run lint` (biome) — clean.
- `npm run build` — passes.
- Manually re-ran the issue's repro command and confirmed correct output for class+immutable, class+mutable-properties, and struct cases.

Fixes #2781

🤖 Generated with [Claude Code](https://claude.com/claude-code)