### PR TITLE
Python: add opt-in keep-property-names option

### DIFF
--- a/packages/quicktype-core/src/language/Python/PythonRenderer.ts
+++ b/packages/quicktype-core/src/language/Python/PythonRenderer.ts
@@ -32,7 +32,11 @@ import { matchType, removeNullFromUnion } from "../../Type/TypeUtils.js";
 
 import { forbiddenPropertyNames, forbiddenTypeNames } from "./constants.js";
 import type { pythonOptions } from "./language.js";
-import { classNameStyle, snakeNameStyle } from "./utils.js";
+import {
+    classNameStyle,
+    isLegalPythonIdentifier,
+    snakeNameStyle,
+} from "./utils.js";
 
 export class PythonRenderer extends ConvenienceRenderer {
     private readonly imports: Map<string, Set<string>> = new Map();
@@ -68,9 +72,16 @@ export class PythonRenderer extends ConvenienceRenderer {
     }
 
     protected namerForObjectProperty(): Namer {
-        return funPrefixNamer("property", (s) =>
-            snakeNameStyle(s, false, this.pyOptions.nicePropertyNames),
-        );
+        return funPrefixNamer("property", (s) => {
+            if (
+                this.pyOptions.keepPropertyNames &&
+                isLegalPythonIdentifier(s)
+            ) {
+                return s;
+            }
+
+            return snakeNameStyle(s, false, this.pyOptions.nicePropertyNames);
+        });
     }
 
     protected makeUnionMemberNamer(): null {

--- a/packages/quicktype-core/src/language/Python/language.ts
+++ b/packages/quicktype-core/src/language/Python/language.ts
@@ -80,6 +80,11 @@ export const pythonOptions = {
         "Transform property names to be Pythonic",
         true,
     ),
+    keepPropertyNames: new BooleanOption(
+        "keep-property-names",
+        "Keep original property names when they are valid Python identifiers",
+        false,
+    ),
     pydanticBaseModel: new BooleanOption(
         "pydantic-base-model",
         "Uses pydantic BaseModel",

--- a/packages/quicktype-core/src/language/Python/utils.ts
+++ b/packages/quicktype-core/src/language/Python/utils.ts
@@ -44,6 +44,32 @@ function isPartCharacter3(utf16Unit: number): boolean {
     return true;
 }
 
+function isPythonIdentifierStart(utf16Unit: number): boolean {
+    return utf16Unit === 0x5f || isNormalizedStartCharacter3(utf16Unit);
+}
+
+function isPythonIdentifierPart(utf16Unit: number): boolean {
+    return (
+        isPythonIdentifierStart(utf16Unit) ||
+        isNormalizedPartCharacter3(utf16Unit)
+    );
+}
+
+export function isLegalPythonIdentifier(original: string): boolean {
+    if (
+        original.length === 0 ||
+        !isPythonIdentifierStart(original.charCodeAt(0))
+    ) {
+        return false;
+    }
+
+    for (let i = 1; i < original.length; i++) {
+        if (!isPythonIdentifierPart(original.charCodeAt(i))) return false;
+    }
+
+    return true;
+}
+
 const legalizeName3 = utf16LegalizeCharacters(isPartCharacter3);
 
 export function classNameStyle(original: string): string {

--- a/test/unit/python-property-names.test.ts
+++ b/test/unit/python-property-names.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "vitest";
+
+import {
+    InputData,
+    JSONSchemaInput,
+    quicktype,
+} from "../../packages/quicktype-core/src/index.js";
+
+const schema = JSON.stringify({
+    type: "object",
+    properties: {
+        source_m3u8: { type: "string" },
+        "has-dash": { type: "string" },
+    },
+});
+
+async function pythonFor(keepPropertyNames: boolean): Promise<string> {
+    const schemaInput = new JSONSchemaInput(undefined);
+    await schemaInput.addSource({ name: "TopLevel", schema });
+
+    const inputData = new InputData();
+    inputData.addInput(schemaInput);
+
+    const result = await quicktype({
+        inputData,
+        lang: "python",
+        rendererOptions: {
+            "keep-property-names": keepPropertyNames,
+        },
+    });
+
+    return result.lines.join("\n");
+}
+
+test("Python keeps the default naming behavior", async () => {
+    const output = await pythonFor(false);
+
+    expect(output).toContain("source_m3_u8: str");
+    expect(output).toContain("has_dash: str");
+});
+
+test("Python can keep valid original property names", async () => {
+    const output = await pythonFor(true);
+
+    expect(output).toContain("source_m3u8: str");
+    expect(output).toContain("has_dash: str");
+    expect(output).toContain('obj.get("source_m3u8")');
+});


### PR DESCRIPTION
Fixes #3099

This adds an opt-in `--keep-property-names` Python renderer option.

When enabled, valid original JSON property names such as `source_m3u8` are kept as Python attributes, so generated `from_dict`/`to_dict` mappings and Pydantic/FastAPI request fields use the same name. Invalid identifiers continue to use the existing naming logic.

The default remains unchanged.

Tests:
- `npm run test:unit`
- `npm run build`