### PR TITLE
Fix premature generated-output report comments

### DIFF
--- a/.github/workflows/output-diffs.yaml
+++ b/.github/workflows/output-diffs.yaml
@@ -50,9 +50,6 @@ jobs:
         name: Compare generated output
         if: github.event_name == 'pull_request'
         runs-on: ubuntu-22.04
-        permissions:
-            contents: read
-            pull-requests: write
         steps:
             - name: Restore exact base snapshot
               id: base-cache
@@ -189,34 +186,3 @@ jobs:
                   path: .output-diffs/result
                   if-no-files-found: error
                   retention-days: 14
-
-            # A workflow_run workflow always uses its definition from the
-            # default branch.  Keep this same-repository path while #3074
-            # demonstrates the publisher fix before it reaches master.
-            - name: Preview output-diff comment on same-repository PRs
-              if: github.event.pull_request.head.repo.full_name == github.repository
-              env:
-                  GH_TOKEN: ${{ github.token }}
-                  PR_NUMBER: ${{ github.event.pull_request.number }}
-                  REPORT_URL: https://hostr.flingit.run/s/quicktype/output-diffs/pr-${{ github.event.pull_request.number }}/${{ github.sha }}/${{ github.event.pull_request.head.sha }}/index.html
-              run: |
-                  COMMENT_ID=$(gh api --paginate "repos/${{ github.repository }}/issues/$PR_NUMBER/comments" \
-                      --jq '.[] | select(.body | contains("<!-- quicktype-generated-output-diff -->") or contains("<!-- quicktype-generated-output-diff-preview -->")) | .id' | sed -n '1p')
-                  node - <<'NODE' > /tmp/output-diff-comment
-                  const fs = require("node:fs");
-                  const result = JSON.parse(fs.readFileSync(".output-diffs/result/result.json", "utf8"));
-                  if (result.hasDifferences) {
-                      const s = result.summary;
-                      process.stdout.write(`<!-- quicktype-generated-output-diff -->\n### Generated-output differences\n\n**${s.files} files differ** — ${s.modified} modified, ${s.added} new, ${s.deleted} deleted  \n**${s.changedLines} changed lines** — +${s.insertions} / −${s.deletions}\n\n[Open the generated-output report →](${process.env.REPORT_URL})\n`);
-                  } else {
-                      // The preview marker keeps the default-branch version of
-                      // the publisher from deleting this comment before the
-                      // clean-comment behavior in this PR is merged.
-                      process.stdout.write("<!-- quicktype-generated-output-diff-preview -->\n### No generated-output differences\n\n✅ Generated outputs are unchanged between the PR base and head revisions.\n");
-                  }
-                  NODE
-                  if [[ -n "$COMMENT_ID" ]]; then
-                      gh api --method PATCH "repos/${{ github.repository }}/issues/comments/$COMMENT_ID" -F body=@/tmp/output-diff-comment >/dev/null
-                  else
-                      gh api --method POST "repos/${{ github.repository }}/issues/$PR_NUMBER/comments" -F body=@/tmp/output-diff-comment >/dev/null
-                  fi


### PR DESCRIPTION
## Problem

The demo-only same-repository commenter from #3074 was accidentally merged. It posted the deterministic report link as soon as the comparison artifact was uploaded, before the trusted publisher had rendered and uploaded the report. The link therefore returned no report for roughly 30 seconds.

## Fix

Remove the demo-only commenter and its write permission. The trusted `workflow_run` publisher already uploads the report before creating or updating the PR comment, so every newly posted link is live.

The report linked from #2997 is available now and contains all 34 generated files.
