### PR TITLE
Fix output-diff publishing and post a new comment per run

### DIFF
--- a/.github/workflows/publish-output-diffs.yaml
+++ b/.github/workflows/publish-output-diffs.yaml
@@ -154,10 +154,10 @@ jobs:
                       echo "is_current=true" >> "$GITHUB_OUTPUT"
                   else
                       echo "is_current=false" >> "$GITHUB_OUTPUT"
-                      echo "The PR advanced to $CURRENT_HEAD; leaving its current output-diff comment untouched." >> "$GITHUB_STEP_SUMMARY"
+                      echo "The PR advanced to $CURRENT_HEAD; not posting a comment for this stale comparison." >> "$GITHUB_STEP_SUMMARY"
                   fi
 
-            - name: Create or update output-diff comment
+            - name: Create output-diff comment
               if: steps.metadata.outputs.supported == 'true' && steps.current.outputs.is_current == 'true'
               env:
                   GH_TOKEN: ${{ github.token }}
@@ -186,10 +186,4 @@ jobs:
                   EOF
                       )
                   fi
-                  COMMENT_ID=$(gh api --paginate "repos/${{ github.repository }}/issues/$PR_NUMBER/comments" \
-                      --jq '.[] | select(.body | contains("<!-- quicktype-generated-output-diff -->")) | .id' | sed -n '1p')
-                  if [[ -n "$COMMENT_ID" ]]; then
-                      gh api --method PATCH "repos/${{ github.repository }}/issues/comments/$COMMENT_ID" -f body="$BODY" >/dev/null
-                  else
-                      gh api --method POST "repos/${{ github.repository }}/issues/$PR_NUMBER/comments" -f body="$BODY" >/dev/null
-                  fi
+                  gh api --method POST "repos/${{ github.repository }}/issues/$PR_NUMBER/comments" -f body="$BODY" >/dev/null

--- a/.github/workflows/publish-output-diffs.yaml
+++ b/.github/workflows/publish-output-diffs.yaml
@@ -35,7 +35,6 @@ jobs:
             - name: Validate metadata and result
               id: metadata
               env:
-                  DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
                   EVENT_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
                   EVENT_HEAD_REPOSITORY: ${{ github.event.workflow_run.head_repository.full_name }}
                   EVENT_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
@@ -45,16 +44,24 @@ jobs:
               run: |
                   PR_NUMBER=$(node -e 'const m = require("./comparison/metadata.json"); if (!Number.isSafeInteger(m.prNumber) || m.prNumber <= 0) process.exit(1); process.stdout.write(String(m.prNumber))')
                   gh api "repos/$REPOSITORY/pulls/$PR_NUMBER" > /tmp/pull-request.json
