### PR TITLE
feat(go): --enum-type-name-suffix to avoid same-package enum conflicts

### DIFF
--- a/packages/quicktype-core/src/language/Golang/GolangRenderer.ts
+++ b/packages/quicktype-core/src/language/Golang/GolangRenderer.ts
@@ -222,8 +222,8 @@ export class GoRenderer extends ConvenienceRenderer {
             t instanceof ClassType
                 ? this.collectClassImports(t)
                 : t instanceof UnionType
-                  ? this.collectUnionImports(t)
-                  : undefined;
+                    ? this.collectUnionImports(t)
+                    : undefined;
         this.emitPackageDefinitons(true, imports);
 
         const unmarshalName = defined(this._topLevelUnmarshalNames.get(name));
@@ -303,7 +303,7 @@ export class GoRenderer extends ConvenienceRenderer {
         const columns: Sourcelike[][] = [];
         this.forEachEnumCase(e, "none", (name, jsonName) => {
             columns.push([
-                [name, " "],
+                this._options.enumTypeNameSuffix ? [name, enumName, " "] : [name, " "],
                 [enumName, ' = "', stringEscape(jsonName), '"'],
             ]);
         });

--- a/packages/quicktype-core/src/language/Golang/GolangRenderer.ts
+++ b/packages/quicktype-core/src/language/Golang/GolangRenderer.ts
@@ -222,8 +222,8 @@ export class GoRenderer extends ConvenienceRenderer {
             t instanceof ClassType
                 ? this.collectClassImports(t)
                 : t instanceof UnionType
-                    ? this.collectUnionImports(t)
-                    : undefined;
+                  ? this.collectUnionImports(t)
+                  : undefined;
         this.emitPackageDefinitons(true, imports);
 
         const unmarshalName = defined(this._topLevelUnmarshalNames.get(name));
@@ -303,7 +303,9 @@ export class GoRenderer extends ConvenienceRenderer {
         const columns: Sourcelike[][] = [];
         this.forEachEnumCase(e, "none", (name, jsonName) => {
             columns.push([
-                this._options.enumTypeNameSuffix ? [name, enumName, " "] : [name, " "],
+                this._options.enumTypeNameSuffix
+                    ? [name, enumName, " "]
+                    : [name, " "],
                 [enumName, ' = "', stringEscape(jsonName), '"'],
             ]);
         });

--- a/packages/quicktype-core/src/language/Golang/language.ts
+++ b/packages/quicktype-core/src/language/Golang/language.ts
@@ -43,6 +43,11 @@ export const goOptions = {
         'If set, all non-required objects will be tagged with ",omitempty"',
         false,
     ),
+    enumTypeNameSuffix: new BooleanOption(
+        "enum-type-name-suffix",
+        "Appends the type name to enum contracts",
+        false,
+    ),
 };
 
 const golangLanguageConfig = {

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -581,6 +581,7 @@ export const GoLanguage: Language = {
         // fields preserve null instead of being omitted.
         ["omit-empty.json", { "omit-empty": "true" }],
         ["nullable-optional-one-of.schema", { "omit-empty": "true" }],
+        ["enum.schema", { "enum-type-name-suffix": "true" }],
     ],
     sourceFiles: ["src/language/Golang/index.ts"],
 };

--- a/test/unit/golang-enum-type-name-suffix.test.ts
+++ b/test/unit/golang-enum-type-name-suffix.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "vitest";
+
+import {
+    InputData,
+    JSONSchemaInput,
+    quicktype,
+} from "../../packages/quicktype-core/src/index.js";
+
+async function renderGo(enumTypeNameSuffix: boolean): Promise<string> {
+    const schemaInput = new JSONSchemaInput(undefined);
+    await schemaInput.addSource({
+        name: "TreePart",
+        schema: JSON.stringify({
+            type: "string",
+            enum: ["BARK", "LEAF", "ROOT"],
+        }),
+    });
+
+    const inputData = new InputData();
+    inputData.addInput(schemaInput);
+
+    const result = await quicktype({
+        inputData,
+        lang: "go",
+        rendererOptions: {
+            "enum-type-name-suffix": enumTypeNameSuffix,
+        },
+    });
+    return result.lines.join("\n");
+}
+
+describe("Go enum-type-name-suffix", () => {
+    test("appends the enum type name to each constant when enabled", async () => {
+        const output = await renderGo(true);
+
+        expect(output).toMatch(/BarkTreePart\s+TreePart = "BARK"/);
+        expect(output).toMatch(/LeafTreePart\s+TreePart = "LEAF"/);
+        expect(output).toMatch(/RootTreePart\s+TreePart = "ROOT"/);
+    });
+});


### PR DESCRIPTION
## Description

Adds a `--enum-type-name-suffix` flag (defaults to false) that will generate Golang enums with their type appended to member names (e.g. `Red Colour = "RED"` -> `RedColour Colour = "RED"`), resolving an issue with conflicting enums in the same package.

## Related Issue

#2624

## Motivation and Context

See the issue above for motivation / context, previous behaviour, new behaviour, and test instructions.

