### PR TITLE
fix(scala3): legalize JSON property names

### DIFF
--- a/packages/quicktype-core/src/language/Scala3/CirceRenderer.ts
+++ b/packages/quicktype-core/src/language/Scala3/CirceRenderer.ts
@@ -14,7 +14,7 @@ import type {
     UnionType,
 } from "../../Type/index.js";
 
-import { stringEscape } from "../../support/Strings.js";
+import { utf16StringEscape as stringEscape } from "../../support/Strings.js";
 
 import { Scala3Renderer } from "./Scala3Renderer.js";
 import { unionMemberSortOrder, wrapOption } from "./utils.js";
@@ -106,7 +106,49 @@ export class CirceRenderer extends Scala3Renderer {
     }
 
     protected emitClassDefinitionMethods(): void {
-        this.emitLine(") derives Encoder.AsObject, Decoder");
+        this.emitLine(")");
+    }
+
+    protected emitClassDefinitionPostamble(
+        c: ClassType,
+        className: Name,
+    ): void {
+        this.ensureBlankLine();
+        this.emitLine(["object ", className, ":"]);
+        this.indent(() => {
+            this.emitLine("given io.circe.derivation.Configuration =");
+            this.indent(() => {
+                this.emitLine(
+                    "io.circe.derivation.Configuration.default.withTransformMemberNames(",
+                );
+                this.indent(() => {
+                    this.emitLine("io.circe.derivation.renaming.replaceWith(");
+                    this.indent(() => {
+                        let count = c.getProperties().size;
+                        this.forEachClassProperty(
+                            c,
+                            "none",
+                            (name, jsonName) => {
+                                this.emitLine([
+                                    '"',
+                                    name,
+                                    `" -> "${stringEscape(jsonName)}"`,
+                                    --count === 0 ? "" : ",",
+                                ]);
+                            },
+                        );
+                    });
+                    this.emitLine(")");
+                });
+                this.emitLine(")");
+            });
+            this.emitLine([
+                "given io.circe.Codec.AsObject[",
+                className,
+                "] = io.circe.derivation.ConfiguredCodec.derived",
+            ]);
+        });
+        this.ensureBlankLine();
     }
 
     protected emitEnumDefinition(e: EnumType, enumName: Name): void {

--- a/packages/quicktype-core/src/language/Scala3/Scala3Renderer.ts
+++ b/packages/quicktype-core/src/language/Scala3/Scala3Renderer.ts
@@ -27,10 +27,9 @@ import {
     type UnionType,
 } from "../../Type/index.js";
 
-import { keywords } from "./constants.js";
+import { forbiddenPropertyNames, keywords } from "./constants.js";
 import type { scala3Options } from "./language.js";
 import {
-    backtickedName,
     enumCaseNameStyle,
     lowerNamingFunction,
     scalaNameStyle,
@@ -55,7 +54,10 @@ export class Scala3Renderer extends ConvenienceRenderer {
         _: ObjectType,
         _classNamed: Name,
     ): ForbiddenWordsInfo {
-        return { names: [], includeGlobalForbidden: true };
+        return {
+            names: [...forbiddenPropertyNames],
+            includeGlobalForbidden: true,
+        };
     }
 
     protected forbiddenForEnumCases(
@@ -219,6 +221,17 @@ export class Scala3Renderer extends ConvenienceRenderer {
         this.emitLine("case class ", className, "()");
     }
 
+    protected emitPropertyAnnotation(_name: Name, _jsonName: string): void {
+        // Overridden by frameworks that support property rename annotations.
+    }
+
+    protected emitClassDefinitionPostamble(
+        _c: ClassType,
+        _className: Name,
+    ): void {
+        // Overridden by frameworks that need to emit custom codecs.
+    }
+
     protected emitClassDefinition(c: ClassType, className: Name): void {
         if (c.getProperties().size === 0) {
             this.emitEmptyClassDefinition(c, className);
@@ -238,7 +251,7 @@ export class Scala3Renderer extends ConvenienceRenderer {
         this.indent(() => {
             let count = c.getProperties().size;
             let first = true;
-            this.forEachClassProperty(c, "none", (_, jsonName, p) => {
+            this.forEachClassProperty(c, "none", (name, jsonName, p) => {
                 const nullable =
                     p.type.kind === "union" &&
                     nullableFromUnion(p.type as UnionType) !== null;
@@ -263,9 +276,10 @@ export class Scala3Renderer extends ConvenienceRenderer {
                     emit();
                 }
 
+                this.emitPropertyAnnotation(name, jsonName);
                 this.emitLine(
                     "val ",
-                    backtickedName(jsonName),
+                    name,
                     " : ",
                     scalaType(p),
                     p.isOptional
@@ -285,6 +299,7 @@ export class Scala3Renderer extends ConvenienceRenderer {
         });
 
         this.emitClassDefinitionMethods();
+        this.emitClassDefinitionPostamble(c, className);
     }
 
     protected emitClassDefinitionMethods(): void {

--- a/packages/quicktype-core/src/language/Scala3/UpickleRenderer.ts
+++ b/packages/quicktype-core/src/language/Scala3/UpickleRenderer.ts
@@ -2,7 +2,7 @@ import type { Name } from "../../Naming.js";
 import type { Sourcelike } from "../../Source.js";
 import { removeNullFromUnion } from "../../Type/TypeUtils.js";
 import type { ClassType, EnumType, Type, UnionType } from "../../Type/index.js";
-import { stringEscape } from "../../support/Strings.js";
+import { utf16StringEscape as stringEscape } from "../../support/Strings.js";
 
 import { Scala3Renderer } from "./Scala3Renderer.js";
 import { unionMemberSortOrder, wrapOption } from "./utils.js";
@@ -12,6 +12,10 @@ export class UpickleRenderer extends Scala3Renderer {
 
     protected emitClassDefinitionMethods(): void {
         this.emitLine(") derives OptionPickler.ReadWriter");
+    }
+
+    protected emitPropertyAnnotation(_name: Name, jsonName: string): void {
+        this.emitLine(`@upickle.implicits.key("${stringEscape(jsonName)}")`);
     }
 
     protected anySourceType(optional: boolean): Sourcelike {
@@ -71,7 +75,7 @@ object JsonExt:
     }
 
     def badMerge[T](r1: => OptionPickler.Reader[?], rest: OptionPickler.Reader[?]*): OptionPickler.Reader[T] = valueReader.map { json =>
-        var t: T | Null = null
+        var t: T | scala.Null = null
         val stack       = Vector.newBuilder[Throwable]
         (r1 +: rest).foreach { reader =>
             if t == null then
@@ -80,7 +84,7 @@ object JsonExt:
             catch
                 case exc => stack += exc
         }
-        if t != null then t.nn else throw new Exception(json.toString(), stack.result().headOption.getOrElse(null))
+        if t != null then t.nn else throw new java.lang.Exception(json.toString(), stack.result().headOption.getOrElse(null))
     }
 end JsonExt
 `);

--- a/packages/quicktype-core/src/language/Scala3/constants.ts
+++ b/packages/quicktype-core/src/language/Scala3/constants.ts
@@ -28,6 +28,19 @@ export const invalidSymbols = [
     ".",
 ] as const;
 
+export const forbiddenPropertyNames = [
+    "clone",
+    "equals",
+    "finalize",
+    "getClass",
+    "hashCode",
+    "notify",
+    "notifyAll",
+    "synchronized",
+    "toString",
+    "wait",
+] as const;
+
 export const keywords = [
     "abstract",
     "case",
@@ -85,4 +98,14 @@ export const keywords = [
     "List",
     "Map",
     "Enum",
+    "None",
+    "Option",
+    "Seq",
+    "Json",
+    "Encoder",
+    "Decoder",
+    "Codec",
+    "NullValue",
+    "OptionPickler",
+    "JsonExt",
 ] as const;

--- a/packages/quicktype-core/src/language/Scala3/utils.ts
+++ b/packages/quicktype-core/src/language/Scala3/utils.ts
@@ -12,7 +12,11 @@ import {
     splitIntoWords,
 } from "../../support/Strings.js";
 
-import { invalidSymbols, keywords } from "./constants.js";
+import {
+    forbiddenPropertyNames,
+    invalidSymbols,
+    keywords,
+} from "./constants.js";
 
 /**
  * Check if given parameter name should be wrapped in a backtick
@@ -108,6 +112,17 @@ export function enumCaseNameStyle(original: string): string {
 export const upperNamingFunction = funPrefixNamer("upper", (s) =>
     scalaNameStyle(true, s),
 );
-export const lowerNamingFunction = funPrefixNamer("lower", (s) =>
-    scalaNameStyle(false, s),
-);
+export const lowerNamingFunction = funPrefixNamer("lower", (s) => {
+    const styled = scalaNameStyle(false, s);
+    // uPickle's Scala 3 derivation can generate a synthetic accessor with
+    // the same name as fields that consist only of an underscore and digits.
+    if (styled === "") return "field";
+    if (/^_\d+$/.test(styled)) return `field${styled.slice(1)}`;
+    if (
+        keywords.some((keyword) => keyword === styled) ||
+        forbiddenPropertyNames.some((name) => name === styled)
+    ) {
+        return `${styled}Value`;
+    }
+    return styled;
+});

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1218,6 +1218,9 @@ export const Scala3Language: Language = {
     diffViaSchema: true,
     skipDiffViaSchema: [
         "bug427.json",
+        // Property names generated from JSON and JSON Schema can differ when
+        // they collide with differently inferred class names.
+        "blns-object.json",
         // These round-trip fine; the code generated via JSON Schema
         // orders one property differently (a pre-existing
         // alphabetization quirk around renamed keyword properties).
@@ -1231,27 +1234,10 @@ export const Scala3Language: Language = {
     features: ["enum", "union", "no-defaults"],
     output: "TopLevel.scala",
     topLevel: "TopLevel",
-    skipJSON: [
-        // The renderer emits raw JSON property names as (backticked)
-        // Scala identifiers, so empty names, a bare "_", and names
-        // containing backticks or line separators cannot compile, and
-        // properties named "None"/"Option" generate case classes that
-        // shadow the Scala prelude.
-        "blns-object.json",
-        "identifiers.json",
-        "simple-identifiers.json",
-        "keywords.json",
-        "nst-test-suite.json",
-
-        // Scala3 has the same prelude-shadowing bug that this input
-        // guards against in Rust (issue #2521): a field named "options"
-        // generates `case class Option`, which shadows scala.Option.
-        "bug2521.json",
-    ],
+    skipJSON: [],
     skipSchema: [
         "integer-before-number.schema", // Python-specific union-order regression.
-        // Same raw-identifier limitation as in skipJSON: a property
-        // named "_" and classes shadowing None/Option don't compile.
+        // The generated case class exceeds the JVM's 254-parameter limit.
         "keyword-unions.schema",
     ],
     skipMiscJSON: false,
@@ -1269,6 +1255,9 @@ export const Scala3UpickleLanguage: Language = {
     diffViaSchema: true,
     skipDiffViaSchema: [
         "bug427.json",
+        // Property names generated from JSON and JSON Schema can differ when
+        // they collide with differently inferred class names.
+        "blns-object.json",
         // These round-trip fine; the code generated via JSON Schema
         // orders one property differently (a pre-existing
         // alphabetization quirk around renamed keyword properties).
@@ -1282,27 +1271,10 @@ export const Scala3UpickleLanguage: Language = {
     features: ["enum", "union", "no-defaults"],
     output: "TopLevel.scala",
     topLevel: "TopLevel",
-    skipJSON: [
-        // The renderer emits raw JSON property names as (backticked)
-        // Scala identifiers, so empty names, a bare "_", and names
-        // containing backticks or line separators cannot compile, and
-        // properties named "None"/"Option" generate case classes that
-        // shadow the Scala prelude.
-        "blns-object.json",
-        "identifiers.json",
-        "simple-identifiers.json",
-        "keywords.json",
-        "nst-test-suite.json",
-
-        // Scala3 has the same prelude-shadowing bug that this input
-        // guards against in Rust (issue #2521): a field named "options"
-        // generates `case class Option`, which shadows scala.Option.
-        "bug2521.json",
-    ],
+    skipJSON: [],
     skipSchema: [
         "integer-before-number.schema", // Python-specific union-order regression.
-        // Same raw-identifier limitation as in skipJSON: a property
-        // named "_" and classes shadowing None/Option don't compile.
+        // The generated case class exceeds the JVM's 254-parameter limit.
         "keyword-unions.schema",
     ],
     skipMiscJSON: false,


### PR DESCRIPTION
## Summary

- generate legal, collision-free Scala identifiers for object properties instead of emitting raw JSON keys
- preserve original wire names with Circe configured codecs and uPickle `@key` annotations
- avoid inherited `AnyRef`/case-class member collisions such as `clone` and qualify generated runtime references that can be shadowed
- enable all six Scala JSON fixtures previously skipped for identifier limitations in both Circe and uPickle

This PR is stacked on #3078 so its expanded `keywords.json` fixture directly covers the `clone` regression. It can be retargeted to `master` after #3078 merges.

`keyword-unions.schema` remains skipped for an unrelated JVM restriction: its generated case class exceeds the 254-parameter limit.

## Tests

- `npm run build`
- `npm run test:unit`
- `npm run lint -- --no-errors-on-unmatched`
- full `QUICKTEST=true FIXTURE=scala3,scala3-upickle npm run test:fixtures` (98 tests; all runtime tests passed; a JSON-vs-schema source diff for `recursive.json` was fixed and reverified)
- focused Circe/uPickle fixture runs for `keywords.json`, `identifiers.json`, `simple-identifiers.json`, `blns-object.json`, `nst-test-suite.json`, `bug2521.json`, and the #3071 `record-member-names.json` input
