### PR TITLE
fix(typescript-input): preserve declared property order (#898)

### DIFF
--- a/packages/quicktype-typescript-input/src/index.ts
+++ b/packages/quicktype-typescript-input/src/index.ts
@@ -20,6 +20,7 @@ const settings: PartialArgs = {
     titles: true,
     topRef: true,
     noExtraProps: true,
+    propOrder: true,
 };
 
 const compilerOptions: ts.CompilerOptions = {
@@ -186,9 +187,17 @@ export function schemaForTypeScriptSources(
             if (
                 definition === null ||
                 Array.isArray(definition) ||
-                typeof definition !== "object" ||
-                typeof definition.description !== "string"
+                typeof definition !== "object"
             ) {
+                continue;
+            }
+
+            if (Array.isArray(definition.propertyOrder)) {
+                (definition as Record<string, unknown>).quicktypePropertyOrder =
+                    definition.propertyOrder;
+            }
+
+            if (typeof definition.description !== "string") {
                 continue;
             }
 

--- a/test/unit/typescript-input.test.ts
+++ b/test/unit/typescript-input.test.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 
+import { InputData, JSONSchemaInput, quicktype } from "quicktype-core";
 import { schemaForTypeScriptSources } from "quicktype-typescript-input";
 import { afterAll, describe, expect, test } from "vitest";
 
@@ -18,13 +19,17 @@ afterAll(() => {
 
 let uniqueFileIndex = 0;
 
-function schemaForSource(source: string) {
+function schemaSourceForSource(source: string) {
     const fileName = path.join(
         path.relative(process.cwd(), temporaryDirectory),
         `input-${uniqueFileIndex++}.ts`,
     );
     fs.writeFileSync(fileName, source);
-    const result = schemaForTypeScriptSources([fileName]);
+    return schemaForTypeScriptSources([fileName]);
+}
+
+function schemaForSource(source: string) {
+    const result = schemaSourceForSource(source);
     return {
         name: result.name ?? "",
         schema: JSON.parse(result.schema),
@@ -32,7 +37,33 @@ function schemaForSource(source: string) {
     };
 }
 
+async function swiftForSource(source: string): Promise<string> {
+    const schemaInput = new JSONSchemaInput(undefined);
+    await schemaInput.addSource(schemaSourceForSource(source));
+
+    const inputData = new InputData();
+    inputData.addInput(schemaInput);
+
+    const result = await quicktype({ inputData, lang: "swift" });
+    return result.lines.join("\n");
+}
+
 describe("schemaForTypeScriptSources", () => {
+    test("preserves class property declaration order in generated output", async () => {
+        const output = await swiftForSource(`
+            class A {
+                name: string;
+                age: number;
+            }
+        `);
+
+        const nameIndex = output.indexOf("let name: String");
+        const ageIndex = output.indexOf("let age: Double");
+        expect(nameIndex).toBeGreaterThanOrEqual(0);
+        expect(ageIndex).toBeGreaterThanOrEqual(0);
+        expect(nameIndex).toBeLessThan(ageIndex);
+    });
+
     test("converts a simple interface", () => {
         const { schema, uris } = schemaForSource(`
             export interface Person {


### PR DESCRIPTION
## Bug

Given TypeScript class input:

```ts
class A {
    name: string;
    age: number;
}
```

quicktype's Swift output alphabetized the fields instead of preserving
declaration order:

```swift
struct A {
    let age: Double
    let name: String
}
```

This breaks the generated memberwise initializer's parameter order and,
more generally, silently reorders any output that's sensitive to property
order.

## Root cause

`packages/quicktype-typescript-input/src/index.ts` invokes
`typescript-json-schema` to convert TypeScript sources into a JSON Schema,
but never passed the `propOrder` setting. Without it, `typescript-json-schema`
emits no `propertyOrder` metadata on schema definitions, so downstream
`JSONSchemaInput` has no order information to work with and falls back to
alphabetical/insertion order from the schema object.

quicktype already has a mechanism for this: `JSONSchemaInput` reads an
optional `quicktypePropertyOrder` field off each schema definition
(`packages/quicktype-core/src/input/JSONSchemaInput.ts`), it just was never
populated for TypeScript-source input.

## Fix

- Enable `propOrder: true` in the `typescript-json-schema` settings.
- Copy the emitted `propertyOrder` array from each schema definition onto
  `quicktypePropertyOrder`, which `JSONSchemaInput` already consumes.

## Tests

Added a regression test in `test/unit/typescript-input.test.ts` that compiles
a TypeScript class through `schemaForTypeScriptSources` and then through
`quicktype` to Swift, asserting `name` is emitted before `age`, matching
declaration order.

This bug is specific to the "TypeScript source as input" path
(`--src-lang typescript`), which starts from `.ts` files rather than JSON or
JSON Schema fixtures, so it isn't expressible via the repo's JSON/JSON Schema
fixture harness (`test/inputs/json`, `test/inputs/schema`) — a unit test is
the appropriate coverage here per repo conventions.

## Verification

- `npm run build` passes.
- `npx vitest run` — all 171 unit tests pass (26 files), including the new
  regression test.
- Manual repro: `node dist/index.js --lang swift --src-lang typescript A.ts`
  with the class above now emits `name` before `age` in the generated
  Swift struct.

Fixes #898

🤖 Generated with [Claude Code](https://claude.com/claude-code)