### PR TITLE
Fix generated-output comparisons and fork comments

### DIFF
--- a/.github/workflows/output-diffs.yaml
+++ b/.github/workflows/output-diffs.yaml
@@ -58,11 +58,10 @@ jobs:
                   path: .output-diffs/base
                   key: ${{ env.OUTPUT_SNAPSHOT_CACHE_PREFIX }}-${{ runner.os }}-${{ github.event.pull_request.base.sha }}
 
-            - name: Check out PR head
+            - name: Check out tested PR merge
               uses: actions/checkout@v4
               with:
-                  repository: ${{ github.event.pull_request.head.repo.full_name }}
-                  ref: ${{ github.event.pull_request.head.sha }}
+                  ref: ${{ github.sha }}
                   path: head-source
 
             - name: Check out base after a cache miss
@@ -115,12 +114,12 @@ jobs:
                   path: .output-diffs/base
                   key: ${{ env.OUTPUT_SNAPSHOT_CACHE_PREFIX }}-${{ runner.os }}-${{ github.event.pull_request.base.sha }}
 
-            - name: Build PR head
+            - name: Build tested PR merge
               if: steps.compatibility.outputs.supported == 'true'
               working-directory: head-source
               run: npm ci && npm run build
 
-            - name: Generate PR head snapshot
+            - name: Generate tested PR merge snapshot
               if: steps.compatibility.outputs.supported == 'true'
               working-directory: head-source
               env:

--- a/.github/workflows/publish-output-diffs.yaml
+++ b/.github/workflows/publish-output-diffs.yaml
@@ -35,16 +35,26 @@ jobs:
             - name: Validate metadata and result
               id: metadata
               env:
+                  DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+                  EVENT_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+                  EVENT_HEAD_REPOSITORY: ${{ github.event.workflow_run.head_repository.full_name }}
+                  EVENT_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
                   EVENT_PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+                  GH_TOKEN: ${{ github.token }}
                   REPOSITORY: ${{ github.repository }}
               run: |
+                  PR_NUMBER=$(node -e 'const m = require("./comparison/metadata.json"); if (!Number.isSafeInteger(m.prNumber) || m.prNumber <= 0) process.exit(1); process.stdout.write(String(m.prNumber))')
+                  gh api "repos/$REPOSITORY/pulls/$PR_NUMBER" > /tmp/pull-request.json
                   node - <<'NODE'
                   const fs = require("node:fs");
                   const metadata = JSON.parse(fs.readFileSync("comparison/metadata.json", "utf8"));
                   const result = JSON.parse(fs.readFileSync("comparison/result.json", "utf8"));
+                  const pullRequest = JSON.parse(fs.readFileSync("/tmp/pull-request.json", "utf8"));
                   const sha = /^[0-9a-f]{40,64}$/;
                   if (!Number.isSafeInteger(metadata.prNumber) || metadata.prNumber <= 0) throw new Error("Invalid PR number");
-                  if (String(metadata.prNumber) !== process.env.EVENT_PR_NUMBER) throw new Error("Artifact PR does not match workflow event");
+                  if (process.env.EVENT_PR_NUMBER !== "" && String(metadata.prNumber) !== process.env.EVENT_PR_NUMBER) throw new Error("Artifact PR does not match workflow event");
+                  if (metadata.headSha !== process.env.EVENT_HEAD_SHA) throw new Error("Artifact head does not match workflow event");
+                  if (pullRequest.number !== metadata.prNumber || pullRequest.base.repo.full_name.toLowerCase() !== process.env.REPOSITORY.toLowerCase() || pullRequest.base.ref !== process.env.DEFAULT_BRANCH || pullRequest.head.repo.full_name.toLowerCase() !== process.env.EVENT_HEAD_REPOSITORY.toLowerCase() || pullRequest.head.ref !== process.env.EVENT_HEAD_BRANCH) throw new Error("Artifact PR does not match workflow source");
                   for (const key of ["baseSha", "prSha", "headSha"]) {
                       if (!sha.test(metadata[key])) throw new Error(`Invalid ${key}`);
                   }

--- a/.github/workflows/publish-output-diffs.yaml
+++ b/.github/workflows/publish-output-diffs.yaml
@@ -175,7 +175,7 @@ jobs:
                   $MARKER
                   ### No generated-output differences
 
-                  ✅ Generated outputs are unchanged between the PR base and head revisions.
+                  ✅ This PR does not change generated outputs.
                   EOF
                       )
                   fi

