### PR TITLE
fix(rust): don't panic when there are no top-level types

### DIFF
--- a/packages/quicktype-core/src/language/Rust/RustRenderer.ts
+++ b/packages/quicktype-core/src/language/Rust/RustRenderer.ts
@@ -13,7 +13,6 @@ import type { Name, Namer } from "../../Naming.js";
 import type { RenderContext } from "../../Renderer.js";
 import type { OptionValues } from "../../RendererOptions/index.js";
 import { type Sourcelike, maybeAnnotated } from "../../Source.js";
-import { defined } from "../../support/Support.js";
 import type { TargetLanguage } from "../../TargetLanguage.js";
 import {
     type ClassType,
@@ -351,9 +350,10 @@ export class RustRenderer extends ConvenienceRenderer {
             return;
         }
 
-        const topLevelName = defined(
-            mapFirst(this.topLevels),
-        ).getCombinedName();
+        const topLevel = mapFirst(this.topLevels);
+        if (topLevel === undefined) return;
+
+        const topLevelName = topLevel.getCombinedName();
         this.emitMultiline(
             `// Example code that deserializes and serializes the model.
 // extern crate serde;

--- a/test/unit/rust-empty-top-levels.test.ts
+++ b/test/unit/rust-empty-top-levels.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "vitest";
+
+import {
+    InputData,
+    JSONSchemaInput,
+    quicktype,
+} from "../../packages/quicktype-core/src/index.js";
+
+async function renderTypeScriptSchema(definitions: object): Promise<string> {
+    const schemaInput = new JSONSchemaInput(undefined);
+    await schemaInput.addSource({
+        name: "",
+        schema: JSON.stringify({ definitions }),
+        uris: ["#/definitions/"],
+        isConverted: true,
+    });
+
+    const inputData = new InputData();
+    inputData.addInput(schemaInput);
+
+    const result = await quicktype({ inputData, lang: "rust" });
+    return result.lines.join("\n");
+}
+
+// TypeScript inputs without a #TopLevel marker use #/definitions/ as their
+// source URI.  If the compiler did not produce any definitions, the renderer
+// receives no top levels and must still emit Rust without crashing.
+test("Rust renders TypeScript schemas with no top levels", async () => {
+    const output = await renderTypeScriptSchema({});
+
+    expect(output).toContain("use serde::{Serialize, Deserialize};");
+});
+
+test("Rust still renders named TypeScript schema definitions", async () => {
+    const output = await renderTypeScriptSchema({
+        Person: {
+            type: "object",
+            properties: { age: { type: "integer" } },
+            required: ["age"],
+        },
+    });
+
+    expect(output).toContain("pub struct Person");
+});


### PR DESCRIPTION
## What was broken

Generating Rust from a TypeScript source that has no `#TopLevel`-marked
interface (the common case — `#TopLevel` is an internal quicktype
convention, not something users write) crashed with:

```
Error: Internal error: Defined value expected, but got undefined.
```

Repro (from the issue, using VS Code's `debugProtocol.d.ts`):

```
node dist/index.js --lang rs --derive-debug --density dense --visibility private \
  --out debugProtocolTypes.rs --src-lang typescript --src debugProtocol.d.ts
```

C# generation from the same input succeeds, confirming this was a
Rust-renderer-specific bug rather than a TypeScript-input or CLI issue (some
issue commenters chased an unrelated `--` argument-parsing red herring).

## Root cause

When the TypeScript-to-JSON-Schema conversion finds no `#TopLevel` marker, it
falls back to `uris: ["#/definitions/"]`, which does not name any specific
top-level type — the renderer's `this.topLevels` map ends up legitimately
empty even though the type graph itself is non-empty. `RustRenderer`'s
`emitLeadingComments()` unconditionally did:

```ts
const topLevelName = defined(mapFirst(this.topLevels)).getCombinedName();
```

`defined()` panics whenever its argument is `undefined`, so an empty
`topLevels` map crashed the whole run. Other renderers (e.g. C#'s
`emitDefaultLeadingComments`) don't assume a top level exists for their
default leading comment, so only Rust was affected.

## Fix

In `packages/quicktype-core/src/language/Rust/RustRenderer.ts`,
`emitLeadingComments()` now checks whether a top level exists and simply
skips the top-level-specific example comment when it doesn't, instead of
panicking:

```ts
const topLevel = mapFirst(this.topLevels);
if (topLevel === undefined) return;

const topLevelName = topLevel.getCombinedName();
```

This is a narrowly scoped change — no other renderer or shared code paths
were touched.

## Test coverage

This condition (empty `topLevels` with a non-empty type graph) isn't
reachable through the JSON/JSON-Schema fixture harness, since fixture
schemas always assign a concrete top-level name. Per repo convention this
makes a `test/unit/` test the right coverage, following the same pattern as
`test/unit/typescript-input.test.ts` and
`test/unit/kotlin-klaxon-empty-object-map.test.ts`.

Added `test/unit/rust-empty-top-levels.test.ts`, which drives `quicktype()`
directly with a `JSONSchemaInput` built the same way
`quicktype-typescript-input` builds one when no `#TopLevel` marker is
present (`uris: ["#/definitions/"]`), asserting:
- Rust renders without throwing when the schema's `definitions` produce no
  top-level type at all.
- Rust still renders named types correctly when a top level is present
  (regression guard).

## Verification

- `npm run build` passes.
- `npx vitest run test/unit/rust-empty-top-levels.test.ts test/unit/typescript-input.test.ts` — all pass.
- Re-ran the exact repro from the issue against the built `dist/index.js`
  with the real VS Code `debugProtocol.d.ts`: previously crashed with the
  "Defined value expected" panic, now exits 0 and writes valid Rust source.
- `QUICKTEST=true FIXTURE=rust script/test` (full Rust fixture suite, using
  the local `rustc`/`cargo` toolchain) — run locally to confirm no
  regressions; CI will also validate this on the PR.

Fixes #1629

🤖 Generated with [Claude Code](https://claude.com/claude-code)
