### PR TITLE
fix(java): emit @JsonFormat for optional date/time properties

### DIFF
--- a/packages/quicktype-core/src/language/Java/JavaJacksonRenderer.ts
+++ b/packages/quicktype-core/src/language/Java/JavaJacksonRenderer.ts
@@ -10,7 +10,10 @@ import {
     type TypeKind,
     UnionType,
 } from "../../Type/index.js";
-import { removeNullFromUnion } from "../../Type/TypeUtils.js";
+import {
+    nullableFromUnion,
+    removeNullFromUnion,
+} from "../../Type/TypeUtils.js";
 
 import { JavaRenderer } from "./JavaRenderer.js";
 import { stringEscape } from "./utils.js";
@@ -58,7 +61,12 @@ export class JacksonRenderer extends JavaRenderer {
             `@JsonProperty("${stringEscape(jsonName)}")`,
         ];
 
-        switch (p.type.kind) {
+        const propertyType =
+            p.type instanceof UnionType
+                ? (nullableFromUnion(p.type) ?? p.type)
+                : p.type;
+
+        switch (propertyType.kind) {
             case "date-time":
                 this._dateTimeProvider.dateTimeJacksonAnnotations.forEach(
                     (annotation) => {

--- a/test/inputs/schema/optional-date-time.1.fail.date-time.json
+++ b/test/inputs/schema/optional-date-time.1.fail.date-time.json
@@ -1,0 +1,8 @@
+{
+    "required-date": "2024-01-02",
+    "required-time": "12:34:56Z",
+    "required-date-time": "not a valid date-time at all",
+    "optional-date": "2024-01-02",
+    "optional-time": "12:34:56Z",
+    "optional-date-time": "2024-01-02T12:34:56Z"
+}

--- a/test/inputs/schema/optional-date-time.1.json
+++ b/test/inputs/schema/optional-date-time.1.json
@@ -1,0 +1,8 @@
+{
+    "required-date": "2024-01-02",
+    "required-time": "12:34:56Z",
+    "required-date-time": "2024-01-02T12:34:56Z",
+    "optional-date": "2024-01-02",
+    "optional-time": "12:34:56Z",
+    "optional-date-time": "2024-01-02T12:34:56Z"
+}

--- a/test/inputs/schema/optional-date-time.schema
+++ b/test/inputs/schema/optional-date-time.schema
@@ -1,0 +1,35 @@
+{
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "required-date": {
+            "type": "string",
+            "format": "date"
+        },
+        "required-time": {
+            "type": "string",
+            "format": "time"
+        },
+        "required-date-time": {
+            "type": "string",
+            "format": "date-time"
+        },
+        "optional-date": {
+            "type": "string",
+            "format": "date"
+        },
+        "optional-time": {
+            "type": "string",
+            "format": "time"
+        },
+        "optional-date-time": {
+            "type": "string",
+            "format": "date-time"
+        }
+    },
+    "required": [
+        "required-date",
+        "required-time",
+        "required-date-time"
+    ]
+}


### PR DESCRIPTION
## Bug

With `--datetime-provider legacy`, the Java (Jackson) renderer attaches
`@JsonFormat(pattern = ...)` to `date`/`date-time`/`time` properties that
are **required**, but silently omits it for the same kind of properties
when they are **optional** — producing inconsistent serialization/parsing
behavior between the two, even though both hold the same value type.

Repro:

```
node dist/index.js --lang java --src-lang schema --lombok --datetime-provider legacy demo.schema
```

with a schema containing both a required and an optional `date-time`
property. Before the fix, only the required property got `@JsonFormat`;
after the fix, both do.

## Root cause

`JavaJacksonRenderer.annotationsForAccessor` switched directly on
`p.type.kind` to decide which `@JsonFormat` annotation to emit. A
**required** date/date-time/time property has that kind directly on its
type, so the switch matched. An **optional** property is represented
internally as a nullable union (`date-time | null`), so `p.type.kind` is
`"union"` and none of the cases matched, silently skipping the
annotation. This was invisible with the default `java8` datetime
provider because that provider's annotation lists are empty regardless.

## Fix

Unwrap a nullable union to its non-null member before switching on the
kind, using the same `nullableFromUnion` pattern already used elsewhere
in the Java renderer (e.g. `JavaRenderer.javaType`). Minimal, four-line
change in `packages/quicktype-core/src/language/Java/JavaJacksonRenderer.ts`.

## Test coverage

Added `test/inputs/schema/optional-date-time.schema` (+
`.1.json` sample) with matching required and optional `date`, `time`, and
`date-time` properties. This schema is picked up automatically by the
existing `schema-java-datetime-legacy` fixture (`JavaLanguageWithLegacyDateTime`
in `test/languages.ts`, registered in `test/fixtures.ts`), and is not
excluded by that language's `skipSchema` list.

## Verification done locally

- `npm run build` passes.
- Re-ran the original repro: `optionalDate`/`requiredDate` now get
  identical `@JsonFormat` annotations under `--datetime-provider legacy`.
- Confirmed the default `java8` provider still emits zero `@JsonFormat`
  annotations (unaffected/expected behavior).
- Spot-checked code generation for the new schema file across several
  other languages (C#, Python, Go, Rust, Swift, Kotlin, TypeScript) to
  confirm the new fixture input doesn't break unrelated languages.
- Maven is not available in this sandbox, so the full compile-and-run
  fixture (`FIXTURE=schema-java-datetime-legacy script/test`) could not
  be executed end-to-end locally; CI will run it.

Fixes #1593

🤖 Generated with [Claude Code](https://claude.com/claude-code)