+                  if [[ -z "$EVENT_PR_NUMBER" ]]; then
+                      HEAD_OWNER=${EVENT_HEAD_REPOSITORY%%/*}
+                      gh api --method GET "repos/$REPOSITORY/pulls" -f state=open -f "head=$HEAD_OWNER:$EVENT_HEAD_BRANCH" > /tmp/source-pulls.json
+                  else
+                      printf '[]\n' > /tmp/source-pulls.json
+                  fi
                   node - <<'NODE'
                   const fs = require("node:fs");
                   const metadata = JSON.parse(fs.readFileSync("comparison/metadata.json", "utf8"));
                   const result = JSON.parse(fs.readFileSync("comparison/result.json", "utf8"));
                   const pullRequest = JSON.parse(fs.readFileSync("/tmp/pull-request.json", "utf8"));
+                  const sourcePulls = JSON.parse(fs.readFileSync("/tmp/source-pulls.json", "utf8"));
                   const sha = /^[0-9a-f]{40,64}$/;
                   if (!Number.isSafeInteger(metadata.prNumber) || metadata.prNumber <= 0) throw new Error("Invalid PR number");
                   if (process.env.EVENT_PR_NUMBER !== "" && String(metadata.prNumber) !== process.env.EVENT_PR_NUMBER) throw new Error("Artifact PR does not match workflow event");
+                  if (process.env.EVENT_PR_NUMBER === "" && (sourcePulls.length !== 1 || sourcePulls[0].number !== metadata.prNumber)) throw new Error("Could not uniquely associate fork workflow with artifact PR");
                   if (metadata.headSha !== process.env.EVENT_HEAD_SHA) throw new Error("Artifact head does not match workflow event");
-                  if (pullRequest.number !== metadata.prNumber || pullRequest.base.repo.full_name.toLowerCase() !== process.env.REPOSITORY.toLowerCase() || pullRequest.base.ref !== process.env.DEFAULT_BRANCH || pullRequest.head.repo.full_name.toLowerCase() !== process.env.EVENT_HEAD_REPOSITORY.toLowerCase() || pullRequest.head.ref !== process.env.EVENT_HEAD_BRANCH) throw new Error("Artifact PR does not match workflow source");
+                  if (pullRequest.number !== metadata.prNumber || pullRequest.base.repo.full_name.toLowerCase() !== process.env.REPOSITORY.toLowerCase() || pullRequest.head.repo.full_name.toLowerCase() !== process.env.EVENT_HEAD_REPOSITORY.toLowerCase() || pullRequest.head.ref !== process.env.EVENT_HEAD_BRANCH) throw new Error("Artifact PR does not match workflow source");
                   for (const key of ["baseSha", "prSha", "headSha"]) {
                       if (!sha.test(metadata[key])) throw new Error(`Invalid ${key}`);
                   }

--- a/OUTPUT-DIFFS.md
+++ b/OUTPUT-DIFFS.md
@@ -4,14 +4,14 @@
 
 For every pull request, compare quicktype's generated source at the exact PR base commit with the generated source at GitHub's tested PR merge commit across all registered JSON, JSON Schema, and GraphQL input/target fixture combinations.
 
-Generated-output differences are informational: they must not fail CI. When differences exist, CI publishes a readable report and posts or updates one PR comment containing:
+Generated-output differences are informational: they must not fail CI. Each completed comparison for the PR's current head posts a new comment. When differences exist, CI publishes a readable report and the new comment contains:
 
 - the number of files that differ;
 - the modified, new, and deleted file counts;
 - the total changed lines, with insertion and deletion counts; and
 - a link to the report.
 
-When there are no differences, no report is published and the output-diff comment confirms that generated outputs are unchanged.
+When there are no differences, no report is published and a new output-diff comment confirms that generated outputs are unchanged.
 
 ## Deterministic snapshots
 
@@ -98,11 +98,11 @@ A separate `workflow_run` workflow runs from the default branch. It:
 2. validates the PR number and SHA fields against the workflow event (or, for fork events that omit the PR number, a unique open PR with the same head repository and branch);
 3. renders the final HTML using trusted code from the default branch;
 4. publishes the HTML and patch using the `HOSTR_TOKEN` repository secret; and
-5. creates or updates one marker-tagged PR comment with either the summary and immutable link or a clean-comparison confirmation.
+5. creates a new marker-tagged PR comment with either the summary and immutable link or a clean-comparison confirmation.
 
-PRs may target the default branch or another branch, including stacked PRs. Before changing a comment, the publisher verifies that the artifact's head SHA is still the PR's current head. A stale completed run may retain its immutable report, but it cannot replace the current PR comment.
+PRs may target the default branch or another branch, including stacked PRs. Before posting a comment, the publisher verifies that the artifact's head SHA is still the PR's current head. A stale completed run may retain its immutable report, but it cannot post a stale PR comment.
 
-For a current clean run, the publisher updates the marker-tagged comment to confirm that generated outputs are unchanged and publishes no report.
+For a current clean run, the publisher creates a new marker-tagged comment confirming that generated outputs are unchanged and publishes no report.
 
 ## Rollout and verification
 

--- a/OUTPUT-DIFFS.md
+++ b/OUTPUT-DIFFS.md
@@ -95,12 +95,12 @@ The workflow that executes PR code is unprivileged and never receives the hostr 
 A separate `workflow_run` workflow runs from the default branch. It:
 
 1. downloads the completed comparison artifact;
-2. validates the PR number and SHA fields;
+2. validates the PR number and SHA fields against the workflow event (or, for fork events that omit the PR number, a unique open PR with the same head repository and branch);
 3. renders the final HTML using trusted code from the default branch;
 4. publishes the HTML and patch using the `HOSTR_TOKEN` repository secret; and
 5. creates or updates one marker-tagged PR comment with either the summary and immutable link or a clean-comparison confirmation.
 
-Before changing a comment, it verifies that the artifact's head SHA is still the PR's current head. A stale completed run may retain its immutable report, but it cannot replace the current PR comment.
+PRs may target the default branch or another branch, including stacked PRs. Before changing a comment, the publisher verifies that the artifact's head SHA is still the PR's current head. A stale completed run may retain its immutable report, but it cannot replace the current PR comment.
 
 For a current clean run, the publisher updates the marker-tagged comment to confirm that generated outputs are unchanged and publishes no report.
 


### PR DESCRIPTION
## Changes

### Support stacked PRs

The trusted publisher previously required every PR to target `master`. PR #3080 targets another branch, so its valid artifact was rejected and no report/comment was created.

When `workflow_run` supplies an exact PR number, validate that number plus the event's head repository, branch, and SHA without requiring a default-branch base. For fork events that omit the PR number, require exactly one open PR associated with the event's head owner and branch.

### Post every current comparison as a new comment

Stop finding and patching an older marker-tagged output-diff comment. Every completed comparison for the PR's current head now creates a new comment, whether outputs differ or are clean. Stale comparisons still cannot comment.

## Verification

- The exact metadata validation script passes against stacked PR #3080 and fork PR #3071 artifacts.
- The comment step contains one unconditional comment `POST`, with no comment lookup or `PATCH` path.
- Workflow YAML parsing, Biome lint, and `git diff --check` pass.