### PR TITLE
CI: report generated output differences

### DIFF
--- a/.github/workflows/output-diffs.yaml
+++ b/.github/workflows/output-diffs.yaml
@@ -1,0 +1,188 @@
+name: Generated output diff
+
+on:
+    push:
+        branches:
+            - master
+    pull_request:
+
+permissions:
+    contents: read
+
+concurrency:
+    group: output-diff-${{ github.event.pull_request.number || github.sha }}
+    cancel-in-progress: true
+
+env:
+    OUTPUT_SNAPSHOT_CACHE_PREFIX: quicktype-output-snapshot-v1
+
+jobs:
+    cache-master-snapshot:
+        name: Cache master output snapshot
+        if: github.event_name == 'push'
+        runs-on: ubuntu-22.04
+        steps:
+            - uses: actions/checkout@v4
+            - name: Restore exact snapshot
+              id: snapshot-cache
+              uses: actions/cache/restore@v4
+              with:
+                  path: .output-diffs/base
+                  key: ${{ env.OUTPUT_SNAPSHOT_CACHE_PREFIX }}-${{ runner.os }}-${{ github.sha }}
+            - uses: ./.github/workflows/setup
+              if: steps.snapshot-cache.outputs.cache-hit != 'true'
+            - name: Generate snapshot
+              if: steps.snapshot-cache.outputs.cache-hit != 'true'
+              env:
+                  ALL_FIXTURES: "1"
+                  CPUs: "4"
+                  ONLY_OUTPUT: "1"
+                  OUTPUT_SNAPSHOT_DIR: ${{ github.workspace }}/.output-diffs/base
+              run: npm run test:output-snapshot
+            - name: Save exact snapshot
+              if: steps.snapshot-cache.outputs.cache-hit != 'true'
+              uses: actions/cache/save@v4
+              with:
+                  path: .output-diffs/base
+                  key: ${{ env.OUTPUT_SNAPSHOT_CACHE_PREFIX }}-${{ runner.os }}-${{ github.sha }}
+
+    compare-pull-request:
+        name: Compare generated output
+        if: github.event_name == 'pull_request'
+        runs-on: ubuntu-22.04
+        steps:
+            - name: Restore exact base snapshot
+              id: base-cache
+              uses: actions/cache/restore@v4
+              with:
+                  path: .output-diffs/base
+                  key: ${{ env.OUTPUT_SNAPSHOT_CACHE_PREFIX }}-${{ runner.os }}-${{ github.event.pull_request.base.sha }}
+
+            - name: Check out PR head
+              uses: actions/checkout@v4
+              with:
+                  repository: ${{ github.event.pull_request.head.repo.full_name }}
+                  ref: ${{ github.event.pull_request.head.sha }}
+                  path: head-source
+
+            - name: Check out base after a cache miss
+              if: steps.base-cache.outputs.cache-hit != 'true'
+              uses: actions/checkout@v4
+              with:
+                  ref: ${{ github.event.pull_request.base.sha }}
+                  path: base-source
+
+            - name: Check snapshot compatibility
+              id: compatibility
+              shell: bash
+              run: |
+                  if [[ "${{ steps.base-cache.outputs.cache-hit }}" == "true" ]]; then
+                      echo "supported=true" >> "$GITHUB_OUTPUT"
+                  elif node -e 'const p=require("./base-source/package.json"); process.exit(p.scripts?.["test:output-snapshot"] ? 0 : 1)'; then
+                      echo "supported=true" >> "$GITHUB_OUTPUT"
+                  else
+                      echo "supported=false" >> "$GITHUB_OUTPUT"
+                      echo "The base commit predates generated-output snapshot support; this bootstrap comparison is skipped." >> "$GITHUB_STEP_SUMMARY"
+                  fi
+
+            - name: Set up Node
+              if: steps.compatibility.outputs.supported == 'true'
+              uses: actions/setup-node@v4
+              with:
+                  node-version-file: head-source/.nvmrc
+                  cache: npm
+                  cache-dependency-path: head-source/package-lock.json
+
+            - name: Build base after a cache miss
+              if: steps.compatibility.outputs.supported == 'true' && steps.base-cache.outputs.cache-hit != 'true'
+              working-directory: base-source
+              run: npm ci && npm run build
+
+            - name: Generate base snapshot after a cache miss
+              if: steps.compatibility.outputs.supported == 'true' && steps.base-cache.outputs.cache-hit != 'true'
+              working-directory: base-source
+              env:
+                  ALL_FIXTURES: "1"
+                  CPUs: "4"
+                  ONLY_OUTPUT: "1"
+                  OUTPUT_SNAPSHOT_DIR: ${{ github.workspace }}/.output-diffs/base
+              run: npm run test:output-snapshot
+
+            - name: Save PR-scoped base snapshot after a cache miss
+              if: steps.compatibility.outputs.supported == 'true' && steps.base-cache.outputs.cache-hit != 'true'
+              uses: actions/cache/save@v4
+              with:
+                  path: .output-diffs/base
+                  key: ${{ env.OUTPUT_SNAPSHOT_CACHE_PREFIX }}-${{ runner.os }}-${{ github.event.pull_request.base.sha }}
+
+            - name: Build PR head
+              if: steps.compatibility.outputs.supported == 'true'
+              working-directory: head-source
+              run: npm ci && npm run build
+
+            - name: Generate PR head snapshot
+              if: steps.compatibility.outputs.supported == 'true'
+              working-directory: head-source
+              env:
+                  ALL_FIXTURES: "1"
+                  CPUs: "4"
+                  ONLY_OUTPUT: "1"
+                  OUTPUT_SNAPSHOT_DIR: ${{ github.workspace }}/.output-diffs/head
+              run: npm run test:output-snapshot
+
+            - name: Compare snapshots
+              if: steps.compatibility.outputs.supported == 'true'
+              run: |
+                  mkdir -p .output-diffs/result
+                  head-source/node_modules/.bin/tsx head-source/script/output-diff.ts compare \
+                      .output-diffs/base .output-diffs/head \
+                      .output-diffs/result/result.json .output-diffs/result/output.diff
+
+            - name: Write bootstrap result
+              if: steps.compatibility.outputs.supported != 'true'
+              run: |
+                  mkdir -p .output-diffs/result
+                  printf '%s\n' '{"version":1,"hasDifferences":false,"files":[],"summary":{"added":0,"changedLines":0,"deleted":0,"deletions":0,"files":0,"insertions":0,"modified":0}}' > .output-diffs/result/result.json
+                  : > .output-diffs/result/output.diff
+
+            - name: Write comparison metadata
+              env:
+                  BASE_SHA: ${{ github.event.pull_request.base.sha }}
+                  HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+                  PR_NUMBER: ${{ github.event.pull_request.number }}
+                  PR_SHA: ${{ github.sha }}
+                  PR_URL: ${{ github.event.pull_request.html_url }}
+                  SUPPORTED: ${{ steps.compatibility.outputs.supported }}
+              run: |
+                  node - <<'NODE'
+                  const fs = require("node:fs");
+                  const metadata = {
+                      baseSha: process.env.BASE_SHA,
+                      headSha: process.env.HEAD_SHA,
+                      prNumber: Number(process.env.PR_NUMBER),
+                      prSha: process.env.PR_SHA,
+                      prUrl: process.env.PR_URL,
+                      supported: process.env.SUPPORTED === "true",
+                  };
+                  fs.writeFileSync(".output-diffs/result/metadata.json", `${JSON.stringify(metadata, null, 2)}\n`);
+                  NODE
+
+            - name: Summarize comparison
+              run: |
+                  node - <<'NODE'
+                  const fs = require("node:fs");
+                  const result = JSON.parse(fs.readFileSync(".output-diffs/result/result.json", "utf8"));
+                  const s = result.summary;
+                  fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY,
+                      result.hasDifferences
+                          ? `Generated output differs in **${s.files} files** (${s.modified} modified, ${s.added} new, ${s.deleted} deleted), with **${s.changedLines} changed lines** (+${s.insertions}/-${s.deletions}).\n`
+                          : "Generated output is unchanged.\n");
+                  NODE
+
+            - name: Upload comparison data
+              uses: actions/upload-artifact@v4
+              with:
+                  name: generated-output-diff
+                  path: .output-diffs/result
+                  if-no-files-found: error
+                  retention-days: 14

