### PR TITLE
Fix output-diff PR comment pagination

### DIFF
--- a/.github/workflows/publish-output-diffs.yaml
+++ b/.github/workflows/publish-output-diffs.yaml
@@ -158,8 +158,8 @@ jobs:
                   [Open the generated-output report →]($REPORT_URL)
                   EOF
                   )
-                  COMMENT_ID=$(gh api --paginate --slurp "repos/${{ github.repository }}/issues/$PR_NUMBER/comments" \
-                      --jq 'map(.[]) | map(select(.body | contains("<!-- quicktype-generated-output-diff -->"))) | .[0].id // empty')
+                  COMMENT_ID=$(gh api --paginate "repos/${{ github.repository }}/issues/$PR_NUMBER/comments" \
+                      --jq '.[] | select(.body | contains("<!-- quicktype-generated-output-diff -->")) | .id' | sed -n '1p')
                   if [[ -n "$COMMENT_ID" ]]; then
                       gh api --method PATCH "repos/${{ github.repository }}/issues/comments/$COMMENT_ID" -f body="$BODY" >/dev/null
                   else


### PR DESCRIPTION
The first live output-diff report rendered and published successfully, but the PR comment step failed because the runner's `gh` version rejects `--slurp` together with `--jq`.

Use the supported paginated `--jq` stream and consume it with `sed`, which avoids both the unsupported flag combination and a `head`/SIGPIPE failure.

Live report from the test run:
https://hostr.flingit.run/s/quicktype/output-diffs/pr-3074/70972f22026a6953afd3819940e9d92fca91f921/8f183049a0e4f42659a6fe942fdc2183a2fe16ab/index.html
