### PR TITLE
fix(go): resolve suffixed enum names through naming

### DIFF
--- a/packages/quicktype-core/src/language/Golang/GolangRenderer.ts
+++ b/packages/quicktype-core/src/language/Golang/GolangRenderer.ts
@@ -66,6 +66,30 @@ export class GoRenderer extends ConvenienceRenderer {
         return true;
     }
 
+    protected makeNameForEnumCase(
+        e: EnumType,
+        enumName: Name,
+        caseName: string,
+        assignedName: string | undefined,
+    ): Name {
+        const name = super.makeNameForEnumCase(
+            e,
+            enumName,
+            caseName,
+            assignedName,
+        );
+        if (!this._options.enumTypeNameSuffix) return name;
+
+        const proposedName = name.namingFunction.nameStyle(
+            name.firstProposedName(new Map()),
+        );
+        return new DependencyName(
+            name.namingFunction,
+            name.order,
+            (lookup) => `${proposedName}_${lookup(enumName)}`,
+        );
+    }
+
     protected makeTopLevelDependencyNames(
         _: Type,
         topLevelName: Name,

--- a/packages/quicktype-core/src/language/Golang/language.ts
+++ b/packages/quicktype-core/src/language/Golang/language.ts
@@ -43,6 +43,11 @@ export const goOptions = {
         'If set, all non-required objects will be tagged with ",omitempty"',
         false,
     ),
+    enumTypeNameSuffix: new BooleanOption(
+        "enum-type-name-suffix",
+        "Append the enum type name to enum constant names",
+        false,
+    ),
 };
 
 const golangLanguageConfig = {

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -581,6 +581,7 @@ export const GoLanguage: Language = {
         // fields preserve null instead of being omitted.
         ["omit-empty.json", { "omit-empty": "true" }],
         ["nullable-optional-one-of.schema", { "omit-empty": "true" }],
+        ["enum.schema", { "enum-type-name-suffix": "true" }],
     ],
     sourceFiles: ["src/language/Golang/index.ts"],
 };

--- a/test/unit/golang-enum-type-name-suffix.test.ts
+++ b/test/unit/golang-enum-type-name-suffix.test.ts
@@ -1,0 +1,85 @@
+import { InputData, JSONSchemaInput, quicktype } from "quicktype-core";
+import { describe, expect, test } from "vitest";
+
+async function renderGo(
+    name: string,
+    schema: object,
+    enumTypeNameSuffix: boolean | undefined,
+): Promise<string> {
+    const schemaInput = new JSONSchemaInput(undefined);
+    await schemaInput.addSource({ name, schema: JSON.stringify(schema) });
+
+    const inputData = new InputData();
+    inputData.addInput(schemaInput);
+
+    const result = await quicktype({
+        inputData,
+        lang: "go",
+        rendererOptions:
+            enumTypeNameSuffix === undefined
+                ? {}
+                : { "enum-type-name-suffix": enumTypeNameSuffix },
+    });
+    return result.lines.join("\n");
+}
+
+const dogNoiseSchema = {
+    type: "string",
+    enum: ["BARK", "GROWL", "HOWL"],
+};
+
+describe("Go enum type name suffix", () => {
+    test("is off by default and qualifies constants when enabled", async () => {
+        const defaultOutput = await renderGo(
+            "DogNoise",
+            dogNoiseSchema,
+            undefined,
+        );
+        const qualifiedOutput = await renderGo(
+            "DogNoise",
+            dogNoiseSchema,
+            true,
+        );
+        const independentlyQualifiedOutput = await renderGo(
+            "TreePart",
+            {
+                type: "string",
+                enum: ["BARK", "LEAF", "ROOT"],
+            },
+            true,
+        );
+
+        expect(defaultOutput).toMatch(/Bark\s+DogNoise = "BARK"/);
+        expect(qualifiedOutput).toMatch(/BarkDogNoise\s+DogNoise = "BARK"/);
+        expect(qualifiedOutput).toMatch(/GrowlDogNoise\s+DogNoise = "GROWL"/);
+        expect(qualifiedOutput).toMatch(/HowlDogNoise\s+DogNoise = "HOWL"/);
+        expect(independentlyQualifiedOutput).toMatch(
+            /BarkTreePart\s+TreePart = "BARK"/,
+        );
+    });
+
+    test("resolves collisions using the complete qualified name", async () => {
+        const output = await renderGo(
+            "TopLevel",
+            {
+                type: "object",
+                properties: {
+                    noise: { $ref: "#/$defs/DogNoise" },
+                    collision: { $ref: "#/$defs/BarkDogNoise" },
+                },
+                $defs: {
+                    DogNoise: dogNoiseSchema,
+                    BarkDogNoise: {
+                        type: "object",
+                        properties: { value: { type: "string" } },
+                    },
+                },
+            },
+            true,
+        );
+
+        expect(output).toContain("type BarkDogNoise struct");
+        expect(output).not.toMatch(/^\s*BarkDogNoise\s+DogNoise = "BARK"/m);
+        expect(output).toMatch(/^\s*\w*BarkDogNoise\s+DogNoise = "BARK"/m);
+    });
+});


### PR DESCRIPTION
## Description

Add an opt-in `--enum-type-name-suffix` Go renderer option, off by default, to make independently generated enums safe to combine in one package when their members overlap.

Unlike #3085, this derives each complete constant identifier with `DependencyName` during quicktype's naming pass instead of appending the enum name while emitting text.  That lets the existing package-global namespace detect collisions involving the final identifier.  For example, if `BarkDogNoise` is already a generated type, the naming pass can rename the enum constant rather than emit invalid Go with two `BarkDogNoise` declarations.

For #2624, enabling the option produces constants such as:

```go
BarkDogNoise DogNoise = "BARK"
BarkTreePart TreePart = "BARK"
```

## Tests

- Added a unit regression covering:
  - default-off behavior
  - independently rendered enums with an overlapping `BARK` member
  - a collision between a qualified enum constant and a generated type
- Added `enum.schema` to Go's `quickTestRendererOptions` with `enum-type-name-suffix=true`, so QUICKTEST generates and compiles qualified enum constants.

Commands run locally:

```sh
npm run build
npm run test:unit
npm run lint
QUICKTEST=true FIXTURE=schema-golang npm run test:fixtures -- test/inputs/schema/enum.schema
```
