### PR TITLE
Fix flaky Scala CI Bloop timeouts

### DIFF
--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -196,6 +196,8 @@ jobs:
             - name: Install scala
               if: ${{ contains(matrix.fixture, 'scala3') }}
               uses: VirtusLab/scala-cli-setup@v1.15.0
+            - run: echo '@main def hello() = println("Warm up the Scala compilation server")' | SCALA_CLI_EXTRA_TIMEOUT=2min scala-cli _
+              if: ${{ contains(matrix.fixture, 'scala3') }}
 
             - name: Install Elixir
               if: ${{ contains(matrix.fixture, 'elixir') }}
@@ -205,6 +207,8 @@ jobs:
                   otp-version: "26.0"
 
             - run: QUICKTEST=true FIXTURE=${{ matrix.fixture }} npm run test:fixtures
+              env:
+                  CPUs: ${{ contains(matrix.fixture, 'scala3') && '2' || '0' }}
 
     test-complete:
         if: ${{ cancelled() || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure') }}

--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -195,9 +195,7 @@ jobs:
 
             - name: Install scala
               if: ${{ contains(matrix.fixture, 'scala3') }}
-              uses: VirtusLab/scala-cli-setup@main
-            - run: echo '@main def hello() = println("We need this spam print statement for bloop to exit correctly...")' | scala-cli _
-              if: ${{ contains(matrix.fixture, 'scala3') }}
+              uses: VirtusLab/scala-cli-setup@v1.15.0
 
             - name: Install Elixir
               if: ${{ contains(matrix.fixture, 'elixir') }}

--- a/test/fixtures/scala3-upickle/run.sh
+++ b/test/fixtures/scala3-upickle/run.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-scala-cli upickle.scala TopLevel.scala
+scala-cli run --server=false upickle.scala TopLevel.scala

--- a/test/fixtures/scala3-upickle/run.sh
+++ b/test/fixtures/scala3-upickle/run.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-scala-cli run --server=false upickle.scala TopLevel.scala
+SCALA_CLI_EXTRA_TIMEOUT="${SCALA_CLI_EXTRA_TIMEOUT:-2min}" scala-cli run upickle.scala TopLevel.scala

--- a/test/fixtures/scala3/run.sh
+++ b/test/fixtures/scala3/run.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-scala-cli circe.scala TopLevel.scala
+scala-cli run --server=false circe.scala TopLevel.scala

--- a/test/fixtures/scala3/run.sh
+++ b/test/fixtures/scala3/run.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-scala-cli run --server=false circe.scala TopLevel.scala
+SCALA_CLI_EXTRA_TIMEOUT="${SCALA_CLI_EXTRA_TIMEOUT:-2min}" scala-cli run circe.scala TopLevel.scala


### PR DESCRIPTION
## Summary

- give Scala CLI's Bloop health checks an additional two minutes under fixture load
- limit Scala fixture jobs to two concurrent workers to reduce compilation-server contention
- retain the Bloop warmup because direct compilation is substantially slower and overflows Scala 3.2.2's compiler stack on large generated sources
- pin the Scala CLI setup action to v1.15.0

## Why

Scala fixture jobs intermittently fail while querying the shared Bloop compilation server:

```text
java.util.concurrent.TimeoutException: Future timed out after [30 seconds]
    at bloop.rifle.BloopRifle$.getCurrentBloopVersion(...)
```

This is an infrastructure failure rather than a generated-code failure. Scala CLI's `SCALA_CLI_EXTRA_TIMEOUT` extends the hard-coded 30-second Bloop health-check timeout, while reducing fixture concurrency makes it less likely that Bloop is too busy compiling to respond.

Example failure: https://github.com/glideapps/quicktype/actions/runs/30034893445/job/89327258609?pr=3046

## Verification

- `npm run lint`
- `PATH="/tmp:$PATH" CPUs=1 QUICKTEST=true FIXTURE=scala3 npm run test:fixtures -- test/inputs/json/samples/reddit.json`
- `PATH="/tmp:$PATH" CPUs=2 QUICKTEST=true FIXTURE=scala3,scala3-upickle npm run test:fixtures -- test/inputs/json/samples/reddit.json test/inputs/json/samples/pokedex.json`