--- a/.github/workflows/publish-output-diffs.yaml
+++ b/.github/workflows/publish-output-diffs.yaml
@@ -1,0 +1,179 @@
+name: Publish generated output diff
+
+on:
+    workflow_run:
+        workflows:
+            - Generated output diff
+        types:
+            - completed
+
+permissions:
+    actions: read
+    contents: read
+    pull-requests: write
+
+jobs:
+    publish:
+        name: Publish report and update PR comment
+        if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+        runs-on: ubuntu-22.04
+        steps:
+            - name: Download comparison data
+              uses: actions/download-artifact@v4
+              with:
+                  name: generated-output-diff
+                  path: comparison
+                  run-id: ${{ github.event.workflow_run.id }}
+                  github-token: ${{ github.token }}
+
+            - name: Check out trusted report renderer
+              uses: actions/checkout@v4
+              with:
+                  ref: ${{ github.event.repository.default_branch }}
+                  path: trusted-source
+
+            - name: Validate metadata and result
+              id: metadata
+              env:
+                  EVENT_PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+                  REPOSITORY: ${{ github.repository }}
+              run: |
+                  node - <<'NODE'
+                  const fs = require("node:fs");
+                  const metadata = JSON.parse(fs.readFileSync("comparison/metadata.json", "utf8"));
+                  const result = JSON.parse(fs.readFileSync("comparison/result.json", "utf8"));
+                  const sha = /^[0-9a-f]{40,64}$/;
+                  if (!Number.isSafeInteger(metadata.prNumber) || metadata.prNumber <= 0) throw new Error("Invalid PR number");
+                  if (String(metadata.prNumber) !== process.env.EVENT_PR_NUMBER) throw new Error("Artifact PR does not match workflow event");
+                  for (const key of ["baseSha", "prSha", "headSha"]) {
+                      if (!sha.test(metadata[key])) throw new Error(`Invalid ${key}`);
+                  }
+                  if (typeof metadata.supported !== "boolean" || typeof result.hasDifferences !== "boolean") throw new Error("Invalid comparison state");
+                  const summary = result.summary;
+                  for (const key of ["files", "modified", "added", "deleted", "changedLines", "insertions", "deletions"]) {
+                      if (!Number.isSafeInteger(summary[key]) || summary[key] < 0) throw new Error(`Invalid summary field ${key}`);
+                  }
+                  const prUrl = `https://github.com/${process.env.REPOSITORY}/pull/${metadata.prNumber}`;
+                  const values = {
+                      base_sha: metadata.baseSha,
+                      changed_lines: summary.changedLines,
+                      deleted: summary.deleted,
+                      deletions: summary.deletions,
+                      files: summary.files,
+                      has_differences: result.hasDifferences,
+                      head_sha: metadata.headSha,
+                      insertions: summary.insertions,
+                      modified: summary.modified,
+                      new_files: summary.added,
+                      pr_number: metadata.prNumber,
+                      pr_sha: metadata.prSha,
+                      pr_url: prUrl,
+                      supported: metadata.supported,
+                  };
+                  const output = Object.entries(values).map(([key, value]) => `${key}=${value}`).join("\n") + "\n";
+                  fs.appendFileSync(process.env.GITHUB_OUTPUT, output);
+                  NODE
+
+            - name: Set up Node
+              if: steps.metadata.outputs.supported == 'true' && steps.metadata.outputs.has_differences == 'true'
+              uses: actions/setup-node@v4
+              with:
+                  node-version-file: trusted-source/.nvmrc
+                  cache: npm
+                  cache-dependency-path: trusted-source/package-lock.json
+
+            - name: Install trusted report dependencies
+              if: steps.metadata.outputs.supported == 'true' && steps.metadata.outputs.has_differences == 'true'
+              working-directory: trusted-source
+              run: npm ci --ignore-scripts
+
+            - name: Render report
+              if: steps.metadata.outputs.supported == 'true' && steps.metadata.outputs.has_differences == 'true'
+              run: |
+                  mkdir -p report
+                  trusted-source/node_modules/.bin/tsx trusted-source/script/output-diff.ts render \
+                      comparison/result.json comparison/output.diff report/index.html \
+                      '${{ steps.metadata.outputs.pr_url }}' \
+                      '${{ steps.metadata.outputs.base_sha }}' \
+                      '${{ steps.metadata.outputs.pr_sha }}' \
+                      '${{ steps.metadata.outputs.head_sha }}'
+                  cp comparison/output.diff report/output.diff
+
+            - name: Publish immutable report to hostr
+              if: steps.metadata.outputs.supported == 'true' && steps.metadata.outputs.has_differences == 'true'
+              env:
+                  HOSTR_TOKEN: ${{ secrets.HOSTR_TOKEN }}
+                  REPORT_PATH: quicktype/output-diffs/pr-${{ steps.metadata.outputs.pr_number }}/${{ steps.metadata.outputs.pr_sha }}/${{ steps.metadata.outputs.head_sha }}
+              run: |
+                  test -n "$HOSTR_TOKEN"
+                  upload_immutable() {
+                      local file=$1 content_type=$2 url=$3 status
+                      status=$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' "$url")
+                      case "$status" in
+                          200) echo "Already published: $url" ;;
+                          404)
+                              curl --fail-with-body --retry 3 -X POST \
+                                  -H "Authorization: Bearer $HOSTR_TOKEN" \
+                                  -H "Content-Type: $content_type" \
+                                  --data-binary "@$file" "$url"
+                              ;;
+                          *) echo "Unexpected hostr response $status for $url" >&2; return 1 ;;
+                      esac
+                  }
+                  upload_immutable report/index.html 'text/html; charset=utf-8' \
+                      "https://hostr.flingit.run/s/$REPORT_PATH/index.html"
+                  upload_immutable report/output.diff 'text/x-diff; charset=utf-8' \
+                      "https://hostr.flingit.run/s/$REPORT_PATH/output.diff"
+
+            - name: Check whether this is still the current PR head
+              if: steps.metadata.outputs.supported == 'true'
+              id: current
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  PR_NUMBER: ${{ steps.metadata.outputs.pr_number }}
+              run: |
+                  CURRENT_HEAD=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER" --jq .head.sha)
+                  if [[ "$CURRENT_HEAD" == "${{ steps.metadata.outputs.head_sha }}" ]]; then
+                      echo "is_current=true" >> "$GITHUB_OUTPUT"
+                  else
+                      echo "is_current=false" >> "$GITHUB_OUTPUT"
+                      echo "The PR advanced to $CURRENT_HEAD; leaving its current output-diff comment untouched." >> "$GITHUB_STEP_SUMMARY"
+                  fi
+
+            - name: Create or update output-diff comment
+              if: steps.metadata.outputs.has_differences == 'true' && steps.current.outputs.is_current == 'true'
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  PR_NUMBER: ${{ steps.metadata.outputs.pr_number }}
+                  REPORT_URL: https://hostr.flingit.run/s/quicktype/output-diffs/pr-${{ steps.metadata.outputs.pr_number }}/${{ steps.metadata.outputs.pr_sha }}/${{ steps.metadata.outputs.head_sha }}/index.html
+              run: |
+                  MARKER='<!-- quicktype-generated-output-diff -->'
+                  BODY=$(cat <<EOF
+                  $MARKER
+                  ### Generated-output differences
+
+                  **${{ steps.metadata.outputs.files }} files differ** — ${{ steps.metadata.outputs.modified }} modified, ${{ steps.metadata.outputs.new_files }} new, ${{ steps.metadata.outputs.deleted }} deleted  
+                  **${{ steps.metadata.outputs.changed_lines }} changed lines** — +${{ steps.metadata.outputs.insertions }} / −${{ steps.metadata.outputs.deletions }}
+
+                  [Open the generated-output report →]($REPORT_URL)
+                  EOF
+                  )
+                  COMMENT_ID=$(gh api --paginate --slurp "repos/${{ github.repository }}/issues/$PR_NUMBER/comments" \
+                      --jq 'map(.[]) | map(select(.body | contains("<!-- quicktype-generated-output-diff -->"))) | .[0].id // empty')
+                  if [[ -n "$COMMENT_ID" ]]; then
+                      gh api --method PATCH "repos/${{ github.repository }}/issues/comments/$COMMENT_ID" -f body="$BODY" >/dev/null
+                  else
+                      gh api --method POST "repos/${{ github.repository }}/issues/$PR_NUMBER/comments" -f body="$BODY" >/dev/null
+                  fi
+
+            - name: Remove stale comment for a clean comparison
+              if: steps.metadata.outputs.has_differences != 'true' && steps.metadata.outputs.supported == 'true' && steps.current.outputs.is_current == 'true'
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  PR_NUMBER: ${{ steps.metadata.outputs.pr_number }}
+              run: |
+                  gh api --paginate "repos/${{ github.repository }}/issues/$PR_NUMBER/comments" \
+                      --jq '.[] | select(.body | contains("<!-- quicktype-generated-output-diff -->")) | .id' |
+                  while read -r COMMENT_ID; do
+                      [[ -z "$COMMENT_ID" ]] || gh api --method DELETE "repos/${{ github.repository }}/issues/comments/$COMMENT_ID"
+                  done

