### PR TITLE
fix(core): preserve JSON Schema enum case order

### DIFF
--- a/packages/quicktype-core/src/ConvenienceRenderer.ts
+++ b/packages/quicktype-core/src/ConvenienceRenderer.ts
@@ -995,10 +995,7 @@ export abstract class ConvenienceRenderer extends Renderer {
         f: (name: Name, jsonName: string, position: ForEachPosition) => void,
     ): void {
         const caseNames = defined(this._caseNamesStoreView).get(e);
-        const sortedCaseNames = mapSortBy(caseNames, (n) =>
-            defined(this.names.get(n)),
-        );
-        this.forEachWithBlankLines(sortedCaseNames, blankLocations, f);
+        this.forEachWithBlankLines(caseNames, blankLocations, f);
     }
 
     protected forEachTransformation(

--- a/test/unit/enum-order.test.ts
+++ b/test/unit/enum-order.test.ts
@@ -1,0 +1,32 @@
+import {
+    InputData,
+    JSONSchemaInput,
+    quicktype,
+} from "../../packages/quicktype-core/src/index.js";
+import { expect, test } from "vitest";
+
+const schema = JSON.stringify({
+    $schema: "http://json-schema.org/draft-04/schema#",
+    title: "Test",
+    type: "object",
+    properties: {
+        errorCode: {
+            type: "string",
+            enum: ["B", "A", "E"],
+        },
+    },
+});
+
+test("preserves JSON Schema enum case order", async () => {
+    const schemaInput = new JSONSchemaInput(undefined);
+    await schemaInput.addSource({ name: "Test", schema });
+
+    const inputData = new InputData();
+    inputData.addInput(schemaInput);
+
+    const result = await quicktype({ inputData, lang: "c++" });
+
+    expect(result.lines).toContain(
+        "    enum class ErrorCode : int { B, A, E };",
+    );
+});


### PR DESCRIPTION
## Bug

C++ (and, as it turns out, every other language) emitted enum cases in
alphabetical order instead of the order they appear in the source JSON
Schema / JSON `enum` array.

Repro from the issue:

```
quicktype -l c++ --code-format with-getter-setter --wstring use-string --const-style west-const --type-style pascal-case --member-style camel-case --enumerator-style pascal-case --no-boost -s schema test.json
```

with schema property `"enum": ["B", "A", "E"]` produced:

```
enum class ErrorCode : int { A, B, E };
```

instead of preserving the declared order `B, A, E`.

## Root cause

`ConvenienceRenderer.forEachEnumCase` (in
`packages/quicktype-core/src/ConvenienceRenderer.ts`) unconditionally
sorted enum case names alphabetically by their rendered `Name` before
handing them to a language renderer's `emitEnum`:

```ts
const sortedCaseNames = mapSortBy(caseNames, (n) =>
    defined(this.names.get(n)),
);
this.forEachWithBlankLines(sortedCaseNames, blankLocations, f);
```

`forEachEnumCase` is called by essentially every language's `emitEnum`
(C++, C#, Java, Kotlin, Swift, Python, Go, Rust, PHP, Ruby, etc.), so
this alphabetization was not C++-specific — it affected all generators.
The underlying `caseNames` map already reflects the original
schema/JSON input order (JS `Map`/`Set` preserve insertion order), so
the fix is simply to stop forcibly re-sorting it, mirroring how
`forEachClassProperty` already preserves declared property order by
default (only alphabetizing when the existing, opt-in
`_alphabetizeProperties` renderer option is set).

## Fix

Removed the unconditional `mapSortBy` alphabetization in
`forEachEnumCase`, so enum cases are emitted in the same order they
appear in the source input.

## Test coverage

- Added `test/unit/enum-order.test.ts`, which reproduces the issue's
  exact schema (`enum: ["B", "A", "E"]`) and asserts the generated C++
  contains `enum class ErrorCode : int { B, A, E };`. This fails on
  unfixed code (previously emitted `A, B, E`) and passes after the fix.
- End-to-end fixture coverage already exists via
  `test/inputs/schema/enum.schema`, whose enum arrays
  (`["lawful", "neutral", "chaotic"]`, `["good", "neutral", "evil"]`)
  are non-alphabetical and are exercised for C++ through the
  `schema-cplusplus` fixture (not in that language's `skipSchema` list),
  giving ongoing round-trip regression coverage for this case.

## Verification

- `npm run build` passes.
- `npx vitest run test/unit` — all 171 unit tests pass, including the
  new regression test.
- `QUICKTEST=true FIXTURE=schema-cplusplus script/test` — all 70 tests
  pass locally (g++ toolchain available in this environment).
- Manually re-ran the exact CLI repro from the issue; output now shows
  `enum class ErrorCode : int { B, A, E };`, matching input order.
- CI will additionally validate the other language fixtures that call
  `forEachEnumCase`.

Fixes #1289.

🤖 Generated with [Claude Code](https://claude.com/claude-code)