### PR TITLE
fix(ci): align generated-output diff sections by path

### DIFF
--- a/script/output-diff.ts
+++ b/script/output-diff.ts
@@ -74,7 +74,14 @@ function lineCounts(patchSection: string): {
     return { additions, deletions };
 }
 
-function generatePatch(baseDirectory: string, headDirectory: string): string {
+function generatePatch(
+    baseDirectory: string,
+    headDirectory: string,
+): {
+    baseArgument: string;
+    headArgument: string;
+    patch: string;
+} {
     const base = path.resolve(baseDirectory);
     const head = path.resolve(headDirectory);
     const sameParent = path.dirname(base) === path.dirname(head);
@@ -102,7 +109,33 @@ function generatePatch(baseDirectory: string, headDirectory: string): string {
             `git diff failed (${diff.status ?? "signal"}): ${diff.stderr}`,
         );
     }
-    return diff.stdout;
+    return { baseArgument, headArgument, patch: diff.stdout };
+}
+
+function patchSectionPath(
+    section: string,
+    baseArgument: string,
+    headArgument: string,
+): string {
+    const oldPath = /^--- (.+)$/m.exec(section)?.[1];
+    const newPath = /^\+\+\+ (.+)$/m.exec(section)?.[1];
+    if (oldPath === undefined || newPath === undefined) {
+        throw new Error("Patch section has no file headers");
+    }
+
+    const isDeleted = newPath === "/dev/null";
+    const patchPath = isDeleted ? oldPath : newPath;
+    const argument = isDeleted ? baseArgument : headArgument;
+    const side = isDeleted ? "a" : "b";
+    const normalizedArgument = argument
+        .split(path.sep)
+        .join("/")
+        .replace(/^\/+/, "");
+    const prefix = `${side}/${normalizedArgument}/`;
+    if (!patchPath.startsWith(prefix)) {
+        throw new Error(`Unexpected generated-output patch path: ${patchPath}`);
+    }
+    return patchPath.slice(prefix.length);
 }
 
 export function compareOutputSnapshots(
@@ -151,18 +184,34 @@ export function compareOutputSnapshots(
         ];
     });
 
-    const patch =
-        changed.length === 0 ? "" : generatePatch(baseDirectory, headDirectory);
+    const generated =
+        changed.length === 0
+            ? { baseArgument: "", headArgument: "", patch: "" }
+            : generatePatch(baseDirectory, headDirectory);
+    const { baseArgument, headArgument, patch } = generated;
     const sections = splitPatch(patch);
     if (sections.length !== changed.length) {
         throw new Error(
             `Expected ${changed.length} patch sections, found ${sections.length}`,
         );
     }
-    const files = changed.map((file, index) => ({
-        ...file,
-        ...lineCounts(sections[index]),
-    }));
+    const changedByPath = new Map(changed.map((file) => [file.path, file]));
+    const seen = new Set<string>();
+    const files = sections.map((section) => {
+        const relativePath = patchSectionPath(
+            section,
+            baseArgument,
+            headArgument,
+        );
+        const file = changedByPath.get(relativePath);
+        if (file === undefined || seen.has(relativePath)) {
+            throw new Error(
+                `Unexpected generated-output patch section: ${relativePath}`,
+            );
+        }
+        seen.add(relativePath);
+        return { ...file, ...lineCounts(section) };
+    });
     const insertions = files.reduce((sum, file) => sum + file.additions, 0);
     const deletions = files.reduce((sum, file) => sum + file.deletions, 0);
     const result: OutputDiffResult = {

--- a/test/unit/output-diff.test.ts
+++ b/test/unit/output-diff.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, test } from "vitest";
 import {
     compareOutputSnapshots,
     renderOutputDiffReport,
+    splitPatch,
 } from "../../script/output-diff";
 import {
     outputSnapshotCaseDirectory,
@@ -124,6 +125,35 @@ describe("generated-output comparison", () => {
             },
         ]);
         expect(patch).toContain("+three");
+    });
+
+    test("keeps patch sections aligned when one target name prefixes another", () => {
+        const root = temporaryDirectory();
+        const base = path.join(root, "base");
+        const head = path.join(root, "head");
+        const outputs = [
+            "typescript/test/inputs/json/priority/example.json/default/TopLevel.ts",
+            "typescript-effect-schema/test/inputs/json/priority/example.json/default/TopLevel.ts",
+            "typescript-zod/test/inputs/json/misc/0a91a.json/default/TopLevel.ts",
+        ];
+        for (const output of outputs) {
+            fs.mkdirSync(path.dirname(path.join(base, output)), {
+                recursive: true,
+            });
+            fs.mkdirSync(path.dirname(path.join(head, output)), {
+                recursive: true,
+            });
+            fs.writeFileSync(path.join(base, output), `old ${output}\n`);
+            fs.writeFileSync(path.join(head, output), `new ${output}\n`);
+        }
+
+        const { patch, result } = compareOutputSnapshots(base, head);
+        const sections = splitPatch(patch);
+
+        expect(result.files).toHaveLength(outputs.length);
+        result.files.forEach((file, index) => {
+            expect(sections[index]).toContain(`+new ${file.path}`);
+        });
     });
 
     test("a clean comparison has no patch or report", () => {


### PR DESCRIPTION
## Summary

- associate unified-diff sections with generated files by their actual paths
- stop relying on JavaScript and Git directory traversal producing the same order
- cover the `typescript`, `typescript-effect-schema`, and `typescript-zod` prefix-ordering regression

The old index-based association jumbled labels, counts, and diff bodies whenever one fixture target name was a prefix of another. For example, the Effect Schema output in the PR #3062 report appeared under the TypeScript Zod `0a91a.json` entry.

## Verification

- `npm run test:unit`
- `npm run build`
- `npx biome check script/output-diff.ts test/unit/output-diff.test.ts`
- `git diff --check`


## Corrected example

The report from PR #3062 regenerated from the original comparison artifact with path-aligned sections: https://hostr.flingit.run/s/quicktype/output-diffs/pr-3062/e4e459dbdc777e877d709b7e66cf2cd3f8ab3d5b/610ed6cc6d0bdd810250d1d1a5bf121eca094911/corrected-pr-3082/index.html