--- a/OUTPUT-DIFFS.md
+++ b/OUTPUT-DIFFS.md
@@ -1,0 +1,119 @@
+# Generated-output diffs in CI
+
+## Goals
+
+For every pull request, compare quicktype's generated source at the exact PR base commit with the generated source at the PR head commit across all registered JSON, JSON Schema, and GraphQL input/target fixture combinations.
+
+Generated-output differences are informational: they must not fail CI. When differences exist, CI publishes a readable report and posts or updates one PR comment containing:
+
+- the number of files that differ;
+- the modified, new, and deleted file counts;
+- the total changed lines, with insertion and deletion counts; and
+- a link to the report.
+
+When there are no differences, no report is published and no output-diff comment remains on the PR.
+
+## Deterministic snapshots
+
+The fixture harness has a dedicated output-snapshot mode. It:
+
+- runs the full registered generation fixture set without `QUICKTEST`;
+- includes renderer-option variants;
+- skips compilation and round-trip execution;
+- records multi-file renderer output as well as each target's primary output; and
+- writes every case under a stable, collision-resistant path derived from the fixture, input path, and renderer options.
+
+A snapshot contains generated files only. Fixture drivers, copied inputs, tool output, timestamps, and absolute checkout paths are not included.
+
+Both revisions run with the same Node version, timezone, locale, and repository-relative inputs. CI compares the exact `pull_request.base.sha` and `pull_request.head.sha`, not the moving tip of `master`.
+
+## Base snapshot cache
+
+Base snapshots are cached by exact base commit SHA from the start.
+
+The output-diff workflow also runs on pushes to `master`. That job generates the new commit's snapshot and saves it in the default branch's GitHub Actions cache, where pull-request workflows can restore it. The key includes the operating system and exact commit SHA:
+
+```text
+quicktype-output-snapshot-v1-<os>-<base-sha>
+```
+
+Pull-request jobs restore only the exact key; there are no prefix restore keys. On a cache miss, the PR job generates the base snapshot and saves a PR-scoped cache, which at least benefits reruns of that PR. The push job is what makes the snapshot reusable by unrelated PRs, in accordance with GitHub Actions cache scoping.
+
+The head snapshot is always generated from the current PR head.
+
+## Comparison data
+
+A repository-owned TypeScript tool compares the two snapshot trees with rename detection disabled. A moved path is therefore represented as one deleted file and one new file.
+
+It emits machine-readable JSON plus a unified patch. Its summary contains:
+
+- total differing files;
+- modified files;
+- new files;
+- deleted files;
+- inserted lines;
+- deleted lines; and
+- total changed lines (`insertions + deletions`).
+
+A difference is a successful result. Snapshot-generation errors, malformed comparison data, and publication errors remain real CI failures.
+
+## Report
+
+The report is static, self-contained HTML with:
+
+- summary cards and base/head commit metadata;
+- a prominent link back to the pull request;
+- filtering by file status and text search;
+- navigation grouped by fixture/target;
+- collapsible, syntax-styled unified diffs; and
+- per-file insertion/deletion totals.
+
+Generated source and paths are always HTML-escaped. The page has a restrictive content-security policy and makes no third-party network requests.
+
+The unified patch is hosted next to the HTML report. Intermediate snapshots and comparison data use GitHub Actions artifacts/caches, not hostr.
+
+## Immutable hostr URLs
+
+Every report is immutable and is published under the path below. The publisher checks for an existing object and never overwrites it:
+
+```text
+quicktype/output-diffs/pr-<number>/<pr-sha>/<head-sha>/index.html
+```
+
+Here `pr-sha` is the pull-request workflow's tested merge SHA (`github.sha`) and `head-sha` is the contributor branch's exact head commit SHA. Including both distinguishes updates to the PR branch as well as a regenerated test merge after the base branch changes.
+
+The neighboring raw patch is:
+
+```text
+quicktype/output-diffs/pr-<number>/<pr-sha>/<head-sha>/output.diff
+```
+
+## Security and PR comments
+
+The workflow that executes PR code is unprivileged and never receives the hostr credential or a write-capable GitHub token. It uploads comparison data as a GitHub Actions artifact.
+
+A separate `workflow_run` workflow runs from the default branch. It:
+
+1. downloads the completed comparison artifact;
+2. validates the PR number and SHA fields;
+3. renders the final HTML using trusted code from the default branch;
+4. publishes the HTML and patch using the `HOSTR_TOKEN` repository secret; and
+5. creates or updates one marker-tagged PR comment with the summary and immutable link.
+
+Before changing a comment, it verifies that the artifact's head SHA is still the PR's current head. A stale completed run may retain its immutable report, but it cannot replace the current PR comment.
+
+For a current clean run, the publisher deletes any previous marker-tagged output-diff comment and publishes nothing.
+
+## Rollout and verification
+
+The implementation is verified with focused tests for:
+
+- stable snapshot paths and renderer-option collision resistance;
+- multi-file and overwritten output capture;
+- added, deleted, and modified files;
+- insertion/deletion/total-line statistics;
+- clean comparisons producing no HTML;
+- HTML escaping of generated paths and source; and
+- the PR backlink and report summary.
+
+The initial infrastructure PR cannot compare against a base that predates snapshot mode. It records an explicit unsupported/clean artifact instead of producing a misleading all-new report. Once merged, the push-to-`master` job creates the first shared base cache, and subsequent PRs exercise the complete flow.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
         "test:unit": "vitest run",
         "test:unit:watch": "vitest",
         "test:fixtures": "script/test",