--- a/OUTPUT-DIFFS.md
+++ b/OUTPUT-DIFFS.md
@@ -2,7 +2,7 @@
 
 ## Goals
 
-For every pull request, compare quicktype's generated source at the exact PR base commit with the generated source at the PR head commit across all registered JSON, JSON Schema, and GraphQL input/target fixture combinations.
+For every pull request, compare quicktype's generated source at the exact PR base commit with the generated source at GitHub's tested PR merge commit across all registered JSON, JSON Schema, and GraphQL input/target fixture combinations.
 
 Generated-output differences are informational: they must not fail CI. When differences exist, CI publishes a readable report and posts or updates one PR comment containing:
 
@@ -25,7 +25,7 @@ The fixture harness has a dedicated output-snapshot mode. It:
 
 A snapshot contains generated files only. Fixture drivers, copied inputs, tool output, timestamps, and absolute checkout paths are not included.
 
-Both revisions run with the same Node version, timezone, locale, and repository-relative inputs. CI compares the exact `pull_request.base.sha` and `pull_request.head.sha`, not the moving tip of `master`.
+Both revisions run with the same Node version, timezone, locale, and repository-relative inputs. CI compares the exact `pull_request.base.sha` with the exact tested merge at `github.sha`, not the contributor branch tip in isolation. This matches GitHub's PR diff semantics and prevents changes added to the base branch after the PR forked from appearing as deletions.
 
 ## Base snapshot cache
 
@@ -39,7 +39,7 @@ quicktype-output-snapshot-v1-<os>-<base-sha>
 
 Pull-request jobs restore only the exact key; there are no prefix restore keys. On a cache miss, the PR job generates the base snapshot and saves a PR-scoped cache, which at least benefits reruns of that PR. The push job is what makes the snapshot reusable by unrelated PRs, in accordance with GitHub Actions cache scoping.
 
-The head snapshot is always generated from the current PR head.
+The comparison snapshot is always generated from GitHub's current tested PR merge commit. The contributor branch's exact head SHA is still recorded for identity, stale-run protection, and immutable report URLs.
 
 ## Comparison data
 
@@ -61,7 +61,7 @@ A difference is a successful result. Snapshot-generation errors, malformed compa
 
 The report is static, self-contained HTML with:
 
-- summary cards and base/head commit metadata;
+- summary cards and base/merge/head commit metadata;
 - a prominent link back to the pull request;
 - filtering by file status and text search;
 - navigation grouped by fixture/target;

--- a/script/output-diff.ts
+++ b/script/output-diff.ts
@@ -423,7 +423,7 @@ footer { padding: 30px 0 50px; color: var(--muted) }
 <body>
 <header>
 <h1>Generated-output differences</h1>
-<div class="subtitle">quicktype output changed between the PR base and head revisions.</div>
+<div class="subtitle">quicktype output changed between the PR base and tested PR merge revisions.</div>
 <a class="pr-link" href="${escapeHTML(prUrl)}">← Back to the pull request</a>
 <div class="cards">
 <div class="card"><strong>${formatNumber(summary.files)}</strong><span>files differ</span></div>

--- a/test/unit/output-diff.test.ts
+++ b/test/unit/output-diff.test.ts
@@ -174,6 +174,7 @@ describe("generated-output comparison", () => {
         });
 
         expect(html).toContain("Back to the pull request");
+        expect(html).toContain("base and tested PR merge revisions");
         expect(html).toContain(
             "https://github.com/glideapps/quicktype/pull/123",
         );


### PR DESCRIPTION
## Problems

1. The snapshot job compared the current base tip against the contributor branch tip. When `master` advanced after a branch forked, unrelated base changes appeared as modified/deleted generated files. PR #3077 incorrectly reported 67 differences for this reason.
2. `workflow_run.pull_requests` is empty for fork pull requests, so the trusted publisher rejected #3071's comparison artifact and never commented.

## Fix

- Compare the exact base snapshot against GitHub's tested PR merge commit (`github.sha`). This mirrors GitHub's PR diff semantics and isolates changes introduced by the PR.
- Resolve the artifact's PR through the GitHub API and validate its base repository/branch and head repository/branch/SHA against trusted `workflow_run` data.

## Verification

- The first #3077 run reproduced the bug: 27 modified and 40 deleted files.
- After switching to the tested merge commit, the same PR produced 0 changed files and updated its sticky comment to **No generated-output differences**.
- Fork validation was exercised against #3071 metadata and same-repository validation against #2997 metadata.
- Lint, workflow YAML parsing, and focused output-diff unit tests pass.