+        "test:output-snapshot": "script/output-snapshot",
         "test:release": "tsx test/release-version.ts",
         "benchmark:markov-chain": "npm run build --workspace quicktype-core && node --expose-gc script/benchmark-markov-chain.mjs",
         "benchmark:markov-chain:fidelity": "npm run build --workspace quicktype-core && node script/benchmark-markov-fidelity.mjs",

--- a/script/output-diff.ts
+++ b/script/output-diff.ts
@@ -1,0 +1,414 @@
+#!/usr/bin/env tsx
+
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+type FileStatus = "added" | "deleted" | "modified";
+
+export interface OutputDiffFile {
+    additions: number;
+    deletions: number;
+    path: string;
+    status: FileStatus;
+}
+
+export interface OutputDiffResult {
+    files: OutputDiffFile[];
+    hasDifferences: boolean;
+    summary: {
+        added: number;
+        changedLines: number;
+        deleted: number;
+        deletions: number;
+        files: number;
+        insertions: number;
+        modified: number;
+    };
+    version: 1;
+}
+
+function filesBelow(root: string, current = root): string[] {
+    if (!fs.existsSync(current)) return [];
+    return fs.readdirSync(current, { withFileTypes: true }).flatMap((entry) => {
+        const fullPath = path.join(current, entry.name);
+        if (entry.isDirectory()) return filesBelow(root, fullPath);
+        return entry.isFile() ? [path.relative(root, fullPath)] : [];
+    });
+}
+
+function buffersEqual(left: string, right: string): boolean {
+    const leftStat = fs.statSync(left);
+    const rightStat = fs.statSync(right);
+    if (leftStat.size !== rightStat.size) return false;
+    return fs.readFileSync(left).equals(fs.readFileSync(right));
+}
+
+export function splitPatch(patch: string): string[] {
+    if (patch.length === 0) return [];
+    const starts: number[] = [];
+    const matcher = /^diff --git /gm;
+    for (
+        let match = matcher.exec(patch);
+        match !== null;
+        match = matcher.exec(patch)
+    ) {
+        starts.push(match.index);
+    }
+    return starts.map((start, index) =>
+        patch.slice(start, starts[index + 1] ?? patch.length).trimEnd(),
+    );
+}
+
+function lineCounts(patchSection: string): {
+    additions: number;
+    deletions: number;
+} {
+    let additions = 0;
+    let deletions = 0;
+    for (const line of patchSection.split("\n")) {
+        if (line.startsWith("+++") || line.startsWith("---")) continue;
+        if (line.startsWith("+")) additions++;
+        if (line.startsWith("-")) deletions++;
+    }
+    return { additions, deletions };
+}
+
+function generatePatch(baseDirectory: string, headDirectory: string): string {
+    const base = path.resolve(baseDirectory);
+    const head = path.resolve(headDirectory);
+    const sameParent = path.dirname(base) === path.dirname(head);
+    const cwd = sameParent ? path.dirname(base) : process.cwd();
+    const baseArgument = sameParent ? path.basename(base) : base;
+    const headArgument = sameParent ? path.basename(head) : head;
+    const diff = spawnSync(
+        "git",
+        [
+            "-c",
+            "core.quotePath=false",
+            "diff",
+            "--no-index",
+            "--no-renames",
+            "--text",
+            "--unified=3",
+            "--",
+            baseArgument,
+            headArgument,
+        ],
+        { cwd, encoding: "utf8", maxBuffer: 512 * 1024 * 1024 },
+    );
+    if (diff.status !== 0 && diff.status !== 1) {
+        throw new Error(
+            `git diff failed (${diff.status ?? "signal"}): ${diff.stderr}`,
+        );
+    }
+    return diff.stdout;
+}
+
+export function compareOutputSnapshots(
+    baseDirectory: string,
+    headDirectory: string,
+): { patch: string; result: OutputDiffResult } {
+    const baseFiles = new Set(filesBelow(baseDirectory));
+    const headFiles = new Set(filesBelow(headDirectory));
+    const allFiles = Array.from(new Set([...baseFiles, ...headFiles])).sort();
+    const changed = allFiles.flatMap((relativePath): OutputDiffFile[] => {
+        if (!baseFiles.has(relativePath)) {
+            return [
+                {
+                    additions: 0,
+                    deletions: 0,
+                    path: relativePath,
+                    status: "added",
+                },
+            ];
+        }
+        if (!headFiles.has(relativePath)) {
+            return [
+                {
+                    additions: 0,
+                    deletions: 0,
+                    path: relativePath,
+                    status: "deleted",
+                },
+            ];
+        }
+        if (
+            buffersEqual(
+                path.join(baseDirectory, relativePath),
+                path.join(headDirectory, relativePath),
+            )
+        ) {
+            return [];
+        }
+        return [
+            {
+                additions: 0,
+                deletions: 0,
+                path: relativePath,
+                status: "modified",
+            },
+        ];
+    });
+
+    const patch =
+        changed.length === 0 ? "" : generatePatch(baseDirectory, headDirectory);
+    const sections = splitPatch(patch);
+    if (sections.length !== changed.length) {
+        throw new Error(
+            `Expected ${changed.length} patch sections, found ${sections.length}`,
+        );
+    }
+    const files = changed.map((file, index) => ({
+        ...file,
+        ...lineCounts(sections[index]),
+    }));
+    const insertions = files.reduce((sum, file) => sum + file.additions, 0);
+    const deletions = files.reduce((sum, file) => sum + file.deletions, 0);
+    const result: OutputDiffResult = {
+        files,
+        hasDifferences: files.length > 0,
+        summary: {
+            added: files.filter(({ status }) => status === "added").length,
+            changedLines: insertions + deletions,
+            deleted: files.filter(({ status }) => status === "deleted").length,
+            deletions,
+            files: files.length,
+            insertions,
+            modified: files.filter(({ status }) => status === "modified")
+                .length,
+        },
+        version: 1,
+    };
+    return { patch, result };
+}
+
+function escapeHTML(value: string): string {
+    return value
+        .replaceAll("&", "&amp;")
+        .replaceAll("<", "&lt;")
+        .replaceAll(">", "&gt;")
+        .replaceAll('"', "&quot;")
+        .replaceAll("'", "&#39;");
+}
+
+function formatNumber(value: number): string {
+    return new Intl.NumberFormat("en-US").format(value);
+}
+
+function validateResult(value: unknown): asserts value is OutputDiffResult {
+    if (typeof value !== "object" || value === null)
+        throw new Error("Invalid diff result");
+    const result = value as Partial<OutputDiffResult>;
+    if (result.version !== 1 || !Array.isArray(result.files)) {
+        throw new Error("Unsupported diff result");
+    }
+    if (
+        typeof result.hasDifferences !== "boolean" ||
+        typeof result.summary !== "object" ||
+        result.summary === null
+    ) {
+        throw new Error("Invalid diff summary");
+    }
+    const summary = result.summary as Record<string, unknown>;
+    for (const key of [
+        "added",
+        "changedLines",
+        "deleted",
+        "deletions",
+        "files",
+        "insertions",
+        "modified",
+    ]) {
+        if (
+            !Number.isSafeInteger(summary[key]) ||
+            (summary[key] as number) < 0
+        ) {
+            throw new Error(`Invalid diff summary field: ${key}`);
+        }
+    }
+    for (const file of result.files) {
+        if (
+            typeof file.path !== "string" ||
+            !["added", "deleted", "modified"].includes(file.status) ||
+            !Number.isSafeInteger(file.additions) ||
+            file.additions < 0 ||
+            !Number.isSafeInteger(file.deletions) ||
+            file.deletions < 0
+        ) {
+            throw new Error("Invalid diff file entry");
+        }
+    }
+}
+
+function renderPatchLines(section: string): string {
+    return section
+        .split("\n")
+        .map((line) => {
+            const kind =
+                line.startsWith("diff --git") ||
+                line.startsWith("index ") ||
+                line.startsWith("+++") ||
+                line.startsWith("---")
+                    ? "meta"
+                    : line.startsWith("@@")
+                      ? "hunk"
+                      : line.startsWith("+")
+                        ? "addition"
+                        : line.startsWith("-")
+                          ? "deletion"
+                          : "context";
+            return `<span class="line ${kind}">${escapeHTML(line)}</span>`;
+        })
+        .join("\n");
+}
+
+export function renderOutputDiffReport(args: {
+    baseSha: string;
+    headSha: string;
+    patch: string;
+    prSha: string;
+    prUrl: string;
+    result: OutputDiffResult;
+}): string {
+    const { baseSha, headSha, patch, prSha, prUrl, result } = args;
+    validateResult(result);
+    if (!result.hasDifferences)
+        throw new Error("A clean comparison has no report");
+
+    const sections = splitPatch(patch);
+    if (sections.length !== result.files.length) {
+        throw new Error("Patch and result file counts differ");
+    }
+    const fixtures = Array.from(
+        new Set(result.files.map((file) => file.path.split(path.sep)[0])),
+    ).sort();
+    const fileHTML = result.files
+        .map((file, index) => {
+            const fixture = file.path.split(path.sep)[0];
+            const statusLetter =
+                file.status === "added"
+                    ? "A"
+                    : file.status === "deleted"
+                      ? "D"
+                      : "M";
+            return `<details class="file" data-path="${escapeHTML(file.path.toLowerCase())}" data-status="${file.status}" data-fixture="${escapeHTML(fixture)}" id="file-${index}">
+<summary><span class="status ${file.status}">${statusLetter}</span><span class="file-path">${escapeHTML(file.path)}</span><span class="counts"><b>+${formatNumber(file.additions)}</b> <i>−${formatNumber(file.deletions)}</i></span></summary>
+<pre>${renderPatchLines(sections[index])}</pre>
+</details>`;
+        })
+        .join("\n");
+    const fixtureOptions = fixtures
+        .map(
+            (fixture) =>
+                `<option value="${escapeHTML(fixture)}">${escapeHTML(fixture)}</option>`,
+        )
+        .join("");
+    const summary = result.summary;
+
+    return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; base-uri 'none'; form-action 'none'">
+<title>quicktype generated-output diff</title>
+<style>
+:root{color-scheme:light dark;--bg:#0d1117;--panel:#161b22;--border:#30363d;--text:#e6edf3;--muted:#8b949e;--green:#3fb950;--red:#f85149;--blue:#58a6ff;--purple:#bc8cff}*{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--text);font:14px/1.5 ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}a{color:var(--blue)}header,main{width:min(1500px,calc(100% - 32px));margin:auto}header{padding:34px 0 20px}h1{font-size:28px;margin:0 0 8px}.subtitle,.commits{color:var(--muted)}.pr-link{display:inline-block;margin-top:12px;font-weight:700}.cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));gap:12px;margin:24px 0}.card{background:var(--panel);border:1px solid var(--border);border-radius:10px;padding:16px}.card strong{display:block;font-size:24px}.card span{color:var(--muted)}.toolbar{position:sticky;top:0;z-index:2;display:flex;gap:10px;flex-wrap:wrap;padding:12px;background:rgba(13,17,23,.95);border:1px solid var(--border);border-radius:10px;margin-bottom:14px}input,select,button{background:var(--panel);border:1px solid var(--border);border-radius:6px;color:var(--text);padding:8px 10px}input{flex:1;min-width:240px}.file{border:1px solid var(--border);border-radius:8px;background:var(--panel);margin:10px 0;overflow:hidden}.file[hidden]{display:none}.file summary{cursor:pointer;display:flex;align-items:center;gap:10px;padding:11px 14px}.file-path{font-family:ui-monospace,SFMono-Regular,Consolas,monospace;overflow-wrap:anywhere}.counts{margin-left:auto;white-space:nowrap}.counts b{color:var(--green)}.counts i{color:var(--red);font-style:normal}.status{width:24px;height:24px;display:inline-grid;place-items:center;border-radius:5px;font-weight:800;color:#fff}.status.added{background:#238636}.status.deleted{background:#da3633}.status.modified{background:#8957e5}pre{margin:0;padding:12px 0;overflow:auto;border-top:1px solid var(--border);background:#010409;font:12px/1.45 ui-monospace,SFMono-Regular,Consolas,monospace}.line{display:block;white-space:pre;padding:0 14px;min-height:1.45em}.line.addition{background:rgba(46,160,67,.2);color:#aff5b4}.line.deletion{background:rgba(248,81,73,.2);color:#ffdcd7}.line.hunk{background:rgba(56,139,253,.15);color:#a5d6ff}.line.meta{color:var(--muted)}.empty{display:none;padding:40px;text-align:center;color:var(--muted)}footer{padding:30px 0 50px;color:var(--muted)}@media(prefers-color-scheme:light){:root{--bg:#fff;--panel:#f6f8fa;--border:#d0d7de;--text:#1f2328;--muted:#656d76;--green:#1a7f37;--red:#cf222e;--blue:#0969da}.toolbar{background:rgba(255,255,255,.95)}pre{background:#fff}.line.addition{color:#116329}.line.deletion{color:#82071e}}
+</style>
+</head>
+<body>
+<header>
+<h1>Generated-output differences</h1>
+<div class="subtitle">quicktype output changed between the PR base and head revisions.</div>
+<a class="pr-link" href="${escapeHTML(prUrl)}">← Back to the pull request</a>
+<div class="cards">
+<div class="card"><strong>${formatNumber(summary.files)}</strong><span>files differ</span></div>
+<div class="card"><strong>${formatNumber(summary.modified)}</strong><span>modified</span></div>
+<div class="card"><strong>${formatNumber(summary.added)}</strong><span>new</span></div>
+<div class="card"><strong>${formatNumber(summary.deleted)}</strong><span>deleted</span></div>
+<div class="card"><strong>${formatNumber(summary.changedLines)}</strong><span>changed lines</span></div>
+<div class="card"><strong><span style="color:var(--green)">+${formatNumber(summary.insertions)}</span> <span style="color:var(--red)">−${formatNumber(summary.deletions)}</span></strong><span>insertions / deletions</span></div>
+</div>
+<div class="commits">Base <code>${escapeHTML(baseSha)}</code> · PR merge <code>${escapeHTML(prSha)}</code> · Head <code>${escapeHTML(headSha)}</code> · <a href="output.diff">raw patch</a></div>
+</header>
+<main>
+<div class="toolbar">
+<input id="search" type="search" placeholder="Filter generated files…" aria-label="Filter generated files">
+<select id="fixture"><option value="">All targets</option>${fixtureOptions}</select>
+<select id="status"><option value="">All statuses</option><option value="modified">Modified</option><option value="added">New</option><option value="deleted">Deleted</option></select>
+<button id="expand" type="button">Expand visible</button>
+<button id="collapse" type="button">Collapse all</button>
+</div>
+<div id="files">${fileHTML}</div>
+<div class="empty" id="empty">No generated files match these filters.</div>
+<footer>Generated by quicktype CI. This report is immutable for the tested PR and head SHAs.</footer>
+</main>
+<script>
+const files=[...document.querySelectorAll('.file')],search=document.querySelector('#search'),fixture=document.querySelector('#fixture'),status=document.querySelector('#status'),empty=document.querySelector('#empty');function filter(){const q=search.value.trim().toLowerCase();let visible=0;for(const file of files){const show=(!q||file.dataset.path.includes(q))&&(!fixture.value||file.dataset.fixture===fixture.value)&&(!status.value||file.dataset.status===status.value);file.hidden=!show;if(show)visible++}empty.style.display=visible?'none':'block'}search.addEventListener('input',filter);fixture.addEventListener('change',filter);status.addEventListener('change',filter);document.querySelector('#expand').addEventListener('click',()=>files.forEach(file=>{if(!file.hidden)file.open=true}));document.querySelector('#collapse').addEventListener('click',()=>files.forEach(file=>file.open=false));
+</script>
+</body>
+</html>`;
+}
+
+function writeComparison(
+    base: string,
+    head: string,
+    resultPath: string,
+    patchPath: string,
+): void {
+    const { patch, result } = compareOutputSnapshots(base, head);
+    fs.mkdirSync(path.dirname(resultPath), { recursive: true });
+    fs.writeFileSync(resultPath, `${JSON.stringify(result, undefined, 2)}\n`);
+    fs.writeFileSync(patchPath, patch);
+}
+
+function renderFromFiles(
+    resultPath: string,
+    patchPath: string,
+    outputPath: string,
+    metadata: string[],
+): void {
+    const result: unknown = JSON.parse(fs.readFileSync(resultPath, "utf8"));
+    validateResult(result);
+    const [prUrl, baseSha, prSha, headSha] = metadata;
+    if ([prUrl, baseSha, prSha, headSha].some((value) => value === undefined)) {
+        throw new Error(
+            "render requires PR URL, base SHA, PR SHA, and head SHA",
+        );
+    }
+    const html = renderOutputDiffReport({
+        baseSha,
+        headSha,
+        patch: fs.readFileSync(patchPath, "utf8"),
+        prSha,
+        prUrl,
+        result,
+    });
+    fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+    fs.writeFileSync(outputPath, html);
+}
+
+function main(): void {
+    const [command, ...args] = process.argv.slice(2);
+    if (command === "compare" && args.length === 4) {
+        writeComparison(args[0], args[1], args[2], args[3]);
+        return;
+    }
+    if (command === "render" && args.length === 7) {
+        renderFromFiles(args[0], args[1], args[2], args.slice(3));
+        return;
+    }
+    throw new Error(
+        "Usage: output-diff.ts compare <base-dir> <head-dir> <result.json> <patch.diff> | render <result.json> <patch.diff> <index.html> <pr-url> <base-sha> <pr-sha> <head-sha>",
+    );
+}
+
+if (require.main === module) {
+    try {
+        main();
+    } catch (error) {
+        console.error(error instanceof Error ? error.message : error);
+        process.exitCode = 1;
+    }
+}

--- a/script/output-snapshot
+++ b/script/output-snapshot
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${OUTPUT_SNAPSHOT_DIR:?Set OUTPUT_SNAPSHOT_DIR to the snapshot destination}"
+
+export ALL_FIXTURES=1
+export ONLY_OUTPUT=1
+export FIXTURE="${FIXTURE:-json,schema,graphql,comment-injection}"
+
+exec "$(dirname "$0")/test" "$@"

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -40,12 +40,17 @@ import {
     defined,
 } from "../packages/quicktype-core/dist/support/Support";
 import { DefaultDateTimeRecognizer } from "../packages/quicktype-core/dist/DateTime";
+import { saveOutputSnapshot, snapshotFileState } from "./outputSnapshot";
 
 import chalk from "chalk";
 const timeout = require("promise-timeout").timeout;
 
 const OUTPUT_DIR = process.env.OUTPUT_DIR;
-const ONLY_OUTPUT = process.env.ONLY_OUTPUT !== undefined;
+const OUTPUT_SNAPSHOT_DIR = process.env.OUTPUT_SNAPSHOT_DIR;
+const ONLY_OUTPUT =
+    process.env.ONLY_OUTPUT !== undefined || OUTPUT_SNAPSHOT_DIR !== undefined;
+const INCLUDE_RENDERER_OPTION_SAMPLES =
+    !ONLY_OUTPUT || OUTPUT_SNAPSHOT_DIR !== undefined;
 
 const MAX_TEST_RUNTIME_MS = 30 * 60 * 1000;
 
@@ -279,6 +284,11 @@ abstract class LanguageFixture extends Fixture {
             shell.cp(sampleFile, cwd);
         }
 
+        const beforeGeneration =
+            OUTPUT_SNAPSHOT_DIR === undefined
+                ? undefined
+                : snapshotFileState(cwd);
+
         let numFiles = -1;
         await inDir(cwd, async () => {
             await this.runQuicktype(
@@ -304,13 +314,24 @@ abstract class LanguageFixture extends Fixture {
             }
         });
 
-        // FIXME: This is an ugly hack to exclude Java, which has multiple
-        // output files.  We have to support that eventually.
-        if (
+        if (OUTPUT_SNAPSHOT_DIR !== undefined) {
+            saveOutputSnapshot({
+                before: defined(beforeGeneration),
+                fixtureName: this.name,
+                primaryOutput: this.language.output,
+                rendererOptions: sample.additionalRendererOptions,
+                runDirectory: cwd,
+                samplePath: sample.path,
+                snapshotRoot: OUTPUT_SNAPSHOT_DIR,
+            });
+        } else if (
             sample.saveOutput &&
             OUTPUT_DIR !== undefined &&
             this.language.output.indexOf("/") < 0
         ) {
+            // Keep the legacy single-file output path for callers of
+            // OUTPUT_DIR.  Snapshot mode above also handles nested and
+            // multi-file renderer output.
             const outputDir = path.join(
                 OUTPUT_DIR,
                 this.language.name,
@@ -488,7 +509,7 @@ class JSONFixture extends LanguageFixture {
                 { prioritySamples },
             );
         }
-        if (sources.length === 0 && !ONLY_OUTPUT) {
+        if (sources.length === 0 && INCLUDE_RENDERER_OPTION_SAMPLES) {
             const quickTestSamples = _.chain(
                 this.language.quickTestRendererOptions,
             )
@@ -794,7 +815,7 @@ class JSONSchemaFixture extends LanguageFixture {
             "schema",
         );
 
-        if (sources.length === 0 && !ONLY_OUTPUT) {
+        if (sources.length === 0 && INCLUDE_RENDERER_OPTION_SAMPLES) {
             // Pinned-input quick-test entries that name a `.schema` file
             // run in this fixture with their renderer options.  Plain
             // renderer-option combinations and `.json` entries run in
@@ -1518,7 +1539,9 @@ class GraphQLFixture extends LanguageFixture {
 
     runForName(name: string): boolean {
         return (
-            this.name === name || (!this._onlyExactName && name === "graphql")
+            this.name === name ||
+            ((!this._onlyExactName || OUTPUT_SNAPSHOT_DIR !== undefined) &&
+                name === "graphql")
         );
     }
 
@@ -1661,7 +1684,7 @@ class CommandSuccessfulLanguageFixture extends LanguageFixture {
                 { prioritySamples },
             );
         }
-        if (sources.length === 0 && !ONLY_OUTPUT) {
+        if (sources.length === 0 && INCLUDE_RENDERER_OPTION_SAMPLES) {
             const quickTestSamples = _.chain(
                 this.language.quickTestRendererOptions,
             )

--- a/test/outputSnapshot.ts
+++ b/test/outputSnapshot.ts
@@ -1,0 +1,140 @@
+import { createHash } from "node:crypto";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import type { RendererOptions } from "quicktype-core";
+
+type FileState = {
+    mtimeMs: number;
+    size: number;
+};
+
+function filesBelow(root: string, current = root): string[] {
+    if (!fs.existsSync(current)) return [];
+
+    return fs.readdirSync(current, { withFileTypes: true }).flatMap((entry) => {
+        const fullPath = path.join(current, entry.name);
+        if (entry.isDirectory()) return filesBelow(root, fullPath);
+        if (!entry.isFile()) return [];
+        return [path.relative(root, fullPath)];
+    });
+}
+
+export function snapshotFileState(root: string): Map<string, FileState> {
+    return new Map(
+        filesBelow(root).map((relativePath) => {
+            const stat = fs.statSync(path.join(root, relativePath));
+            return [relativePath, { mtimeMs: stat.mtimeMs, size: stat.size }];
+        }),
+    );
+}
+
+function canonicalRendererOptions(options: RendererOptions): string {
+    return JSON.stringify(
+        Object.entries(options).sort(([left], [right]) =>
+            left.localeCompare(right),
+        ),
+    );
+}
+
+export function rendererOptionsID(options: RendererOptions): string {
+    const canonical = canonicalRendererOptions(options);
+    if (canonical === "[]") return "default";
+
+    const readable = Object.entries(options)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, value]) => `${key}-${String(value)}`)
+        .join("__")
+        .replace(/[^A-Za-z0-9_.-]+/g, "-")
+        .replace(/^-+|-+$/g, "")
+        .slice(0, 80);
+    const hash = createHash("sha256")
+        .update(canonical)
+        .digest("hex")
+        .slice(0, 12);
+    return `${readable || "options"}--${hash}`;
+}
+
+function safeRelativePath(relativePath: string): string {
+    const normalized = path.normalize(relativePath);
+    if (
+        path.isAbsolute(normalized) ||
+        normalized === ".." ||
+        normalized.startsWith(`..${path.sep}`)
+    ) {
+        throw new Error(
+            `Output snapshot path escapes its root: ${relativePath}`,
+        );
+    }
+    return normalized;
+}
+
+export function outputSnapshotCaseDirectory(
+    snapshotRoot: string,
+    fixtureName: string,
+    samplePath: string,
+    rendererOptions: RendererOptions,
+): string {
+    const repositoryRelativeSample = safeRelativePath(
+        path.relative(process.cwd(), path.resolve(samplePath)),
+    );
+    return path.join(
+        snapshotRoot,
+        fixtureName.replace(/[^A-Za-z0-9_.-]+/g, "-"),
+        repositoryRelativeSample,
+        rendererOptionsID(rendererOptions),
+    );
+}
+
+export function saveOutputSnapshot(args: {
+    before: Map<string, FileState>;
+    fixtureName: string;
+    primaryOutput: string;
+    rendererOptions: RendererOptions;
+    runDirectory: string;
+    samplePath: string;
+    snapshotRoot: string;
+}): string[] {
+    const {
+        before,
+        fixtureName,
+        primaryOutput,
+        rendererOptions,
+        runDirectory,
+        samplePath,
+        snapshotRoot,
+    } = args;
+    const after = snapshotFileState(runDirectory);
+    const generated = new Set<string>();
+
+    for (const [relativePath, state] of after) {
+        const oldState = before.get(relativePath);
+        if (
+            oldState === undefined ||
+            oldState.size !== state.size ||
+            oldState.mtimeMs !== state.mtimeMs
+        ) {
+            generated.add(relativePath);
+        }
+    }
+
+    const safePrimaryOutput = safeRelativePath(primaryOutput);
+    if (fs.existsSync(path.join(runDirectory, safePrimaryOutput))) {
+        generated.add(safePrimaryOutput);
+    }
+
+    const caseDirectory = outputSnapshotCaseDirectory(
+        snapshotRoot,
+        fixtureName,
+        samplePath,
+        rendererOptions,
+    );
+    const saved = Array.from(generated).sort();
+    for (const relativePath of saved) {
+        const safePath = safeRelativePath(relativePath);
+        const destination = path.join(caseDirectory, safePath);
+        fs.mkdirSync(path.dirname(destination), { recursive: true });
+        fs.copyFileSync(path.join(runDirectory, safePath), destination);
+    }
+    return saved;
+}

--- a/test/test.ts
+++ b/test/test.ts
@@ -16,7 +16,10 @@ const CPUs = Number.parseInt(process.env.CPUs || "0", 10) || os.cpus().length;
 export type WorkItem = { sample: Sample; fixtureName: string };
 
 async function main(sources: string[]) {
-    let fixtures = affectedFixtures();
+    let fixtures =
+        process.env.ALL_FIXTURES === undefined
+            ? affectedFixtures()
+            : allFixtures;
     const fixturesFromCmdline = process.env.FIXTURE;
     if (fixturesFromCmdline) {
         const fixtureNames = fixturesFromCmdline.split(",");

--- a/test/unit/output-diff.test.ts
+++ b/test/unit/output-diff.test.ts
@@ -1,0 +1,183 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+
+import {
+    compareOutputSnapshots,
+    renderOutputDiffReport,
+} from "../../script/output-diff";
+import {
+    outputSnapshotCaseDirectory,
+    rendererOptionsID,
+    saveOutputSnapshot,
+    snapshotFileState,
+} from "../outputSnapshot";
+
+const temporaryDirectories: string[] = [];
+
+function temporaryDirectory(): string {
+    const directory = fs.mkdtempSync(
+        path.join(os.tmpdir(), "quicktype-output-diff-"),
+    );
+    temporaryDirectories.push(directory);
+    return directory;
+}
+
+afterEach(() => {
+    for (const directory of temporaryDirectories.splice(0)) {
+        fs.rmSync(directory, { force: true, recursive: true });
+    }
+});
+
+describe("output snapshots", () => {
+    test("uses stable option IDs regardless of key order", () => {
+        expect(rendererOptionsID({ b: "two", a: "one" })).toBe(
+            rendererOptionsID({ a: "one", b: "two" }),
+        );
+        expect(rendererOptionsID({})).toBe("default");
+        expect(rendererOptionsID({ a: "one" })).not.toBe(
+            rendererOptionsID({ a: "two" }),
+        );
+    });
+
+    test("captures primary and additional generated files without fixture files", () => {
+        const root = temporaryDirectory();
+        const runDirectory = path.join(root, "run");
+        const snapshotRoot = path.join(root, "snapshot");
+        fs.mkdirSync(path.join(runDirectory, "support"), { recursive: true });
+        fs.writeFileSync(path.join(runDirectory, "driver.txt"), "unchanged");
+        fs.writeFileSync(path.join(runDirectory, "TopLevel.h"), "old output");
+        const before = snapshotFileState(runDirectory);
+
+        fs.writeFileSync(path.join(runDirectory, "TopLevel.h"), "new output");
+        fs.writeFileSync(path.join(runDirectory, "TopLevel.c"), "extra output");
+        const saved = saveOutputSnapshot({
+            before,
+            fixtureName: "cjson-multi-split",
+            primaryOutput: "TopLevel.h",
+            rendererOptions: { "source-style": "multi-source" },
+            runDirectory,
+            samplePath: "test/inputs/json/priority/combinations1.json",
+            snapshotRoot,
+        });
+
+        expect(saved).toEqual(["TopLevel.c", "TopLevel.h"]);
+        const caseDirectory = outputSnapshotCaseDirectory(
+            snapshotRoot,
+            "cjson-multi-split",
+            "test/inputs/json/priority/combinations1.json",
+            { "source-style": "multi-source" },
+        );
+        expect(
+            fs.readFileSync(path.join(caseDirectory, "TopLevel.h"), "utf8"),
+        ).toBe("new output");
+        expect(fs.existsSync(path.join(caseDirectory, "driver.txt"))).toBe(
+            false,
+        );
+    });
+});
+
+describe("generated-output comparison", () => {
+    test("summarizes modified, new, and deleted files and changed lines", () => {
+        const root = temporaryDirectory();
+        const base = path.join(root, "base");
+        const head = path.join(root, "head");
+        fs.mkdirSync(base);
+        fs.mkdirSync(head);
+        fs.writeFileSync(path.join(base, "modified.ts"), "one\ntwo\n");
+        fs.writeFileSync(path.join(head, "modified.ts"), "one\nthree\n");
+        fs.writeFileSync(path.join(base, "deleted.ts"), "gone\n");
+        fs.writeFileSync(path.join(head, "added.ts"), "new\nlines\n");
+        fs.writeFileSync(path.join(base, "same.ts"), "same\n");
+        fs.writeFileSync(path.join(head, "same.ts"), "same\n");
+
+        const { patch, result } = compareOutputSnapshots(base, head);
+
+        expect(result.summary).toEqual({
+            added: 1,
+            changedLines: 5,
+            deleted: 1,
+            deletions: 2,
+            files: 3,
+            insertions: 3,
+            modified: 1,
+        });
+        expect(result.files).toEqual([
+            {
+                additions: 2,
+                deletions: 0,
+                path: "added.ts",
+                status: "added",
+            },
+            {
+                additions: 0,
+                deletions: 1,
+                path: "deleted.ts",
+                status: "deleted",
+            },
+            {
+                additions: 1,
+                deletions: 1,
+                path: "modified.ts",
+                status: "modified",
+            },
+        ]);
+        expect(patch).toContain("+three");
+    });
+
+    test("a clean comparison has no patch or report", () => {
+        const root = temporaryDirectory();
+        const base = path.join(root, "base");
+        const head = path.join(root, "head");
+        fs.mkdirSync(base);
+        fs.mkdirSync(head);
+        fs.writeFileSync(path.join(base, "same.ts"), "same\n");
+        fs.writeFileSync(path.join(head, "same.ts"), "same\n");
+
+        const { patch, result } = compareOutputSnapshots(base, head);
+
+        expect(result.hasDifferences).toBe(false);
+        expect(patch).toBe("");
+        expect(() =>
+            renderOutputDiffReport({
+                baseSha: "base",
+                headSha: "head",
+                patch,
+                prSha: "merge",
+                prUrl: "https://github.com/glideapps/quicktype/pull/1",
+                result,
+            }),
+        ).toThrow("no report");
+    });
+
+    test("renders escaped output and a pull-request backlink", () => {
+        const root = temporaryDirectory();
+        const base = path.join(root, "base");
+        const head = path.join(root, "head");
+        fs.mkdirSync(base);
+        fs.mkdirSync(head);
+        fs.writeFileSync(path.join(base, "unsafe.ts"), "safe\n");
+        fs.writeFileSync(
+            path.join(head, "unsafe.ts"),
+            "<script>alert(1)</script>\n",
+        );
+        const { patch, result } = compareOutputSnapshots(base, head);
+
+        const html = renderOutputDiffReport({
+            baseSha: "base-sha",
+            headSha: "head-sha",
+            patch,
+            prSha: "pr-sha",
+            prUrl: "https://github.com/glideapps/quicktype/pull/123",
+            result,
+        });
+
+        expect(html).toContain("Back to the pull request");
+        expect(html).toContain(
+            "https://github.com/glideapps/quicktype/pull/123",
+        );
+        expect(html).toContain("&lt;script&gt;alert(1)&lt;/script&gt;");
+        expect(html).not.toContain("<script>alert(1)</script>");
+    });
+});


### PR DESCRIPTION
## Summary

- snapshot every registered generated-output fixture for the exact PR base and head
- cache base snapshots by exact base SHA, seeded by pushes to `master`
- generate a searchable HTML diff report without failing CI on output changes
- securely publish immutable reports through hostr and post/update a summary PR comment

## Report behavior

Reports use:

```
quicktype/output-diffs/pr-<number>/<pr-sha>/<head-sha>/index.html
```

They include a link back to the PR and counts for modified/new/deleted files and changed lines. Clean comparisons publish no report and remove an earlier output-diff comment.

The unprivileged PR workflow never receives publishing credentials. A trusted `workflow_run` workflow renders, publishes, and comments.

## Bootstrap

This PR's base predates snapshot support, so its generated-output comparison intentionally records a bootstrap skip. Once merged, the `master` push job seeds the first exact-SHA base cache; subsequent PRs exercise the complete comparison and report flow.

## Verification

- `npm run build`
- `npm run lint`
- `npm run test:unit` (213 tests)
- focused TypeScript, Java nested-output, and CJSON multi-file snapshots
- local compare and HTML rendering
